### PR TITLE
Allow switching to Map/Commit/Stashes directly from Quick View

### DIFF
--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -1739,7 +1739,7 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
   }
   
   if (item.action == @selector(switchMode:)) {
-    if ([_windowMode isEqualToString:kWindowModeString_Map_QuickView] || [_windowMode isEqualToString:kWindowModeString_Map_Diff]
+    if ([_windowMode isEqualToString:kWindowModeString_Map_Diff]
         || [_windowMode isEqualToString:kWindowModeString_Map_Rewrite] || [_windowMode isEqualToString:kWindowModeString_Map_Config]) {
       return NO;
     }


### PR DESCRIPTION
Cmd+1/2/3 from Quick View previously did absolutely nothing - it'd be more convenient to be able to jump to the other main views instead, and this has been requested in the forum: http://forums.gitup.co/t/324

It might also be worth permitting Cmd+1/2/3 from the "quick diff" view you get with I in the Map. (I'm not sure it has a name?)