### PR TITLE
Add Objective-C generic types to collections in headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: objective-c
 script: ./travis-build.sh
-osx_image: xcode6.4
+osx_image: xcode7

--- a/GitUpKit/Components/GICommitListViewController.h
+++ b/GitUpKit/Components/GICommitListViewController.h
@@ -25,7 +25,7 @@
 @interface GICommitListViewController : GIViewController
 @property(nonatomic, assign) id<GICommitListViewControllerDelegate> delegate;
 @property(nonatomic, copy) NSArray* results;  // Can contain GCHistoryCommit, GCHistoryLocalBranch, GCHistoryRemoteBranch or GCHistoryTag
-@property(nonatomic, readonly) NSArray* commits;  // Converted results to GCHistoryCommits
+@property(nonatomic, readonly) NSArray<GCHistoryCommit*>* commits;  // Converted results to GCHistoryCommits
 @property(nonatomic, assign) id selectedResult;
 @property(nonatomic, assign) GCHistoryCommit* selectedCommit;
 @property(nonatomic, copy) NSString* emptyLabel;

--- a/GitUpKit/Components/GIDiffContentsViewController.h
+++ b/GitUpKit/Components/GIDiffContentsViewController.h
@@ -38,9 +38,9 @@ extern NSString* const GIDiffContentsViewControllerUserDefaultKey_DiffViewMode; 
 @property(nonatomic, copy) NSString* emptyLabel;
 @property(nonatomic, strong) NSView* headerView;
 
-@property(nonatomic, readonly) NSArray* deltas;
-@property(nonatomic, readonly) NSDictionary* conflicts;
-- (void)setDeltas:(NSArray*)deltas usingConflicts:(NSDictionary*)conflicts;
+@property(nonatomic, readonly) NSArray<GCDiffDelta*>* deltas;
+@property(nonatomic, readonly) NSDictionary<NSString*, GCIndexConflict*>* conflicts;
+- (void)setDeltas:(NSArray<GCDiffDelta*>*)deltas usingConflicts:(NSDictionary<NSString*, GCIndexConflict*>*)conflicts;
 
 - (GCDiffDelta*)topVisibleDelta:(CGFloat*)offset;
 - (void)setTopVisibleDelta:(GCDiffDelta*)delta offset:(CGFloat)offset;

--- a/GitUpKit/Components/GIDiffFilesViewController.h
+++ b/GitUpKit/Components/GIDiffFilesViewController.h
@@ -17,17 +17,17 @@
 
 #import "GCDiff.h"
 
-@class GIDiffFilesViewController;
+@class GCIndexConflict, GIDiffFilesViewController;
 
 @protocol GIDiffFilesViewControllerDelegate <NSObject>
 @optional
 - (void)diffFilesViewControllerDidBecomeFirstResponder:(GIDiffFilesViewController*)controller;
 - (void)diffFilesViewControllerDidChangeSelection:(GIDiffFilesViewController*)controller;
-- (void)diffFilesViewController:(GIDiffFilesViewController*)controller didDoubleClickDeltas:(NSArray*)deltas;
+- (void)diffFilesViewController:(GIDiffFilesViewController*)controller didDoubleClickDeltas:(NSArray<GCDiffDelta*>*)deltas;
 - (BOOL)diffFilesViewController:(GIDiffFilesViewController*)controller handleKeyDownEvent:(NSEvent*)event;
 - (void)diffFilesViewController:(GIDiffFilesViewController*)controller willSelectDelta:(GCDiffDelta*)delta;
 - (BOOL)diffFilesViewControllerShouldAcceptDeltas:(GIDiffFilesViewController*)controller fromOtherController:(GIDiffFilesViewController*)otherController;
-- (BOOL)diffFilesViewController:(GIDiffFilesViewController*)controller didReceiveDeltas:(NSArray*)deltas fromOtherController:(GIDiffFilesViewController*)otherController;
+- (BOOL)diffFilesViewController:(GIDiffFilesViewController*)controller didReceiveDeltas:(NSArray<GCDiffDelta*>*)deltas fromOtherController:(GIDiffFilesViewController*)otherController;
 @end
 
 @interface GIDiffFilesViewController : GIViewController
@@ -36,10 +36,10 @@
 @property(nonatomic, copy) NSString* emptyLabel;
 @property(nonatomic) BOOL allowsMultipleSelection;  // Default is NO
 
-@property(nonatomic, readonly) NSArray* deltas;
-@property(nonatomic, readonly) NSDictionary* conflicts;
-- (void)setDeltas:(NSArray*)deltas usingConflicts:(NSDictionary*)conflicts;
+@property(nonatomic, readonly) NSArray<GCDiffDelta*>* deltas;
+@property(nonatomic, readonly) NSDictionary<NSString*, GCIndexConflict*>* conflicts;
+- (void)setDeltas:(NSArray<GCDiffDelta*>*)deltas usingConflicts:(NSDictionary<NSString*, GCIndexConflict*>*)conflicts;
 
 @property(nonatomic, assign) GCDiffDelta* selectedDelta;
-@property(nonatomic, assign) NSArray* selectedDeltas;
+@property(nonatomic, assign) NSArray<GCDiffDelta*>* selectedDeltas;
 @end

--- a/GitUpKit/Core/GCBranch.h
+++ b/GitUpKit/Core/GCBranch.h
@@ -41,9 +41,9 @@
 
 - (GCLocalBranch*)findLocalBranchWithName:(NSString*)name error:(NSError**)error;
 - (GCRemoteBranch*)findRemoteBranchWithName:(NSString*)name error:(NSError**)error;
-- (NSArray*)listLocalBranches:(NSError**)error;  // git branch
-- (NSArray*)listRemoteBranches:(NSError**)error;  // git branch -r
-- (NSArray*)listAllBranches:(NSError**)error;  // git branch -a
+- (NSArray<GCLocalBranch*>*)listLocalBranches:(NSError**)error;  // git branch
+- (NSArray<GCRemoteBranch*>*)listRemoteBranches:(NSError**)error;  // git branch -r
+- (NSArray<__kindof GCBranch*>*)listAllBranches:(NSError**)error;  // git branch -a
 
 - (GCCommit*)lookupTipCommitForBranch:(GCBranch*)branch error:(NSError**)error;  // git show-ref {branch}
 

--- a/GitUpKit/Core/GCCommit.h
+++ b/GitUpKit/Core/GCCommit.h
@@ -41,6 +41,6 @@
 - (NSString*)computeUniqueShortSHA1ForCommit:(GCCommit*)commit error:(NSError**)error;  // (?)
 - (GCCommit*)findCommitWithSHA1:(NSString*)sha1 error:(NSError**)error;  // (?)
 - (GCCommit*)findCommitWithSHA1Prefix:(NSString*)prefix error:(NSError**)error;  // (?)
-- (NSArray*)lookupParentsForCommit:(GCCommit*)commit error:(NSError**)error;  // git log -n 1 {commit_id}
+- (NSArray<GCCommit*>*)lookupParentsForCommit:(GCCommit*)commit error:(NSError**)error;  // git log -n 1 {commit_id}
 - (NSString*)checkTreeForCommit:(GCCommit*)commit containsFile:(NSString*)path error:(NSError**)error;  // (?) - Returns SHA1 if present
 @end

--- a/GitUpKit/Core/GCCommitDatabase.h
+++ b/GitUpKit/Core/GCCommitDatabase.h
@@ -33,5 +33,5 @@ extern NSString* const SQLiteErrorDomain;
 @property(nonatomic, readonly) GCCommitDatabaseOptions options;
 - (instancetype)initWithRepository:(GCRepository*)repository databasePath:(NSString*)path options:(GCCommitDatabaseOptions)options error:(NSError**)error;
 - (BOOL)updateWithProgressHandler:(GCCommitDatabaseProgressHandler)handler error:(NSError**)error;  // Handler can be NULL - Return NO from handler to cancel
-- (NSArray*)findCommitsMatching:(NSString*)match error:(NSError**)error;  // Search commit messages, authors and committers and orders results from newest to oldest - Returns nil on error
+- (NSArray<__kindof GCCommit*>*)findCommitsMatching:(NSString*)match error:(NSError**)error;  // Search commit messages, authors and committers and orders results from newest to oldest - Returns nil on error
 @end

--- a/GitUpKit/Core/GCDiff.h
+++ b/GitUpKit/Core/GCDiff.h
@@ -110,7 +110,7 @@ typedef void (^GCDiffEndHunkHandler)();
 @property(nonatomic, readonly) NSUInteger maxContextLines;
 @property(nonatomic, readonly, getter=isModified) BOOL modified;  // Ignores unmodified files
 @property(nonatomic, readonly) BOOL hasChanges;  // Ignores unmodified and untracked files
-@property(nonatomic, readonly) NSArray* deltas;
+@property(nonatomic, readonly) NSArray<GCDiffDelta*>* deltas;
 @end
 
 @interface GCDiff (Extensions)

--- a/GitUpKit/Core/GCHistory.m
+++ b/GitUpKit/Core/GCHistory.m
@@ -1205,7 +1205,7 @@ cleanup:
   return [self _reloadHistory:history usingSnapshot:nil referencesDidChange:NULL addedCommits:NULL removedCommits:NULL error:error] ? history : nil;
 }
 
-- (BOOL)reloadHistory:(GCHistory*)history referencesDidChange:(BOOL*)referencesDidChange addedCommits:(NSArray**)addedCommits removedCommits:(NSArray**)removedCommits error:(NSError**)error {
+- (BOOL)reloadHistory:(GCHistory*)history referencesDidChange:(BOOL*)referencesDidChange addedCommits:(NSArray<GCHistoryCommit*>**)addedCommits removedCommits:(NSArray<GCHistoryCommit*>**)removedCommits error:(NSError**)error {
   return [self _reloadHistory:history usingSnapshot:nil referencesDidChange:referencesDidChange addedCommits:addedCommits removedCommits:removedCommits error:error];
 }
 

--- a/GitUpKit/Core/GCLiveRepository.h
+++ b/GitUpKit/Core/GCLiveRepository.h
@@ -43,7 +43,7 @@ extern NSString* const GCLiveRepositorySearchDidUpdateNotification;
 extern NSString* const GCLiveRepositoryCommitOperationReason;
 extern NSString* const GCLiveRepositoryAmendOperationReason;
 
-@class GCLiveRepository, GCDiff, GCReferenceTransform;
+@class GCLiveRepository, GCDiff, GCReferenceTransform, GCStash;
 
 @protocol GCLiveRepositoryDelegate <GCRepositoryDelegate>
 @optional
@@ -87,7 +87,7 @@ extern NSString* const GCLiveRepositoryAmendOperationReason;
 
 @property(nonatomic, getter=areSnapshotsEnabled) BOOL snapshotsEnabled;  // Default is NO - Should be enabled *after* setting delegate so any error can be received
 @property(nonatomic, getter=areAutomaticSnapshotsEnabled) BOOL automaticSnapshotsEnabled;  // Requires @snapshotsEnabled to be YES
-@property(nonatomic, readonly) NSArray* snapshots;  // Nil if snapshots are disabled
+@property(nonatomic, readonly) NSArray<GCSnapshot*>* snapshots;  // Nil if snapshots are disabled
 
 @property(nonatomic) GCLiveRepositoryDiffWhitespaceMode diffWhitespaceMode;  // Default is kGCLiveRepositoryDiffWhitespaceMode_Normal
 @property(nonatomic) NSUInteger diffMaxInterHunkLines;  // Default is 0
@@ -98,10 +98,10 @@ extern NSString* const GCLiveRepositoryAmendOperationReason;
 @property(nonatomic, readonly) GCDiff* unifiedStatus;  // Nil on error
 @property(nonatomic, readonly) GCDiff* workingDirectoryStatus;  // Nil on error
 @property(nonatomic, readonly) GCDiff* indexStatus;  // Nil on error
-@property(nonatomic, readonly) NSDictionary* indexConflicts;  // Nil on error
+@property(nonatomic, readonly) NSDictionary<NSString*, GCIndexConflict*>* indexConflicts;  // Nil on error
 
 @property(nonatomic, getter=areStashesEnabled) BOOL stashesEnabled;  // Default is NO - Should be enabled *after* setting delegate so any error can be received
-@property(nonatomic, readonly) NSArray* stashes;  // Nil on error
+@property(nonatomic, readonly) NSArray<GCStash*>* stashes;  // Nil on error
 
 @property(nonatomic, strong) NSUndoManager* undoManager;  // Default is nil
 - (void)setUndoActionName:(NSString*)name;  // Wrapper for -[NSUndoManager setActionName:] that doesn't open an undo block

--- a/GitUpKit/Core/GCPrivate.h
+++ b/GitUpKit/Core/GCPrivate.h
@@ -132,7 +132,7 @@ extern int git_submodule_foreach_block(git_repository* repo, int (^block)(git_su
 @interface GCTask : NSObject
 @property(nonatomic, readonly) NSString* executablePath;
 @property(nonatomic) NSTimeInterval executionTimeOut;  // Default is 0.0 i.e. no timeout
-@property(nonatomic, copy) NSDictionary* additionalEnvironment;
+@property(nonatomic, copy) NSDictionary<NSString*, NSString*>* additionalEnvironment;
 @property(nonatomic, copy) NSString* currentDirectoryPath;
 - (instancetype)initWithExecutablePath:(NSString*)path;
 - (BOOL)runWithArguments:(NSArray*)arguments stdin:(NSData*)stdin stdout:(NSData**)stdout stderr:(NSData**)stderr exitStatus:(int*)exitStatus error:(NSError**)error;  // Returns NO if "exitStatus" is NULL and executable exits with a non-zero status
@@ -214,8 +214,8 @@ extern int git_submodule_foreach_block(git_repository* repo, int (^block)(git_su
 @end
 
 @interface GCSnapshot ()
-@property(nonatomic, readonly) NSDictionary* config;
-@property(nonatomic, readonly) NSArray* serializedReferences;
+@property(nonatomic, readonly) NSDictionary<NSString*, NSString*>* config;
+@property(nonatomic, readonly) NSArray<GCSerializedReference*>* serializedReferences;
 - (id)initWithRepository:(GCRepository*)repository error:(NSError**)error;
 - (GCSerializedReference*)serializedReferenceWithName:(const char*)name;
 @end
@@ -260,7 +260,7 @@ extern int git_submodule_foreach_block(git_repository* repo, int (^block)(git_su
 @end
 
 @interface GCCommitDatabase ()
-- (NSArray*)findCommitsUsingHistory:(GCHistory*)history matching:(NSString*)match error:(NSError**)error;
+- (NSArray<__kindof GCCommit*>*)findCommitsUsingHistory:(GCHistory*)history matching:(NSString*)match error:(NSError**)error;
 #if DEBUG
 - (NSUInteger)countCommits;  // Returns NSNotFound on error
 - (NSUInteger)countTips;  // Returns NSNotFound on error
@@ -279,14 +279,14 @@ extern int git_submodule_foreach_block(git_repository* repo, int (^block)(git_su
 - (GCCommit*)createCommitFromCommit:(git_commit*)commit
                           withIndex:(git_index*)index
                      updatedMessage:(NSString*)message
-                     updatedParents:(NSArray*)parents
+                     updatedParents:(NSArray<__kindof GCCommit*>*)parents
                     updateCommitter:(BOOL)updateCommitter
                               error:(NSError**)error;
 
 - (GCCommit*)createCommitFromCommit:(git_commit*)commit
                            withTree:(git_tree*)tree
                      updatedMessage:(NSString*)message
-                     updatedParents:(NSArray*)parents
+                     updatedParents:(NSArray<__kindof GCCommit*>*)parents
                     updateCommitter:(BOOL)updateCommitter
                               error:(NSError**)error;
 @end

--- a/GitUpKit/Core/GCRemote.h
+++ b/GitUpKit/Core/GCRemote.h
@@ -39,7 +39,7 @@ typedef NS_OPTIONS(NSUInteger, GCRemoteCheckOptions) {
 @end
 
 @interface GCRepository (GCRemote)
-- (NSArray*)listRemotes:(NSError**)error;  // git remote -v
+- (NSArray<GCRemote*>*)listRemotes:(NSError**)error;  // git remote -v
 - (GCRemote*)lookupRemoteWithName:(NSString*)name error:(NSError**)error;  // git remote -v
 
 - (GCRemote*)addRemoteWithName:(NSString*)name url:(NSURL*)url error:(NSError**)error;  // git remote add {name} {url}
@@ -50,14 +50,14 @@ typedef NS_OPTIONS(NSUInteger, GCRemoteCheckOptions) {
 
 - (BOOL)checkForChangesInRemote:(GCRemote*)remote
                     withOptions:(GCRemoteCheckOptions)options
-                addedReferences:(NSDictionary**)addedReferences  // Full-names / SHA1s
-             modifiedReferences:(NSDictionary**)modifiedReferences  // Full-names / SHA1s
-              deletedReferences:(NSDictionary**)deletedReferences  // Full-names / SHA1s
+                addedReferences:(NSDictionary<NSString*, NSString*>**)addedReferences  // Full-names / SHA1s
+             modifiedReferences:(NSDictionary<NSString*, NSString*>**)modifiedReferences  // Full-names / SHA1s
+              deletedReferences:(NSDictionary<NSString*, NSString*>**)deletedReferences  // Full-names / SHA1s
                           error:(NSError**)error;
 
 - (BOOL)fetchRemoteBranch:(GCRemoteBranch*)branch tagMode:(GCFetchTagMode)mode updatedTips:(NSUInteger*)updatedTips error:(NSError**)error;  // git fetch {-n|-t} {-p} {remote} 'refs/heads/{branch}:refs/remotes/{remote}/{branch}'
 - (BOOL)fetchDefaultRemoteBranchesFromRemote:(GCRemote*)remote tagMode:(GCFetchTagMode)mode prune:(BOOL)prune updatedTips:(NSUInteger*)updatedTips error:(NSError**)error;  // git fetch {-n|-t} {-p} {remote}
-- (NSArray*)fetchTagsFromRemote:(GCRemote*)remote prune:(BOOL)prune updatedTips:(NSUInteger*)updatedTips error:(NSError**)error;  // git fetch {remote} 'refs/tags/*:refs/tags/*' - Returns the tags in the remote
+- (NSArray<__kindof GCTag*>*)fetchTagsFromRemote:(GCRemote*)remote prune:(BOOL)prune updatedTips:(NSUInteger*)updatedTips error:(NSError**)error;  // git fetch {remote} 'refs/tags/*:refs/tags/*' - Returns the tags in the remote
 
 - (BOOL)pushLocalBranchToUpstream:(GCLocalBranch*)branch force:(BOOL)force usedRemote:(GCRemote**)usedRemote error:(NSError**)error;  // git push
 - (BOOL)pushLocalBranch:(GCLocalBranch*)branch toRemote:(GCRemote*)remote force:(BOOL)force setUpstream:(BOOL)setUpstream error:(NSError**)error;  // git push {-f} {-u} {remote} 'refs/heads/{branch}:refs/heads/{branch}'

--- a/GitUpKit/Core/GCRemote.m
+++ b/GitUpKit/Core/GCRemote.m
@@ -244,9 +244,9 @@ cleanup:
 // Inspired from git_remote_prune()
 - (BOOL)checkForChangesInRemote:(GCRemote*)remote
                     withOptions:(GCRemoteCheckOptions)options
-                addedReferences:(NSDictionary**)addedReferences
-             modifiedReferences:(NSDictionary**)modifiedReferences
-              deletedReferences:(NSDictionary**)deletedReferences
+                addedReferences:(NSDictionary<NSString*, NSString*>**)addedReferences
+             modifiedReferences:(NSDictionary<NSString*, NSString*>**)modifiedReferences
+              deletedReferences:(NSDictionary<NSString*, NSString*>**)deletedReferences
                           error:(NSError**)error {
   BOOL success = NO;
   CFDictionaryKeyCallBacks keyCallbacks = {0, GCCStringCopyCallBack, GCFreeReleaseCallBack, NULL, GCCStringEqualCallBack, GCCStringHashCallBack};

--- a/GitUpKit/Core/GCRepository+Bare.h
+++ b/GitUpKit/Core/GCRepository+Bare.h
@@ -65,7 +65,7 @@ typedef GCCommit* (^GCConflictHandler)(GCIndex* index, GCCommit* ourCommit, GCCo
 
 - (GCCommit*)copyCommit:(GCCommit*)copyCommit
      withUpdatedMessage:(NSString*)message
-         updatedParents:(NSArray*)parents
+         updatedParents:(NSArray<__kindof GCCommit*>*)parents
    updatedTreeFromIndex:(GCIndex*)index
         updateCommitter:(BOOL)updateCommitter
                   error:(NSError**)error;
@@ -74,7 +74,7 @@ typedef GCCommit* (^GCConflictHandler)(GCIndex* index, GCCommit* ourCommit, GCCo
                ontoCommit:(GCCommit*)ontoCommit
        withAncestorCommit:(GCCommit*)ancestorCommit  // Typically a parent of "replayCommit" (the first one to use the main line)
            updatedMessage:(NSString*)message
-           updatedParents:(NSArray*)parents
+           updatedParents:(NSArray<__kindof GCCommit*>*)parents
           updateCommitter:(BOOL)updateCommitter
             skipIdentical:(BOOL)skipIdentical
           conflictHandler:(GCConflictHandler)handler

--- a/GitUpKit/Core/GCRepository+Config.h
+++ b/GitUpKit/Core/GCRepository+Config.h
@@ -35,6 +35,6 @@ typedef NS_ENUM(NSUInteger, GCConfigLevel) {
 - (GCConfigOption*)readConfigOptionForLevel:(GCConfigLevel)level variable:(NSString*)variable error:(NSError**)error;
 - (BOOL)writeConfigOptionForLevel:(GCConfigLevel)level variable:(NSString*)variable withValue:(NSString*)value error:(NSError**)error;  // Pass a nil value to delete the option
 
-- (NSArray*)readConfigForLevel:(GCConfigLevel)level error:(NSError**)error;
-- (NSArray*)readAllConfigs:(NSError**)error;  // Does not de-duplicate variables
+- (NSArray<GCConfigOption*>*)readConfigForLevel:(GCConfigLevel)level error:(NSError**)error;
+- (NSArray<GCConfigOption*>*)readAllConfigs:(NSError**)error;  // Does not de-duplicate variables
 @end

--- a/GitUpKit/Core/GCRepository+Mock.h
+++ b/GitUpKit/Core/GCRepository+Mock.h
@@ -39,7 +39,7 @@
 */
 
 @interface GCRepository (Mock)
-- (NSArray*)createMockCommitHierarchyFromNotation:(NSString*)notation force:(BOOL)force error:(NSError**)error;
+- (NSArray<GCCommit*>*)createMockCommitHierarchyFromNotation:(NSString*)notation force:(BOOL)force error:(NSError**)error;
 @end
 
 @interface GCHistory (Mock)

--- a/GitUpKit/Core/GCRepository+Reflog.h
+++ b/GitUpKit/Core/GCRepository+Reflog.h
@@ -46,8 +46,8 @@ typedef NS_OPTIONS(NSUInteger, GCReflogActions) {
 @property(nonatomic, readonly) NSTimeZone* timeZone;
 @property(nonatomic, readonly) NSString* committerName;
 @property(nonatomic, readonly) NSString* committerEmail;
-@property(nonatomic, readonly) NSArray* references;  // Matches @messages
-@property(nonatomic, readonly) NSArray* messages;  // Matches @references
+@property(nonatomic, readonly) NSArray<GCReference*>* references;  // Matches @messages
+@property(nonatomic, readonly) NSArray<NSString*>* messages;  // Matches @references
 @property(nonatomic, readonly) GCReflogActions actions;  // Guessed from messages (might not be reliable)
 @end
 
@@ -56,6 +56,6 @@ typedef NS_OPTIONS(NSUInteger, GCReflogActions) {
 @end
 
 @interface GCRepository (Reflog)
-- (NSArray*)loadReflogEntriesForReference:(GCReference*)reference error:(NSError**)error;  // git reflog {reference}
-- (NSArray*)loadAllReflogEntries:(NSError**)error;  // This deduplicate entries
+- (NSArray<GCReflogEntry*>*)loadReflogEntriesForReference:(GCReference*)reference error:(NSError**)error;  // git reflog {reference}
+- (NSArray<GCReflogEntry*>*)loadAllReflogEntries:(NSError**)error;  // This deduplicate entries
 @end

--- a/GitUpKit/Core/GCRepository+Status.h
+++ b/GitUpKit/Core/GCRepository+Status.h
@@ -47,7 +47,7 @@ typedef NS_OPTIONS(NSUInteger, GCCleanCheckOptions) {
 @end
 
 @interface GCRepository (Status)
-- (NSDictionary*)checkConflicts:(NSError**)error;
+- (NSDictionary<NSString*, GCIndexConflict*>*)checkConflicts:(NSError**)error;
 
 - (BOOL)checkClean:(GCCleanCheckOptions)options error:(NSError**)error;  // git status
 @end

--- a/GitUpKit/Core/GCRepository.h
+++ b/GitUpKit/Core/GCRepository.h
@@ -76,5 +76,5 @@ typedef NS_ENUM(NSUInteger, GCFileMode) {
 - (BOOL)exportBlobWithSHA1:(NSString*)sha1 toPath:(NSString*)path error:(NSError**)error;
 
 - (NSString*)pathForHookWithName:(NSString*)name;  // Returns nil if hook doesn't exist
-- (BOOL)runHookWithName:(NSString*)name arguments:(NSArray*)arguments standardInput:(NSString*)standardInput error:(NSError**)error;  // Silently ignores non-existing hooks
+- (BOOL)runHookWithName:(NSString*)name arguments:(NSArray<NSString*>*)arguments standardInput:(NSString*)standardInput error:(NSError**)error;  // Silently ignores non-existing hooks
 @end

--- a/GitUpKit/Core/GCStash.h
+++ b/GitUpKit/Core/GCStash.h
@@ -26,7 +26,7 @@
 
 @interface GCRepository (GCStash)
 - (GCStash*)saveStashWithMessage:(NSString*)message keepIndex:(BOOL)keepIndex includeUntracked:(BOOL)includeUntracked error:(NSError**)error;  // git stash {-k} {-u}
-- (NSArray*)listStashes:(NSError**)error;  // git stash list
+- (NSArray<GCStash*>*)listStashes:(NSError**)error;  // git stash list
 - (BOOL)applyStash:(GCStash*)stash restoreIndex:(BOOL)restoreIndex error:(NSError**)error;  // git stash apply {--index} {stash}
 - (BOOL)dropStash:(GCStash*)stash error:(NSError**)error;  // git stash drop {stash}
 - (BOOL)popStash:(GCStash*)stash restoreIndex:(BOOL)restoreIndex error:(NSError**)error;  // git stash pop {--index} {stash}

--- a/GitUpKit/Core/GCSubmodule.h
+++ b/GitUpKit/Core/GCSubmodule.h
@@ -57,7 +57,7 @@ typedef NS_ENUM(NSUInteger, GCSubmoduleUpdateMode) {
 - (BOOL)initializeAllSubmodules:(BOOL)recursive error:(NSError**)error;  // git submodule update --init {--recursive} - This will skip already initialized submodules
 
 - (GCSubmodule*)lookupSubmoduleWithName:(NSString*)name error:(NSError**)error;  // git submodule
-- (NSArray*)listSubmodules:(NSError**)error;  // git submodule
+- (NSArray<GCSubmodule*>*)listSubmodules:(NSError**)error;  // git submodule
 - (BOOL)updateSubmodule:(GCSubmodule*)submodule force:(BOOL)force error:(NSError**)error;  // git submodule update {--force} {submodule}
 - (BOOL)updateAllSubmodulesResursively:(BOOL)force error:(NSError**)error;  // git submodule update --recursive {--force} (except this does not fetch) - This will skip uninitialized submodules
 

--- a/GitUpKit/Core/GCTag.h
+++ b/GitUpKit/Core/GCTag.h
@@ -41,7 +41,7 @@
 + (BOOL)isValidTagName:(NSString*)name;
 
 - (GCTag*)findTagWithName:(NSString*)name error:(NSError**)error;
-- (NSArray*)listTags:(NSError**)error;  // git tag
+- (NSArray<GCTag*>*)listTags:(NSError**)error;  // git tag
 
 - (GCCommit*)lookupCommitForTag:(GCTag*)tag annotation:(GCTagAnnotation**)annotation error:(NSError**)error;  // git show-ref {tag}
 

--- a/GitUpKit/Interface/GIBranch.h
+++ b/GitUpKit/Interface/GIBranch.h
@@ -22,8 +22,8 @@
 
 // Computed properties
 @property(nonatomic, readonly) GINode* tipNode;
-@property(nonatomic, readonly) NSArray* localBranches;
-@property(nonatomic, readonly) NSArray* remoteBranches;
-@property(nonatomic, readonly) NSArray* tags;
+@property(nonatomic, readonly) NSArray<GCLocalBranch*>* localBranches;
+@property(nonatomic, readonly) NSArray<GCRemoteBranch*>* remoteBranches;
+@property(nonatomic, readonly) NSArray<GCTag*>* tags;
 @property(nonatomic, readonly) GIBranch* parentBranch;
 @end

--- a/GitUpKit/Interface/GIGraph.h
+++ b/GitUpKit/Interface/GIGraph.h
@@ -31,13 +31,13 @@ typedef NS_OPTIONS(NSUInteger, GIGraphOptions) {
 @property(nonatomic, readonly) GIGraphOptions options;
 @property(nonatomic, readonly, getter=isEmpty) BOOL empty;
 
-@property(nonatomic, readonly) NSArray* branches;
-@property(nonatomic, readonly) NSArray* layers;
-@property(nonatomic, readonly) NSArray* lines;
-@property(nonatomic, readonly) NSArray* nodes;
+@property(nonatomic, readonly) NSArray<GIBranch*>* branches;
+@property(nonatomic, readonly) NSArray<GILayer*>* layers;
+@property(nonatomic, readonly) NSArray<GILine*>* lines;
+@property(nonatomic, readonly) NSArray<GINode*>* nodes;
 
 @property(nonatomic, readonly) NSUInteger numberOfDummyNodes;
-@property(nonatomic, readonly) NSArray* nodesWithReferences;
+@property(nonatomic, readonly) NSArray<GINode*>* nodesWithReferences;
 @property(nonatomic, readonly) NSSize size;
 
 - (GINode*)nodeForCommit:(GCHistoryCommit*)commit;

--- a/GitUpKit/Interface/GILayer.h
+++ b/GitUpKit/Interface/GILayer.h
@@ -16,7 +16,7 @@
 #import <Foundation/Foundation.h>
 
 @interface GILayer : NSObject
-@property(nonatomic, readonly) NSArray* nodes;  // NOT RETAINED
-@property(nonatomic, readonly) NSArray* lines;  // NOT RETAINED
+@property(nonatomic, readonly) NSArray<GINode*>* nodes;  // NOT RETAINED
+@property(nonatomic, readonly) NSArray<GILine*>* lines;  // NOT RETAINED
 @property(nonatomic, readonly) NSUInteger index;  // Matches index in layers array
 @end

--- a/GitUpKit/Interface/GILine.h
+++ b/GitUpKit/Interface/GILine.h
@@ -19,7 +19,7 @@
 
 @interface GILine : NSObject
 @property(nonatomic, readonly) GIBranch* branch;  // NOT RETAINED
-@property(nonatomic, readonly) NSArray* nodes;  // NOT RETAINED
+@property(nonatomic, readonly) NSArray<GINode*>* nodes;  // NOT RETAINED
 
 // Computed properties
 @property(nonatomic, readonly, getter=isVirtual) BOOL virtual;

--- a/GitUpKit/Utilities/GIViewController+Utilities.h
+++ b/GitUpKit/Utilities/GIViewController+Utilities.h
@@ -56,7 +56,7 @@ extern NSString* const GIViewController_MergeTool;
 
 - (void)openFileWithDefaultEditor:(NSString*)path;
 - (void)openSubmoduleWithApp:(NSString*)path;
-- (void)viewDeltasInDiffTool:(NSArray*)deltas;
+- (void)viewDeltasInDiffTool:(NSArray<GCDiffDelta*>*)deltas;
 - (void)resolveConflictInMergeTool:(GCIndexConflict*)conflict;
 - (void)markConflictAsResolved:(GCIndexConflict*)conflict;
 
@@ -64,12 +64,12 @@ extern NSString* const GIViewController_MergeTool;
                                     index:(GCIndex*)index
                                 ourCommit:(GCCommit*)ourCommit
                               theirCommit:(GCCommit*)theirCommit
-                            parentCommits:(NSArray*)parentCommits
+                            parentCommits:(NSArray<__kindof GCCommit*>*)parentCommits
                                   message:(NSString*)message
                                     error:(NSError**)error;
 
 - (NSMenu*)contextualMenuForDelta:(GCDiffDelta*)delta withConflict:(GCIndexConflict*)conflict allowOpen:(BOOL)allowOpen;
-- (BOOL)handleKeyDownEvent:(NSEvent*)event forSelectedDeltas:(NSArray*)deltas withConflicts:(NSDictionary*)conflicts allowOpen:(BOOL)allowOpen;
+- (BOOL)handleKeyDownEvent:(NSEvent*)event forSelectedDeltas:(NSArray<GCDiffDelta*>*)deltas withConflicts:(NSDictionary<NSString*, GCIndexConflict*>*)conflicts allowOpen:(BOOL)allowOpen;
 
 - (void)launchDiffToolWithCommit:(GCCommit*)commit otherCommit:(GCCommit*)otherCommit;
 @end


### PR DESCRIPTION
I went through the code base and added support for the new generics introduced in Objective-C in Xcode 7 beta. I'm guessing this probably would be best to merge after the official Xcode 7 release (September 9?), but I wanted to get some feedback on it to make sure everything looks good.

After adding the type specifiers, a couple warnings popped up in one of the test cases where `GCHistoryRemoteBranch` was being assigned `GCHistoryLocalBranch` objects, so I changed those to the proper type.