### PR TITLE
Include both commit messages in squash

### DIFF
--- a/GitUpKit/Views/GIMapViewController+Operations.m
+++ b/GitUpKit/Views/GIMapViewController+Operations.m
@@ -225,7 +225,9 @@ static inline NSString* _CleanedUpCommitMessage(NSString* message) {
 
 - (void)squashCommitWithParent:(GCHistoryCommit*)commit {
   if ([self checkCleanRepositoryForOperationOnCommit:commit]) {
-    [self _promptForCommitMessage:_CleanedUpCommitMessage(commit.message)
+    GCHistoryCommit* parentCommit = commit.parents.firstObject;
+    NSString* mergedMessage = [NSString stringWithFormat:NSLocalizedString(@"%@\n\n%@", nil), _CleanedUpCommitMessage(parentCommit.message), _CleanedUpCommitMessage(commit.message)];
+    [self _promptForCommitMessage:mergedMessage
                         withTitle:NSLocalizedString(@"Squashed commit message:", nil)
                            button:NSLocalizedString(@"Squash", nil)
                             block:^(NSString* message) {


### PR DESCRIPTION
Squash With Parent populates the commit message with the squashed
commit's message and its parent's commit message. This is similar to
the way 'git rebase --interactive' works.

Resolves: http://forums.gitup.co/t/squash-with-parent-should-include-both-commit-messages/315

<img width="1112" alt="screen shot 2015-09-21 at 11 24 56 pm" src="https://cloud.githubusercontent.com/assets/5513/10021540/11588f60-610e-11e5-8097-886708aade86.png">