### PR TITLE
Include both commit messages in squash

### DIFF
--- a/GitUpKit/Views/GIMapViewController+Operations.m
+++ b/GitUpKit/Views/GIMapViewController+Operations.m
@@ -225,7 +225,8 @@ static inline NSString* _CleanedUpCommitMessage(NSString* message) {
 
 - (void)squashCommitWithParent:(GCHistoryCommit*)commit {
   if ([self checkCleanRepositoryForOperationOnCommit:commit]) {
-    [self _promptForCommitMessage:_CleanedUpCommitMessage(commit.message)
+    NSString *mergedMessage = [NSString stringWithFormat:@"# The first commit's message is:\n%@\n\n# This is the 2nd commit message:\n%@", ((GCHistoryCommit*)commit.parents.firstObject).message, commit.message];
+    [self _promptForCommitMessage:_CleanedUpCommitMessage(mergedMessage)
                         withTitle:NSLocalizedString(@"Squashed commit message:", nil)
                            button:NSLocalizedString(@"Squash", nil)
                             block:^(NSString* message) {


### PR DESCRIPTION
Squash With Parent populates the commit message with the squashed
commit's message and its parent's commit message. This is similar to the
way 'git rebase --interactive' works.

Resolves: http://forums.gitup.co/t/squash-with-parent-should-include-both-commit-messages/315