### PR TITLE
Display both author and committer dates in Quick View

### DIFF
--- a/GitUpKit/Core/GCCommit.h
+++ b/GitUpKit/Core/GCCommit.h
@@ -23,8 +23,10 @@
 @property(nonatomic, readonly) NSTimeZone* timeZone;
 @property(nonatomic, readonly) NSString* authorName;
 @property(nonatomic, readonly) NSString* authorEmail;
+@property(nonatomic, readonly) NSDate* authorDate;
 @property(nonatomic, readonly) NSString* committerName;
 @property(nonatomic, readonly) NSString* committerEmail;
+@property(nonatomic, readonly) NSDate* committerDate;
 @property(nonatomic, readonly) NSString* treeSHA1;
 @end
 

--- a/GitUpKit/Core/GCCommit.m
+++ b/GitUpKit/Core/GCCommit.m
@@ -63,10 +63,8 @@ static inline NSString* _ConvertMessage(GCCommit* commit, const char* message, s
   return _ConvertMessage(self, summary, strlen(summary), git_commit_message_encoding((git_commit*)_private));
 }
 
-// Reimplementation of git_commit_time()
 - (NSDate*)date {
-  const git_signature* signature = git_commit_committer((git_commit*)_private);
-  return [NSDate dateWithTimeIntervalSince1970:signature->when.time];
+  return self.committerDate;
 }
 
 // Reimplementation of git_commit_time_offset()
@@ -85,6 +83,11 @@ static inline NSString* _ConvertMessage(GCCommit* commit, const char* message, s
   return [NSString stringWithUTF8String:signature->email];
 }
 
+- (NSDate*)authorDate {
+  const git_signature* signature = git_commit_author((git_commit*)_private);
+  return [NSDate dateWithTimeIntervalSince1970:signature->when.time];
+}
+
 - (NSString*)committerName {
   const git_signature* signature = git_commit_committer((git_commit*)_private);
   return [NSString stringWithUTF8String:signature->name];
@@ -93,6 +96,12 @@ static inline NSString* _ConvertMessage(GCCommit* commit, const char* message, s
 - (NSString*)committerEmail {
   const git_signature* signature = git_commit_committer((git_commit*)_private);
   return [NSString stringWithUTF8String:signature->email];
+}
+
+// Reimplementation of git_commit_time()
+- (NSDate*)committerDate {
+  const git_signature* signature = git_commit_committer((git_commit*)_private);
+  return [NSDate dateWithTimeIntervalSince1970:signature->when.time];
 }
 
 - (NSString*)treeSHA1 {

--- a/GitUpKit/Views/GIQuickViewController.m
+++ b/GitUpKit/Views/GIQuickViewController.m
@@ -29,10 +29,11 @@
 @property(nonatomic, weak) IBOutlet NSView* infoView;
 @property(nonatomic, weak) IBOutlet NSScrollView* infoScrollView;
 @property(nonatomic, weak) IBOutlet NSTextField* sha1TextField;
-@property(nonatomic, weak) IBOutlet NSTextField* dateTextField;
 @property(nonatomic, weak) IBOutlet NSTextField* messageTextField;
 @property(nonatomic, weak) IBOutlet NSTextField* authorTextField;
+@property(nonatomic, weak) IBOutlet NSTextField* authorDateTextField;
 @property(nonatomic, weak) IBOutlet NSTextField* committerTextField;
+@property(nonatomic, weak) IBOutlet NSTextField* committerDateTextField;
 @property(nonatomic, weak) IBOutlet NSView* contentsView;
 @property(nonatomic, weak) IBOutlet NSView* filesView;
 @property(nonatomic, weak) IBOutlet NSBox* separatorBox;
@@ -121,9 +122,10 @@ static NSString* _CleanUpCommitMessage(NSString* message) {
       CGFloat delta = ceil(size.height) - _messageTextField.frame.size.height;
       _infoView.frame = NSMakeRect(0, 0, frame.size.width, frame.size.height + delta);
       
-      _sha1TextField.stringValue = _commit.shortSHA1;
+      _sha1TextField.stringValue = _commit.SHA1;
       
-      _dateTextField.stringValue = [NSString stringWithFormat:@"%@ (%@)", [_dateFormatter stringFromDate:_commit.date], GIFormatDateRelativelyFromNow(_commit.date, NO)];
+      _authorDateTextField.stringValue = [NSString stringWithFormat:@"%@ (%@)", [_dateFormatter stringFromDate:_commit.authorDate], GIFormatDateRelativelyFromNow(_commit.authorDate, NO)];
+      _committerDateTextField.stringValue = [NSString stringWithFormat:@"%@ (%@)", [_dateFormatter stringFromDate:_commit.committerDate], GIFormatDateRelativelyFromNow(_commit.committerDate, NO)];
       
       CGFloat authorFontSize = _authorTextField.font.pointSize;
       NSMutableAttributedString* author = [[NSMutableAttributedString alloc] init];
@@ -158,9 +160,10 @@ static NSString* _CleanUpCommitMessage(NSString* message) {
       [_diffFilesViewController setDeltas:_diff.deltas usingConflicts:nil];
     } else {
       _sha1TextField.stringValue = @"";
-      _dateTextField.stringValue = @"";
       _authorTextField.stringValue = @"";
+      _authorDateTextField.stringValue = @"";
       _committerTextField.stringValue = @"";
+      _committerDateTextField.stringValue = @"";
       _messageTextField.stringValue = @"";
       
       _diff = nil;

--- a/GitUpKit/Views/en.lproj/GIQuickViewController.xib
+++ b/GitUpKit/Views/en.lproj/GIQuickViewController.xib
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="GIQuickViewController">
             <connections>
+                <outlet property="authorDateTextField" destination="NMY-tY-Mrh" id="cJd-Hg-sbc"/>
                 <outlet property="authorTextField" destination="Men-K8-VwT" id="LJG-fX-aM1"/>
+                <outlet property="committerDateTextField" destination="p8J-vi-dDp" id="rnb-jG-CSk"/>
                 <outlet property="committerTextField" destination="5Yv-8b-x0c" id="RhJ-im-KYY"/>
                 <outlet property="contentsView" destination="gnd-mU-OFa" id="aua-gs-pD6"/>
-                <outlet property="dateTextField" destination="1k6-eF-els" id="BVt-4X-eK9"/>
                 <outlet property="filesView" destination="T7C-Lf-raW" id="mzB-kk-e11"/>
                 <outlet property="infoScrollView" destination="A0F-jI-s4n" id="bGh-0w-P8p"/>
                 <outlet property="infoView" destination="Bpc-ZA-3gm" id="hGF-hw-1ve"/>
@@ -49,15 +50,15 @@
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <view id="Bpc-ZA-3gm" customClass="GIFlippedView">
-                                                                <rect key="frame" x="0.0" y="0.0" width="300" height="100"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="300" height="130"/>
                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                 <subviews>
                                                                     <customView id="aKy-Bi-5hY">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="300" height="100"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="300" height="130"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="9bU-TV-AfR">
-                                                                                <rect key="frame" x="8" y="80" width="60" height="14"/>
+                                                                                <rect key="frame" x="8" y="110" width="278" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;SHA1&gt;" id="Tsu-dV-mjp">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -65,17 +66,8 @@
                                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                 </textFieldCell>
                                                                             </textField>
-                                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="1k6-eF-els">
-                                                                                <rect key="frame" x="72" y="80" width="218" height="14"/>
-                                                                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                                                                <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="&lt;DATE&gt;" id="iv2-j9-9i9">
-                                                                                    <font key="font" metaFont="smallSystem"/>
-                                                                                    <color key="textColor" white="0.25" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                </textFieldCell>
-                                                                            </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" id="CIg-ZV-lYt">
-                                                                                <rect key="frame" x="8" y="54" width="282" height="14"/>
+                                                                                <rect key="frame" x="8" y="84" width="282" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;MESSAGE&gt;" id="fqu-LQ-wKF">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -84,12 +76,12 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="LRK-cU-aip">
-                                                                                <rect key="frame" x="10" y="34" width="10" height="10"/>
+                                                                                <rect key="frame" x="10" y="57" width="10" height="10"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" image="icon_author" id="a14-H7-Quo"/>
                                                                             </imageView>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Men-K8-VwT">
-                                                                                <rect key="frame" x="21" y="32" width="269" height="14"/>
+                                                                                <rect key="frame" x="21" y="55" width="269" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" truncatesLastVisibleLine="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;AUTHOR&gt;" id="11W-Hl-yV0">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -97,15 +89,33 @@
                                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                 </textFieldCell>
                                                                             </textField>
+                                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="NMY-tY-Mrh">
+                                                                                <rect key="frame" x="21" y="41" width="269" height="14"/>
+                                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                                <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" truncatesLastVisibleLine="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;AUTHOR_DATE&gt;" id="ESf-oA-sr2">
+                                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                                    <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                </textFieldCell>
+                                                                            </textField>
                                                                             <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="WZG-3V-AFB">
-                                                                                <rect key="frame" x="10" y="12" width="10" height="10"/>
+                                                                                <rect key="frame" x="10" y="21" width="10" height="10"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" image="icon_committer" id="BIg-uL-lng"/>
                                                                             </imageView>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="5Yv-8b-x0c">
-                                                                                <rect key="frame" x="21" y="10" width="269" height="14"/>
+                                                                                <rect key="frame" x="21" y="19" width="269" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" truncatesLastVisibleLine="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;COMMITTER&gt;" id="4Tl-BB-pru">
+                                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                                    <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                </textFieldCell>
+                                                                            </textField>
+                                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="p8J-vi-dDp">
+                                                                                <rect key="frame" x="21" y="7" width="269" height="14"/>
+                                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                                <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" truncatesLastVisibleLine="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;COMMITTER_DATE&gt;" id="Dbg-2h-APW">
                                                                                     <font key="font" metaFont="smallSystem"/>
                                                                                     <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
Quick View should include all salient information on the current commit, and previously the author date was completely hidden everywhere in GitUp; this adds separate fields for both kinds of date and displays them simultaneously.

Additionally, as the previously-included date field is no longer required, it has been removed and the space used to show the complete SHA-1 hash of the commit rather than the shortened version.