### PR TITLE
Animated transition in/out of Quick View

### DIFF
--- a/GitUp/Application/AppDelegate.m
+++ b/GitUp/Application/AppDelegate.m
@@ -81,7 +81,8 @@
     kUserDefaultsKey_ReleaseChannel: kReleaseChannel_Stable,
     kUserDefaultsKey_CheckInterval: @(15 * 60),
     kUserDefaultsKey_FirstLaunch: @(YES),
-    kUserDefaultsKey_DiffWhitespaceMode: @(kGCLiveRepositoryDiffWhitespaceMode_Normal)
+    kUserDefaultsKey_DiffWhitespaceMode: @(kGCLiveRepositoryDiffWhitespaceMode_Normal),
+    kUserDefaultsKey_EnableVisualEffects: @(NO),
   };
   [[NSUserDefaults standardUserDefaults] registerDefaults:defaults];
 }

--- a/GitUp/Application/Common.h
+++ b/GitUp/Application/Common.h
@@ -26,6 +26,7 @@
 #define kUserDefaultsKey_SimpleCommit @"SimpleCommit"  // BOOL
 #define kUserDefaultsKey_DisableSparkle @"DisableSparkle"  // BOOL
 #define kUserDefaultsKey_DiffWhitespaceMode @"DiffWhitespaceMode"  // NSUInteger
+#define kUserDefaultsKey_EnableVisualEffects @"EnableVisualEffects"  // BOOL
 
 #define kRepositoryUserInfoKey_SkipSubmoduleCheck @"SkipSubmoduleCheck"  // BOOL
 #define kRepositoryUserInfoKey_MainWindowFrame @"MainWindowFrame"  // NSString

--- a/GitUp/Application/Document.h
+++ b/GitUp/Application/Document.h
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSUInteger, WindowModeID) {
 @property(nonatomic, weak) IBOutlet NSButton* helpOpenButton;
 
 @property(nonatomic, weak) IBOutlet NSTabView* mainTabView;
-@property(nonatomic, weak) IBOutlet NSView* containerView;
+@property(nonatomic, weak) IBOutlet NSView* mapContainerView;
 
 @property(nonatomic, strong) IBOutlet NSView* titleView;
 @property(nonatomic, weak) IBOutlet NSTextField* titleTextField;

--- a/GitUp/Application/Document.h
+++ b/GitUp/Application/Document.h
@@ -29,6 +29,7 @@ typedef NS_ENUM(NSUInteger, WindowModeID) {
 
 @interface Document : NSDocument <NSUserInterfaceValidations>
 @property(nonatomic, strong) IBOutlet NSWindow* mainWindow;
+@property(nonatomic, strong) IBOutlet NSView* contentView;
 
 @property(nonatomic, strong) IBOutlet NSToolbar* toolbar;
 

--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -45,6 +45,10 @@
 #define kRestorableStateKey_WindowMode @"windowMode"
 
 #define kSideViewAnimationDuration 0.15  // seconds
+#define kQuickViewAnimationDuration 0.25  // seconds
+
+#define kAnimationKey_ID @"animationID"
+#define kAnimationID_QuickViewSnapshot @"snapshotAnimation"
 
 #define kMaxAncestorCommits 1000
 
@@ -105,6 +109,8 @@ static inline WindowModeID _WindowModeIDFromString(NSString* mode) {
   BOOL _unifiedToolbar;
   NSNumberFormatter* _numberFormatter;
   NSDateFormatter* _dateFormatter;
+  CALayer* _fixedSnapshotLayer;
+  CALayer* _animatingSnapshotLayer;
   NSMutableArray* _quickViewCommits;
   GCHistoryWalker* _quickViewAncestors;
   GCHistoryWalker* _quickViewDescendants;
@@ -278,7 +284,13 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
   if (_unifiedToolbar) {
     _mainWindow.titleVisibility = NSWindowTitleHidden;
   }
-  _mapContainerView.wantsLayer = YES;
+  _contentView.wantsLayer = YES;
+  
+  // Text fields must be drawn on an opaque background to avoid subpixel antialiasing issues during animation.
+  for (NSTextField* field in @[_infoTextField1, _infoTextField2, _progressTextField]) {
+    field.drawsBackground = YES;
+    field.backgroundColor = _mainWindow.backgroundColor;
+  }
   
   _mapViewController = [[GIMapViewController alloc] initWithRepository:_repository];
   _mapViewController.delegate = self;
@@ -880,11 +892,11 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
     XLOG_DEBUG_UNREACHABLE();
   }
   if (showHelp) {
-    NSRect contentBounds = [_mainWindow.contentView bounds];
+    NSRect contentBounds = _contentView.bounds;
     _helpView.hidden = NO;
     _mainTabView.frame = NSMakeRect(contentBounds.origin.x, contentBounds.origin.y, contentBounds.size.width, contentBounds.size.height - _helpView.frame.size.height);
   } else if (!_helpView.hidden) {
-    _mainTabView.frame = [_mainWindow.contentView bounds];
+    _mainTabView.frame = _contentView.bounds;
     _helpView.hidden = YES;
   }
 }
@@ -936,7 +948,110 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
   }
   
   _quickViewController.commit = commit;
-  [self _setWindowMode:kWindowModeString_Map_QuickView];
+  
+  [self _animateQuickViewForCommit:commit appearing:YES transition:^{
+    [self _setWindowMode:kWindowModeString_Map_QuickView];
+  }];
+}
+
+- (void)_animateQuickViewForCommit:(GCHistoryCommit*)commit appearing:(BOOL)appearing transition:(void (^)(void))transitionBlock {
+  if (![[NSUserDefaults standardUserDefaults] boolForKey:kUserDefaultsKey_EnableVisualEffects]) {
+    transitionBlock();
+    return;
+  }
+  
+  [CATransaction flush];
+  [CATransaction begin];
+  [CATransaction setDisableActions:YES];
+  
+  BOOL animationInFlight = YES;
+  if (!_fixedSnapshotLayer) {
+    animationInFlight = NO;
+    _fixedSnapshotLayer = [CALayer layer];
+    _fixedSnapshotLayer.backgroundColor = _mainWindow.backgroundColor.CGColor;
+    _animatingSnapshotLayer = [CALayer layer];
+    _animatingSnapshotLayer.backgroundColor = _mainWindow.backgroundColor.CGColor;
+    _animatingSnapshotLayer.shadowOpacity = 0.2;
+    _animatingSnapshotLayer.shadowRadius = 30;
+  }
+  
+  if (animationInFlight) {
+    transitionBlock();
+  } else if (appearing) {
+    _fixedSnapshotLayer.contents = [_contentView takeSnapshot];
+    transitionBlock();
+    _animatingSnapshotLayer.contents = [_contentView takeSnapshot];
+  } else {
+    _animatingSnapshotLayer.contents = [_contentView takeSnapshot];
+    transitionBlock();
+    _fixedSnapshotLayer.contents = [_contentView takeSnapshot];
+  }
+  
+  [_contentView.layer addSublayer:_fixedSnapshotLayer];
+  [_contentView.layer addSublayer:_animatingSnapshotLayer];
+  
+  _fixedSnapshotLayer.frame = _contentView.layer.bounds;
+  
+  CALayer* fromLayer = nil;
+  if (animationInFlight) {
+    fromLayer = _animatingSnapshotLayer.presentationLayer;
+  }
+  
+  if (!fromLayer) {
+    fromLayer = _animatingSnapshotLayer;
+  }
+  
+  CABasicAnimation* position = [CABasicAnimation animationWithKeyPath:@"position"];
+  CABasicAnimation* transform = [CABasicAnimation animationWithKeyPath:@"transform"];
+  
+  [self _configureAnimatingSnapshotLayerForCommit:appearing ? commit : nil];
+  position.fromValue = [fromLayer valueForKey:@"position"];
+  transform.fromValue = [fromLayer valueForKey:@"transform"];
+  
+  [self _configureAnimatingSnapshotLayerForCommit:appearing ? nil : commit];
+  position.toValue = [_animatingSnapshotLayer valueForKey:@"position"];
+  transform.toValue = [_animatingSnapshotLayer valueForKey:@"transform"];
+  
+  CAAnimationGroup* group = [CAAnimationGroup animation];
+  group.animations = @[position, transform];
+  group.delegate = self;
+  [group setValue:kAnimationID_QuickViewSnapshot forKey:kAnimationKey_ID];
+  
+  [CATransaction setAnimationDuration:kQuickViewAnimationDuration];
+  [CATransaction setAnimationTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionDefault]];
+  [_animatingSnapshotLayer addAnimation:group forKey:kAnimationID_QuickViewSnapshot];
+  
+  [CATransaction commit];
+}
+
+- (void)animationDidStop:(CAAnimation*)anim finished:(BOOL)flag {
+  if ([[anim valueForKey:kAnimationKey_ID] isEqual:kAnimationID_QuickViewSnapshot] && flag) {
+    [_fixedSnapshotLayer removeFromSuperlayer];
+    [_animatingSnapshotLayer removeFromSuperlayer];
+    _fixedSnapshotLayer = nil;
+    _animatingSnapshotLayer = nil;
+  }
+}
+
+- (void)_configureAnimatingSnapshotLayerForCommit:(GCHistoryCommit*)commit {
+  if (commit) {
+    NSPoint commitPoint = [_contentView convertPoint:[_mapViewController positionInViewForCommit:commit] fromView:_mapViewController.view];
+    if (NSPointInRect(commitPoint, _contentView.bounds)) {
+      _animatingSnapshotLayer.bounds = _contentView.layer.bounds;
+      _animatingSnapshotLayer.position = [_contentView convertPointToLayer:commitPoint];
+    } else {
+      _animatingSnapshotLayer.frame = _contentView.layer.bounds;
+    }
+    // Shrink the snapshot so it appears at the location of the commit.
+    // (0 is too small and causes the animation to behave incorrectly.)
+    _animatingSnapshotLayer.transform = CATransform3DMakeScale(0.0001, 0.0001, 1);
+  } else {
+    _animatingSnapshotLayer.transform = CATransform3DIdentity;
+    _animatingSnapshotLayer.frame = _contentView.layer.bounds;
+  }
+  CGPathRef path = CGPathCreateWithRect(_animatingSnapshotLayer.bounds, NULL);
+  _animatingSnapshotLayer.shadowPath = path;
+  CGPathRelease(path);
 }
 
 - (BOOL)_hasPreviousQuickView {
@@ -984,7 +1099,9 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
   
   [_repository resumeHistoryUpdates];
   
-  [self _setWindowMode:kWindowModeString_Map];
+  [self _animateQuickViewForCommit:_quickViewController.commit appearing:NO transition:^{
+    [self _setWindowMode:kWindowModeString_Map];
+  }];
 }
 
 #pragma mark - Diff

--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -278,14 +278,14 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
   if (_unifiedToolbar) {
     _mainWindow.titleVisibility = NSWindowTitleHidden;
   }
-  _containerView.wantsLayer = YES;
+  _mapContainerView.wantsLayer = YES;
   
   _mapViewController = [[GIMapViewController alloc] initWithRepository:_repository];
   _mapViewController.delegate = self;
   [_mapControllerView replaceWithView:_mapViewController.view];
-  _mapView.frame = _containerView.bounds;
-  [_containerView addSubview:_mapView];
-  XLOG_DEBUG_CHECK(_containerView.subviews.firstObject == _mapView);
+  _mapView.frame = _mapContainerView.bounds;
+  [_mapContainerView addSubview:_mapView];
+  XLOG_DEBUG_CHECK(_mapContainerView.subviews.firstObject == _mapView);
   [self _updateStatusBar];
   
   _tagsViewController = [[GICommitListViewController alloc] initWithRepository:_repository];
@@ -1661,13 +1661,13 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
 }
 
 - (void)_addSideView:(NSView*)view withIdentifier:(NSString*)identifier completion:(dispatch_block_t)completion {
-  NSRect contentFrame = _containerView.bounds;
+  NSRect contentFrame = _mapContainerView.bounds;
   NSRect mapFrame = _mapView.frame;
   NSRect viewFrame = view.frame;
   NSRect newMapFrame = NSMakeRect(0, mapFrame.origin.y, contentFrame.size.width - viewFrame.size.width, mapFrame.size.height);
   NSRect newViewFrame = NSMakeRect(contentFrame.size.width - viewFrame.size.width, mapFrame.origin.y, viewFrame.size.width, mapFrame.size.height);
   view.frame = NSOffsetRect(newViewFrame, viewFrame.size.width, 0);
-  [_containerView addSubview:view positioned:NSWindowAbove relativeTo:_mapView];
+  [_mapContainerView addSubview:view positioned:NSWindowAbove relativeTo:_mapView];
   
   [NSAnimationContext beginGrouping];
   [[NSAnimationContext currentContext] setDuration:kSideViewAnimationDuration];
@@ -1685,7 +1685,7 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
 }
 
 - (void)_removeSideView:(NSView*)view completion:(dispatch_block_t)completion {
-  NSRect contentFrame = _containerView.bounds;
+  NSRect contentFrame = _mapContainerView.bounds;
   NSRect mapFrame = _mapView.frame;
   NSRect newMapFrame = NSMakeRect(0, mapFrame.origin.y, contentFrame.size.width, mapFrame.size.height);
   NSRect viewFrame = view.frame;

--- a/GitUp/Application/en.lproj/Document.xib
+++ b/GitUp/Application/en.lproj/Document.xib
@@ -9,6 +9,7 @@
             <connections>
                 <outlet property="ancestorsControllerView" destination="4Od-pU-cwC" id="rKi-Xf-O9z"/>
                 <outlet property="ancestorsView" destination="Yj4-Sl-8P8" id="uNx-x0-4Kg"/>
+                <outlet property="contentView" destination="gIp-Ho-8D9" id="BwU-UD-4Je"/>
                 <outlet property="exitButton" destination="FEG-0e-0JW" id="VpC-s7-grz"/>
                 <outlet property="helpContinueButton" destination="W0y-nq-maS" id="tO3-ij-oea"/>
                 <outlet property="helpDismissButton" destination="etB-ce-0PB" id="iMt-Ga-rPE"/>

--- a/GitUp/Application/en.lproj/Document.xib
+++ b/GitUp/Application/en.lproj/Document.xib
@@ -9,7 +9,6 @@
             <connections>
                 <outlet property="ancestorsControllerView" destination="4Od-pU-cwC" id="rKi-Xf-O9z"/>
                 <outlet property="ancestorsView" destination="Yj4-Sl-8P8" id="uNx-x0-4Kg"/>
-                <outlet property="containerView" destination="KTA-UW-CKM" id="CLJ-vA-fY3"/>
                 <outlet property="exitButton" destination="FEG-0e-0JW" id="VpC-s7-grz"/>
                 <outlet property="helpContinueButton" destination="W0y-nq-maS" id="tO3-ij-oea"/>
                 <outlet property="helpDismissButton" destination="etB-ce-0PB" id="iMt-Ga-rPE"/>
@@ -24,6 +23,7 @@
                 <outlet property="leftView" destination="d4D-Mc-I9O" id="Lqi-IU-ziC"/>
                 <outlet property="mainTabView" destination="8LX-i4-RBG" id="CKf-8g-erJ"/>
                 <outlet property="mainWindow" destination="xOd-HO-29H" id="YqJ-z0-2YQ"/>
+                <outlet property="mapContainerView" destination="KTA-UW-CKM" id="8sn-Xg-Vjz"/>
                 <outlet property="mapControllerView" destination="399-bl-TuH" id="cZj-7k-l5R"/>
                 <outlet property="mapView" destination="p3q-Tt-mR8" id="Qym-7v-5bw"/>
                 <outlet property="modeControl" destination="RvM-Rz-Je8" id="rYt-Pf-y7Q"/>

--- a/GitUp/Application/en.lproj/MainMenu.xib
+++ b/GitUp/Application/en.lproj/MainMenu.xib
@@ -29,13 +29,41 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <font key="font" metaFont="system"/>
                         <tabViewItems>
-                            <tabViewItem label="{500, 328}" identifier="general" id="M8N-WY-xpP">
+                            <tabViewItem label="{500, 366}" identifier="general" id="M8N-WY-xpP">
                                 <view key="view" id="ZJf-t1-iGB">
                                     <rect key="frame" x="0.0" y="0.0" width="500" height="400"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="EBQ-WH-0CZ">
+                                            <rect key="frame" x="12" y="363" width="120" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <animations/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Appearance:" id="KoF-W9-skh">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <button id="FHl-t5-4zJ">
+                                            <rect key="frame" x="137" y="362" width="169" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <animations/>
+                                            <buttonCell key="cell" type="check" title="Enable visual effects" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="s0v-Nh-NIo">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <binding destination="AR1-cq-KNa" name="value" keyPath="values.EnableVisualEffects" id="tBi-n6-K2C">
+                                                    <dictionary key="options">
+                                                        <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                        <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                        <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                                    </dictionary>
+                                                </binding>
+                                            </connections>
+                                        </button>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="lyZ-cf-MT6">
-                                            <rect key="frame" x="12" y="224" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="185" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Commits:" id="6J8-35-XZI">
                                                 <font key="font" metaFont="system"/>
@@ -44,7 +72,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button id="CQY-oC-oQ8">
-                                            <rect key="frame" x="137" y="223" width="146" height="18"/>
+                                            <rect key="frame" x="137" y="184" width="146" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Use Simple mode" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="rMb-zc-NF1">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -61,7 +89,7 @@
                                             </connections>
                                         </button>
                                         <button id="T1B-3i-hRB">
-                                            <rect key="frame" x="137" y="133" width="191" height="18"/>
+                                            <rect key="frame" x="137" y="94" width="191" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Show invisible characters" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="omy-Qf-vg9">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -78,7 +106,7 @@
                                             </connections>
                                         </button>
                                         <button id="SyF-mN-F3q">
-                                            <rect key="frame" x="137" y="113" width="270" height="18"/>
+                                            <rect key="frame" x="137" y="74" width="270" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Show margins at 50 and 72 characters" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="AMR-Ne-0QY">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -95,7 +123,7 @@
                                             </connections>
                                         </button>
                                         <button id="ag6-rb-zPH">
-                                            <rect key="frame" x="137" y="93" width="176" height="18"/>
+                                            <rect key="frame" x="137" y="54" width="176" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Enable spell checking" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="G82-Jf-2sb">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -112,7 +140,7 @@
                                             </connections>
                                         </button>
                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="jee-vl-BUt">
-                                            <rect key="frame" x="137" y="161" width="345" height="56"/>
+                                            <rect key="frame" x="137" y="122" width="345" height="56"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="v99-tx-ohB">
                                                 <font key="font" metaFont="smallSystem"/>
@@ -123,7 +151,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="YZU-dx-gjr">
-                                            <rect key="frame" x="12" y="295" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="256" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Diffs Layout:" id="B0V-bN-usw">
                                                 <font key="font" metaFont="system"/>
@@ -132,10 +160,10 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <matrix verticalHuggingPriority="750" allowsEmptySelection="NO" autorecalculatesCellSize="YES" id="pP3-w2-KOs">
-                                            <rect key="frame" x="139" y="255" width="289" height="58"/>
+                                            <rect key="frame" x="139" y="216" width="299" height="58"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            <size key="cellSize" width="280" height="18"/>
+                                            <size key="cellSize" width="299" height="18"/>
                                             <size key="intercellSpacing" width="4" height="2"/>
                                             <buttonCell key="prototype" type="radio" title="Radio" imagePosition="left" alignment="left" inset="2" id="S4o-dE-O99">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -168,7 +196,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </connections>
                                         </matrix>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="mC1-sE-MTH">
-                                            <rect key="frame" x="12" y="134" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="95" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Message Editor:" id="5Hr-DF-QKw">
                                                 <font key="font" metaFont="system"/>
@@ -177,7 +205,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="IO8-Wx-DRo">
-                                            <rect key="frame" x="12" y="369" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="330" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Diff Generation:" id="cxW-C3-fIQ">
                                                 <font key="font" metaFont="system"/>
@@ -186,10 +214,10 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <matrix verticalHuggingPriority="750" allowsEmptySelection="NO" autorecalculatesCellSize="YES" id="zwg-99-t9E">
-                                            <rect key="frame" x="139" y="329" width="289" height="58"/>
+                                            <rect key="frame" x="139" y="290" width="289" height="58"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            <size key="cellSize" width="272" height="18"/>
+                                            <size key="cellSize" width="268" height="18"/>
                                             <size key="intercellSpacing" width="4" height="2"/>
                                             <buttonCell key="prototype" type="radio" title="Radio" imagePosition="left" alignment="left" inset="2" id="aRV-8E-fbW">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>

--- a/GitUp/GitUp.xcodeproj/project.pbxproj
+++ b/GitUp/GitUp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		165C32B61B95739700D2F894 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 165C32B51B95739700D2F894 /* QuartzCore.framework */; };
 		E212A6DE1B92100E00F62B18 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E212A6DD1B92100E00F62B18 /* libiconv.dylib */; };
 		E21739F71A5080DD00EC6777 /* DocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = E21739F61A5080DD00EC6777 /* DocumentController.m */; };
 		E21DCAEB1B253847006424E8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E21DCAEA1B253847006424E8 /* main.m */; };
@@ -101,6 +102,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		165C32B51B95739700D2F894 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E212A6DD1B92100E00F62B18 /* libiconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
 		E21739F51A5080DD00EC6777 /* DocumentController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DocumentController.h; sourceTree = "<group>"; };
 		E21739F61A5080DD00EC6777 /* DocumentController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DocumentController.m; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				165C32B61B95739700D2F894 /* QuartzCore.framework in Frameworks */,
 				E2C338D719F85C2E00063D95 /* Cocoa.framework in Frameworks */,
 				E267E26B1B84E07E00BAB377 /* Security.framework in Frameworks */,
 				E2653D251A5B2FBD006A9871 /* Sparkle.framework in Frameworks */,
@@ -173,6 +176,7 @@
 				E2C338D619F85C2E00063D95 /* Cocoa.framework */,
 				E2C338D819F85C3400063D95 /* Foundation.framework */,
 				E28200AC1A7D71EE00DA4096 /* CoreServices.framework */,
+				165C32B51B95739700D2F894 /* QuartzCore.framework */,
 				E2B14B561A88102C00003E64 /* Security.framework */,
 				E2653D241A5B2FBD006A9871 /* Sparkle.framework */,
 				E2F6AA091A7EED74002DBF56 /* Crashlytics.framework */,

--- a/GitUpKit/Utilities/GIAppKit.h
+++ b/GitUpKit/Utilities/GIAppKit.h
@@ -36,6 +36,7 @@ extern NSString* const GICommitMessageViewUserDefaultKey_EnableSpellChecking;
 
 @interface NSView (GIAppKit)
 - (void)replaceWithView:(NSView*)view;  // Preserves frame and autoresizing mask
+- (NSImage*)takeSnapshot;
 @end
 
 @interface NSMenu (GIAppKit)

--- a/GitUpKit/Utilities/GIAppKit.m
+++ b/GitUpKit/Utilities/GIAppKit.m
@@ -84,6 +84,14 @@ static NSColor* _separatorColor = nil;
   [self.superview replaceSubview:self with:view];
 }
 
+- (NSImage*)takeSnapshot {
+  NSBitmapImageRep* rep = [self bitmapImageRepForCachingDisplayInRect:self.bounds];
+  [self cacheDisplayInRect:self.bounds toBitmapImageRep:rep];
+  NSImage* image = [[NSImage alloc] initWithSize:rep.size];
+  [image addRepresentation:rep];
+  return image;
+}
+
 @end
 
 @implementation NSMenu (GIAppKit)

--- a/GitUpKit/Utilities/GIAppKit.m
+++ b/GitUpKit/Utilities/GIAppKit.m
@@ -350,8 +350,25 @@ static NSColor* _separatorColor = nil;
 // See http://stackoverflow.com/a/30494691/463432
 - (void)splitView:(NSSplitView*)splitView resizeSubviewsWithOldSize:(NSSize)oldSize {
   [splitView adjustSubviews];
-  NSView* view = splitView.subviews.firstObject;
-  [splitView setPosition:(splitView.vertical ? view.frame.size.width : view.frame.size.height) ofDividerAtIndex:0];
+  // Take the min size constraints into account.
+  // Using -setPosition:ofDividerAtIndex: from inside this method confuses Core Animation on 10.8.
+  if (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber10_9) {
+    NSView* view = splitView.subviews.firstObject;
+    [splitView setPosition:(splitView.vertical ? view.frame.size.width : view.frame.size.height) ofDividerAtIndex:0];
+  } else {
+    NSView* view1 = splitView.subviews[0];
+    NSView* view2 = splitView.subviews[1];
+    NSSize splitViewSize = splitView.bounds.size;
+    if (splitView.vertical) {
+      CGFloat splitPosition = MAX(view1.bounds.size.width, _minSize1);
+      view1.frame = NSMakeRect(0, 0, splitPosition, splitViewSize.height);
+      view2.frame = NSMakeRect(splitPosition + splitView.dividerThickness, 0, splitViewSize.width - splitPosition - splitView.dividerThickness, splitViewSize.height);
+    } else {
+      CGFloat splitPosition = MAX(view1.bounds.size.height, _minSize1);
+      view1.frame = NSMakeRect(0, 0, splitViewSize.width, splitPosition);
+      view2.frame = NSMakeRect(0, splitPosition + splitView.dividerThickness, splitViewSize.width, splitViewSize.height - splitPosition - splitView.dividerThickness);
+    }
+  }
 }
 
 @end

--- a/GitUpKit/Views/GIMapViewController.h
+++ b/GitUpKit/Views/GIMapViewController.h
@@ -37,6 +37,7 @@
 @property(nonatomic) BOOL forceShowAllTips;
 - (BOOL)selectCommit:(GCCommit*)commit;  // Also scrolls if needed to ensure commit is visible - Returns YES if commit was selected
 - (GINode*)nodeForCommit:(GCCommit*)commit;
+- (NSPoint)positionInViewForCommit:(GCCommit*)commit;
 
 - (IBAction)toggleTagLabels:(id)sender;
 - (IBAction)toggleBranchLabels:(id)sender;

--- a/GitUpKit/Views/GIMapViewController.m
+++ b/GitUpKit/Views/GIMapViewController.m
@@ -204,6 +204,12 @@ static NSColor* _patternColor = nil;
   return historyCommit ? [_graphView.graph nodeForCommit:historyCommit] : nil;
 }
 
+- (NSPoint)positionInViewForCommit:(GCCommit*)commit {
+  GINode* node = [self nodeForCommit:commit];
+  XLOG_DEBUG_CHECK(node);
+  return node ? [self.view convertPoint:[_graphView positionForNode:node] fromView:_graphView] : NSZeroPoint;
+}
+
 - (void)setShowsVirtualTips:(BOOL)flag {
   if (flag != _showsVirtualTips) {
     _showsVirtualTips = flag;


### PR DESCRIPTION
As Quick View feels a lot like Quick Look, I thought it would be nice to have some smooth transitions. (It would be nice for the title bar to fade at the same time, but I didn't do that in this commit.)

- Use 2 snapshot layers to animate the transition in/out of Quick View
- Rename `Document`'s `_containerView` to `_mapContainerView`, to make its purpose more evident
- Link QuartzCore.framework