### PR TITLE
Polished branch titles

### DIFF
--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -956,12 +956,10 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   CGContextTranslateCTM(context, x, y);
   CGContextRotateCTM(context, 45.0 / 180.0 * M_PI);
   CGContextSetLineWidth(context, 0.5);
-  CGContextSetStrokeColorWithColor(context, color.CGColor);
   
   // Draw text
   CGFloat lastLineWidth = 0.0;
   CFArrayRef lines = CTFrameGetLines(frame);
-  CGMutablePathRef separatorsPath = CGPathCreateMutable();
   for (CFIndex i = 0, count = CFArrayGetCount(lines); i < count; ++i) {
     CTLineRef line = CFArrayGetValueAtIndex(lines, i);
     CGPoint origin;
@@ -978,9 +976,9 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
     CFRange stringRange = CTLineGetStringRange(line);
     if (stringRange.length == 1) {
       CGRect underlineRect = CGRectMake(origin.x - 1.0, origin.y - 1.0, lastLineWidth + 5.0, lineHeight - 3.0);
-      CGPathMoveToPoint(separatorsPath, NULL, underlineRect.origin.x, underlineRect.origin.y);
-      CGPathAddLineToPoint(separatorsPath, NULL, underlineRect.origin.x + underlineRect.size.height, underlineRect.origin.y + underlineRect.size.height);
-      CGPathAddLineToPoint(separatorsPath, NULL, underlineRect.origin.x + underlineRect.size.width, underlineRect.origin.y + underlineRect.size.height);
+      CGContextMoveToPoint(context, underlineRect.origin.x, underlineRect.origin.y);
+      CGContextAddLineToPoint(context, underlineRect.origin.x + underlineRect.size.height, underlineRect.origin.y + underlineRect.size.height);
+      CGContextAddLineToPoint(context, underlineRect.origin.x + underlineRect.size.width, underlineRect.origin.y + underlineRect.size.height);
       continue;
     }
     
@@ -998,8 +996,8 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
     lastLineWidth = MIN(lineWidth, kMaxBranchTitleWidth);
   }
   
-  // Draw connections between titles
-  CGContextAddPath(context, separatorsPath);
+  // Stroke was defined in the for loop before
+  CGContextSetStrokeColorWithColor(context, [color colorWithAlphaComponent:0.5].CGColor);
   CGContextStrokePath(context);
   
   // Reset context
@@ -1012,7 +1010,6 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   [boldRanges release];
   [darkRanges release];
   CGPathRelease(path);
-  CGPathRelease(separatorsPath);
   CFRelease(boldFont);
   CFRelease(ellipsisToken);
   CFRelease(ellipsis);

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -1041,7 +1041,7 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
 
 static void _DrawNodeLabels(CGContextRef context, CGFloat x, CGFloat y, GINode* node, NSDictionary* tagAttributes, NSDictionary* branchAttributes) {
   GCHistoryCommit* commit = node.commit;
-	
+  
   // Generate text
   NSMutableString* label = [[NSMutableString alloc] init];
   NSUInteger separator = NSNotFound;

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -927,14 +927,13 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   
   // Create a light string to show above the HEAD
   
-  NSFont* titleFont = (NSFont *)CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, 12.0, CFSTR("en-US"));
+  CTFontRef titleFont = CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, 12.0, CFSTR("en-US"));
   NSMutableParagraphStyle *style = [NSParagraphStyle defaultParagraphStyle].mutableCopy;
   style.lineHeightMultiple = 0.8;
-  NSDictionary* multilineTitleAttributes = @{ NSFontAttributeName: titleFont, NSForegroundColorAttributeName: color, NSParagraphStyleAttributeName: style };
+  NSDictionary* multilineTitleAttributes = @{ NSFontAttributeName: (id)titleFont, NSForegroundColorAttributeName: color, NSParagraphStyleAttributeName: style };
   NSMutableAttributedString* multilineAttributedTitle = [[NSMutableAttributedString alloc] initWithString:multilineTitle attributes:multilineTitleAttributes];
   [style release];
   [multilineTitle release];
-  [titleFont release];
   
   // Change font to bold on ranges collected before
   
@@ -1037,6 +1036,7 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   CGPathRelease(path);
   CFRelease(framesetter);
   CFRelease(string);
+  CFRelease(titleFont);
 }
 
 static void _DrawNodeLabels(CGContextRef context, CGFloat x, CGFloat y, GINode* node, NSDictionary* tagAttributes, NSDictionary* branchAttributes) {

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -982,6 +982,8 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
       CGContextMoveToPoint(context, underlineRect.origin.x, underlineRect.origin.y);
       CGContextAddLineToPoint(context, underlineRect.origin.x + underlineRect.size.height, underlineRect.origin.y + underlineRect.size.height);
       CGContextAddLineToPoint(context, underlineRect.origin.x + underlineRect.size.width, underlineRect.origin.y + underlineRect.size.height);
+      CGContextSetStrokeColorWithColor(context, [color colorWithAlphaComponent:0.5].CGColor);
+      CGContextStrokePath(context);
       continue;
     }
     
@@ -998,10 +1000,6 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
     // Remember last line width for the next separator below
     lastLineWidth = MIN(lineWidth, kMaxBranchTitleWidth);
   }
-  
-  // Stroke was defined in the for loop before
-  CGContextSetStrokeColorWithColor(context, [color colorWithAlphaComponent:0.5].CGColor);
-  CGContextStrokePath(context);
   
   // Reset context
   CGContextRestoreGState(context);

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -928,8 +928,11 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   // Create a light string to show above the HEAD
 
   NSFont* titleFont = (NSFont *)CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, 12.0, CFSTR("en-US"));
-  NSDictionary* multilineTitleAttributes = @{ NSFontAttributeName: titleFont, NSForegroundColorAttributeName: color };
+  NSMutableParagraphStyle *style = [NSParagraphStyle defaultParagraphStyle].mutableCopy;
+  style.lineHeightMultiple = 0.8;
+  NSDictionary* multilineTitleAttributes = @{ NSFontAttributeName: titleFont, NSForegroundColorAttributeName: color, NSParagraphStyleAttributeName: style };
   NSMutableAttributedString* multilineAttributedTitle = [[NSMutableAttributedString alloc] initWithString:multilineTitle attributes:multilineTitleAttributes];
+  [style release];
   [multilineTitle release];
   [titleFont release];
 

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -860,7 +860,7 @@ static void _DrawLine(GILine* line, CGContextRef context, CGFloat offset, CGFloa
   }
 }
 
-static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, GIBranch* branch, GIGraphOptions options) {
+static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor* color, GIBranch* branch, GIGraphOptions options) {
 
   // Build a long rich text from branches and tags
 
@@ -928,11 +928,9 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, GIBranc
   // Create a light string to show above the HEAD
 
   NSFont* titleFont = (NSFont *)CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, 12.0, CFSTR("en-US"));
-  NSColor* titleColor = [NSColor grayColor];
-  NSDictionary* multilineTitleAttributes = @{ NSFontAttributeName: titleFont, NSForegroundColorAttributeName: titleColor };
+  NSDictionary* multilineTitleAttributes = @{ NSFontAttributeName: titleFont, NSForegroundColorAttributeName: color };
   NSMutableAttributedString* multilineAttributedTitle = [[NSMutableAttributedString alloc] initWithString:multilineTitle attributes:multilineTitleAttributes];
   [multilineTitle release];
-  [titleColor release];
   [titleFont release];
 
   // Change font to bold on ranges collected before
@@ -946,11 +944,10 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, GIBranc
 
   // Change color to dark on ranges collected before
 
-  NSColor* darkColor = [NSColor blackColor];
+  NSColor* darkColor = [color shadowWithLevel:0.8];
   for (NSValue *dark in darkRanges) {
     [multilineAttributedTitle addAttribute:NSForegroundColorAttributeName value:darkColor range:dark.rangeValue];
   }
-  [darkColor release];
   [darkRanges release];
 
   // Create CoreFoundation string from Foundation
@@ -1597,7 +1594,7 @@ static void _DrawSelectedNode(CGContextRef context, CGFloat x, CGFloat y, GINode
       GINode* node = branch.tipNode;
       CGFloat x = CONVERT_X(node.x);
       CGFloat y = CONVERT_Y(offset - node.layer.y);
-      _DrawBranchTitle(context, x, y, branch, graphOptions);
+      _DrawBranchTitle(context, x, y, node.primaryLine.color, branch, graphOptions);
     }
   }
   

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -929,23 +929,18 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   style.lineHeightMultiple = 0.8;
   NSDictionary* multilineTitleAttributes = @{ NSFontAttributeName: (id)titleFont, NSForegroundColorAttributeName: color, NSParagraphStyleAttributeName: style };
   NSMutableAttributedString* multilineAttributedTitle = [[NSMutableAttributedString alloc] initWithString:multilineTitle attributes:multilineTitleAttributes];
-  [style release];
-  [multilineTitle release];
   
   // Change font to bold on ranges collected before
   NSFont* boldFont = (NSFont *)CTFontCreateUIFontForLanguage(kCTFontUIFontEmphasizedSystem, 12.0, CFSTR("en-US"));
   for (NSValue* bold in boldRanges) {
     [multilineAttributedTitle addAttribute:NSFontAttributeName value:boldFont range:bold.rangeValue];
   }
-  [boldFont release];
-  [boldRanges release];
   
   // Change color to dark on ranges collected before
   NSColor* darkColor = [color shadowWithLevel:0.8];
   for (NSValue* dark in darkRanges) {
     [multilineAttributedTitle addAttribute:NSForegroundColorAttributeName value:darkColor range:dark.rangeValue];
   }
-  [darkRanges release];
   
   // Create CoreFoundation string from Foundation
   CFAttributedStringRef string = (CFAttributedStringRef)multilineAttributedTitle.copy;
@@ -1016,6 +1011,11 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   CGContextRestoreGState(context);
   
   // Clean up
+  [style release];
+  [multilineTitle release];
+  [boldFont release];
+  [boldRanges release];
+  [darkRanges release];
   CFRelease(ellipsisToken);
   CFRelease(ellipsis);
   CFRelease(frame);

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -909,7 +909,7 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, GIBranc
   for (GCHistoryTag* tag in branch.tags) {
     NSString* tagName = tag.name;
     [multilineTitle appendFormat:@"[%@]\n", tagName];
-    NSRange tagNameRange = NSMakeRange(multilineTitle.length - tagName.length - 3, tagName.length);
+    NSRange tagNameRange = NSMakeRange(multilineTitle.length - tagName.length - 2, tagName.length);
     [boldRanges addObject:[NSValue valueWithRange:tagNameRange]];
     [darkRanges addObject:boldRanges.lastObject];
   }
@@ -935,12 +935,28 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, GIBranc
   [titleColor release];
   [titleFont release];
 
+  // Change font to bold on ranges collected before
+
+  NSFont* boldFont = (NSFont *)CTFontCreateUIFontForLanguage(kCTFontUIFontEmphasizedSystem, 12.0, CFSTR("en-US"));
+  for (NSValue *bold in boldRanges) {
+    [multilineAttributedTitle addAttribute:NSFontAttributeName value:boldFont range:bold.rangeValue];
+  }
+  [boldFont release];
+  [boldRanges release];
+
+  // Change color to dark on ranges collected before
+
+  NSColor* darkColor = [NSColor blackColor];
+  for (NSValue *dark in darkRanges) {
+    [multilineAttributedTitle addAttribute:NSForegroundColorAttributeName value:darkColor range:dark.rangeValue];
+  }
+  [darkColor release];
+  [darkRanges release];
+
   // Create CoreFoundation string from Foundation
 
   CFAttributedStringRef string = (CFAttributedStringRef)multilineAttributedTitle.copy;
   [multilineAttributedTitle release];
-  [boldRanges release];
-  [darkRanges release];
 
   // Prepare CoreText string from the rich attributed title
 
@@ -965,7 +981,7 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, GIBranc
   CGContextSetRGBFillColor(context, 1.0, 0.0, 0.0, 0.666);
   CGContextFillRect(context, labelRect);
 #endif
-  
+	
   // Draw text
   
   CGContextSetRGBFillColor(context, 0.0, 0.0, 0.0, 1.0);

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -878,10 +878,9 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
       
       NSString* remoteName = remoteBranch.remoteName;
       [multilineTitle appendFormat:@"%@/%@\n", remoteName, branchName];
-      branchNameRange = NSMakeRange(multilineTitle.length - branchName.length - 1, branchName.length);
+      branchNameRange = NSMakeRange(multilineTitle.length - branchName.length - 1, branchName.length); // -1 to exclude '\n'
       [darkRanges addObject:[NSValue valueWithRange:branchNameRange]];
-    }
-    else {
+    } else {
       NSString* branchName = localBranch.name;
       NSRange branchNameRange = NSMakeRange(multilineTitle.length, branchName.length);
       [multilineTitle appendFormat:@"%@\n", branchName];
@@ -896,7 +895,7 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
     NSString* remoteName = remoteBranch.remoteName;
     NSString* branchName = remoteBranch.branchName;
     [multilineTitle appendFormat:@"%@/%@\n", remoteName, branchName];
-    NSRange branchNameRange = NSMakeRange(multilineTitle.length - branchName.length - 1, branchName.length);
+    NSRange branchNameRange = NSMakeRange(multilineTitle.length - branchName.length - 1, branchName.length); // -1 to exclude '\n'
     [boldRanges addObject:[NSValue valueWithRange:branchNameRange]];
     [darkRanges addObject:boldRanges.lastObject];
   }
@@ -908,7 +907,7 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   for (GCHistoryTag* tag in branch.tags) {
     NSString* tagName = tag.name;
     [multilineTitle appendFormat:@"[%@]\n", tagName];
-    NSRange tagNameRange = NSMakeRange(multilineTitle.length - tagName.length - 2, tagName.length);
+    NSRange tagNameRange = NSMakeRange(multilineTitle.length - tagName.length - 2, tagName.length); // -2 to exclude char ']' plus '\n'
     [boldRanges addObject:[NSValue valueWithRange:tagNameRange]];
     [darkRanges addObject:boldRanges.lastObject];
   }
@@ -926,7 +925,7 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   
   // Create a light string to show above the HEAD
   CTFontRef titleFont = CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, 12.0, CFSTR("en-US"));
-  NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
+  NSMutableParagraphStyle* style = [[NSMutableParagraphStyle alloc] init];
   style.lineHeightMultiple = 0.8;
   NSDictionary* multilineTitleAttributes = @{ NSFontAttributeName: (id)titleFont, NSForegroundColorAttributeName: color, NSParagraphStyleAttributeName: style };
   NSMutableAttributedString* multilineAttributedTitle = [[NSMutableAttributedString alloc] initWithString:multilineTitle attributes:multilineTitleAttributes];

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -940,7 +940,7 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   CFRelease(boldFont);
   
   // Change color to dark on ranges collected before
-  NSColor* darkColor = [color shadowWithLevel:0.8];
+  NSColor* darkColor = [color shadowWithLevel:0.7];
   for (NSValue* dark in darkRanges) {
     [multilineAttributedTitle addAttribute:NSForegroundColorAttributeName value:darkColor range:dark.rangeValue];
   }

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -962,8 +962,8 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   CGRect textRect = CGRectMake(kTitleOffsetX, kTitleOffsetY, ceil(size.width), ceil(size.height));
   CGPathRef path = CGPathCreateWithRect(textRect, NULL);
   CTFrameRef frame = CTFramesetterCreateFrame(framesetter, CFRangeMake(0, CFAttributedStringGetLength(string)), path, NULL);
-  CFAttributedStringRef character = CFAttributedStringCreate(kCFAllocatorDefault, CFSTR("\u2026"), (CFDictionaryRef)multilineTitleAttributes);
-  CTLineRef token = CTLineCreateWithAttributedString(character);
+  CFAttributedStringRef ellipsis = CFAttributedStringCreate(kCFAllocatorDefault, CFSTR("\u2026"), (CFDictionaryRef)multilineTitleAttributes);
+  CTLineRef ellipsisToken = CTLineCreateWithAttributedString(ellipsis);
 
   // Prepare context
   
@@ -991,7 +991,7 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
     if (size.width <= kMaxBranchTitleWidth) {
       CTLineDraw(line, context);
     } else {
-      CTLineRef drawLine = CTLineCreateTruncatedLine(line, kMaxBranchTitleWidth, kCTLineTruncationEnd, token);
+      CTLineRef drawLine = CTLineCreateTruncatedLine(line, kMaxBranchTitleWidth, kCTLineTruncationEnd, ellipsisToken);
       CTLineDraw(drawLine, context);
       CFRelease(drawLine);
     }
@@ -1003,8 +1003,8 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   
   // Clean up
   
-  CFRelease(token);
-  CFRelease(character);
+  CFRelease(ellipsisToken);
+  CFRelease(ellipsis);
   CFRelease(frame);
   CGPathRelease(path);
   CFRelease(framesetter);

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -863,7 +863,6 @@ static void _DrawLine(GILine* line, CGContextRef context, CGFloat offset, CGFloa
 static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor* color, GIBranch* branch, GIGraphOptions options) {
   
   // Build a long rich text from branches and tags
-  
   NSMutableString* multilineTitle = [[NSMutableString alloc] init]; // Multiline string above the HEAD
   NSMutableArray* boldRanges = [[NSMutableArray alloc] init];       // Ranges to be drawn using bold font
   NSMutableArray* darkRanges = [[NSMutableArray alloc] init];       // Ranges to draw with darker color
@@ -926,7 +925,6 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   }
   
   // Create a light string to show above the HEAD
-  
   CTFontRef titleFont = CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, 12.0, CFSTR("en-US"));
   NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
   style.lineHeightMultiple = 0.8;
@@ -936,7 +934,6 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   [multilineTitle release];
   
   // Change font to bold on ranges collected before
-  
   NSFont* boldFont = (NSFont *)CTFontCreateUIFontForLanguage(kCTFontUIFontEmphasizedSystem, 12.0, CFSTR("en-US"));
   for (NSValue* bold in boldRanges) {
     [multilineAttributedTitle addAttribute:NSFontAttributeName value:boldFont range:bold.rangeValue];
@@ -945,7 +942,6 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   [boldRanges release];
   
   // Change color to dark on ranges collected before
-  
   NSColor* darkColor = [color shadowWithLevel:0.8];
   for (NSValue* dark in darkRanges) {
     [multilineAttributedTitle addAttribute:NSForegroundColorAttributeName value:darkColor range:dark.rangeValue];
@@ -953,12 +949,10 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   [darkRanges release];
   
   // Create CoreFoundation string from Foundation
-  
   CFAttributedStringRef string = (CFAttributedStringRef)multilineAttributedTitle.copy;
   [multilineAttributedTitle release];
   
   // Prepare CoreText string from the rich attributed title
-  
   CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString(string);
   CGSize size = CTFramesetterSuggestFrameSizeWithConstraints(framesetter, CFRangeMake(0, CFAttributedStringGetLength(string)), NULL, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX), NULL);
   CGRect textRect = CGRectMake(kTitleOffsetX, kTitleOffsetY, ceil(size.width), ceil(size.height));
@@ -968,13 +962,11 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   CTLineRef ellipsisToken = CTLineCreateWithAttributedString(ellipsis);
   
   // Prepare context
-  
   CGContextSaveGState(context);
   CGContextTranslateCTM(context, x, y);
   CGContextRotateCTM(context, 45.0 / 180.0 * M_PI);
   
   // Draw text
-  
   CGFloat lastLineWidth = 0.0;
   CFArrayRef lines = CTFrameGetLines(frame);
   for (CFIndex i = 0, count = CFArrayGetCount(lines); i < count; ++i) {
@@ -990,7 +982,6 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
     CGFloat lineHeight = ascent;
     
     // Draw separator in case of new line which is guaranteed by the building algorithm
-    
     CFRange stringRange = CTLineGetStringRange(line);
     if (stringRange.length == 1) {
       CGRect underlineRect = CGRectMake(origin.x - 1.0, origin.y - 1.0, lastLineWidth + 5.0, lineHeight - 3.0);
@@ -1009,7 +1000,6 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
     }
     
     // Draw line with ellipsis in the end if needed
-    
     CGContextSetTextPosition(context, origin.x, origin.y);
     if (lineWidth <= kMaxBranchTitleWidth) {
       CTLineDraw(line, context);
@@ -1020,16 +1010,13 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
     }
     
     // Remember last line width for the next separator below
-    
     lastLineWidth = MIN(lineWidth, kMaxBranchTitleWidth);
   }
   
   // Reset context
-  
   CGContextRestoreGState(context);
   
   // Clean up
-  
   CFRelease(ellipsisToken);
   CFRelease(ellipsis);
   CFRelease(frame);

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -928,7 +928,7 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   // Create a light string to show above the HEAD
   
   CTFontRef titleFont = CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, 12.0, CFSTR("en-US"));
-  NSMutableParagraphStyle *style = [NSParagraphStyle defaultParagraphStyle].mutableCopy;
+  NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
   style.lineHeightMultiple = 0.8;
   NSDictionary* multilineTitleAttributes = @{ NSFontAttributeName: (id)titleFont, NSForegroundColorAttributeName: color, NSParagraphStyleAttributeName: style };
   NSMutableAttributedString* multilineAttributedTitle = [[NSMutableAttributedString alloc] initWithString:multilineTitle attributes:multilineTitleAttributes];

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -944,7 +944,6 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   
   // Create CoreFoundation string from Foundation
   CFAttributedStringRef string = (CFAttributedStringRef)multilineAttributedTitle.copy;
-  [multilineAttributedTitle release];
   
   // Prepare CoreText string from the rich attributed title
   CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString(string);
@@ -1011,6 +1010,7 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   CGContextRestoreGState(context);
   
   // Clean up
+  [multilineAttributedTitle release];
   [style release];
   [multilineTitle release];
   [boldRanges release];

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -942,15 +942,12 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
     [multilineAttributedTitle addAttribute:NSForegroundColorAttributeName value:darkColor range:dark.rangeValue];
   }
   
-  // Create CoreFoundation string from Foundation
-  CFAttributedStringRef string = (CFAttributedStringRef)multilineAttributedTitle.copy;
-  
   // Prepare CoreText string from the rich attributed title
-  CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString(string);
-  CGSize size = CTFramesetterSuggestFrameSizeWithConstraints(framesetter, CFRangeMake(0, CFAttributedStringGetLength(string)), NULL, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX), NULL);
+  CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString((CFAttributedStringRef)multilineAttributedTitle);
+  CGSize size = CTFramesetterSuggestFrameSizeWithConstraints(framesetter, CFRangeMake(0, multilineAttributedTitle.length), NULL, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX), NULL);
   CGRect textRect = CGRectMake(kTitleOffsetX, kTitleOffsetY, ceil(size.width), ceil(size.height));
   CGPathRef path = CGPathCreateWithRect(textRect, NULL);
-  CTFrameRef frame = CTFramesetterCreateFrame(framesetter, CFRangeMake(0, CFAttributedStringGetLength(string)), path, NULL);
+  CTFrameRef frame = CTFramesetterCreateFrame(framesetter, CFRangeMake(0, multilineAttributedTitle.length), path, NULL);
   CFAttributedStringRef ellipsis = CFAttributedStringCreate(kCFAllocatorDefault, CFSTR("\u2026"), (CFDictionaryRef)multilineTitleAttributes);
   CTLineRef ellipsisToken = CTLineCreateWithAttributedString(ellipsis);
   
@@ -1021,7 +1018,6 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   CFRelease(ellipsis);
   CFRelease(frame);
   CFRelease(framesetter);
-  CFRelease(string);
   CFRelease(titleFont);
 }
 

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -982,8 +982,8 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
     CGPoint origin;
     CTFrameGetLineOrigins(frame, CFRangeMake(i, 1), &origin);
     
-    origin.x += CGRectGetMinX(textRect) + origin.y;
-    origin.y += CGRectGetMinY(textRect);
+    origin.x += textRect.origin.x + origin.y;
+    origin.y += textRect.origin.y;
     
     CGFloat ascent, descent, leading;
     CGFloat lineWidth = CTLineGetTypographicBounds(line, &ascent, &descent, &leading);
@@ -995,9 +995,9 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
     if (stringRange.length == 1) {
       CGRect underlineRect = CGRectMake(origin.x - 1.0, origin.y - 1.0, lastLineWidth + 5.0, lineHeight - 3.0);
       CGMutablePathRef separatorPath = CGPathCreateMutable();
-      CGPathMoveToPoint(separatorPath, NULL, CGRectGetMinX(underlineRect), CGRectGetMinY(underlineRect));
-      CGPathAddLineToPoint(separatorPath, NULL, CGRectGetMinX(underlineRect) + CGRectGetHeight(underlineRect), CGRectGetMaxY(underlineRect));
-      CGPathAddLineToPoint(separatorPath, NULL, CGRectGetMaxX(underlineRect), CGRectGetMaxY(underlineRect));
+      CGPathMoveToPoint(separatorPath, NULL, underlineRect.origin.x, underlineRect.origin.y);
+      CGPathAddLineToPoint(separatorPath, NULL, underlineRect.origin.x + underlineRect.size.height, underlineRect.origin.y + underlineRect.size.height);
+      CGPathAddLineToPoint(separatorPath, NULL, underlineRect.origin.x + underlineRect.size.width, underlineRect.origin.y + underlineRect.size.height);
       CGContextSetLineWidth(context, 0.5);
       CGContextSetStrokeColorWithColor(context, color.CGColor);
       CGContextSaveGState(context);

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -930,6 +930,7 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   NSDictionary* multilineTitleAttributes = @{ NSFontAttributeName: (id)titleFont, NSForegroundColorAttributeName: color, NSParagraphStyleAttributeName: style };
   NSMutableAttributedString* multilineAttributedTitle = [[NSMutableAttributedString alloc] initWithString:multilineTitle attributes:multilineTitleAttributes];
   CFRelease(titleFont);
+  [style release];
   
   // Change font to bold on ranges collected before
   CTFontRef boldFont = CTFontCreateUIFontForLanguage(kCTFontUIFontEmphasizedSystem, 12.0, CFSTR("en-US"));
@@ -1007,7 +1008,6 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   
   // Clean up
   [multilineAttributedTitle release];
-  [style release];
   [multilineTitle release];
   [boldRanges release];
   [darkRanges release];

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -929,12 +929,14 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   style.lineHeightMultiple = 0.8;
   NSDictionary* multilineTitleAttributes = @{ NSFontAttributeName: (id)titleFont, NSForegroundColorAttributeName: color, NSParagraphStyleAttributeName: style };
   NSMutableAttributedString* multilineAttributedTitle = [[NSMutableAttributedString alloc] initWithString:multilineTitle attributes:multilineTitleAttributes];
+  CFRelease(titleFont);
   
   // Change font to bold on ranges collected before
   CTFontRef boldFont = CTFontCreateUIFontForLanguage(kCTFontUIFontEmphasizedSystem, 12.0, CFSTR("en-US"));
   for (NSValue* bold in boldRanges) {
     [multilineAttributedTitle addAttribute:NSFontAttributeName value:(id)boldFont range:bold.rangeValue];
   }
+  CFRelease(boldFont);
   
   // Change color to dark on ranges collected before
   NSColor* darkColor = [color shadowWithLevel:0.8];
@@ -1010,12 +1012,10 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   [boldRanges release];
   [darkRanges release];
   CGPathRelease(path);
-  CFRelease(boldFont);
   CFRelease(ellipsisToken);
   CFRelease(ellipsis);
   CFRelease(frame);
   CFRelease(framesetter);
-  CFRelease(titleFont);
 }
 
 static void _DrawNodeLabels(CGContextRef context, CGFloat x, CGFloat y, GINode* node, NSDictionary* tagAttributes, NSDictionary* branchAttributes) {

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -931,9 +931,9 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   NSMutableAttributedString* multilineAttributedTitle = [[NSMutableAttributedString alloc] initWithString:multilineTitle attributes:multilineTitleAttributes];
   
   // Change font to bold on ranges collected before
-  NSFont* boldFont = (NSFont *)CTFontCreateUIFontForLanguage(kCTFontUIFontEmphasizedSystem, 12.0, CFSTR("en-US"));
+  CTFontRef boldFont = CTFontCreateUIFontForLanguage(kCTFontUIFontEmphasizedSystem, 12.0, CFSTR("en-US"));
   for (NSValue* bold in boldRanges) {
-    [multilineAttributedTitle addAttribute:NSFontAttributeName value:boldFont range:bold.rangeValue];
+    [multilineAttributedTitle addAttribute:NSFontAttributeName value:(id)boldFont range:bold.rangeValue];
   }
   
   // Change color to dark on ranges collected before
@@ -1013,13 +1013,13 @@ static void _DrawBranchTitle(CGContextRef context, CGFloat x, CGFloat y, NSColor
   // Clean up
   [style release];
   [multilineTitle release];
-  [boldFont release];
   [boldRanges release];
   [darkRanges release];
+  CGPathRelease(path);
+  CFRelease(boldFont);
   CFRelease(ellipsisToken);
   CFRelease(ellipsis);
   CFRelease(frame);
-  CGPathRelease(path);
   CFRelease(framesetter);
   CFRelease(string);
   CFRelease(titleFont);


### PR DESCRIPTION
Hello Pierre-Olivier, I had lived in GitUp for months already and found that branch titles representation does not provide enough information in some cases. After working with one of our quite big projects I came up with a small, but hopefully useful design tweaks for those labels. I think this change will improve usability without damaging the information architecture of the graph view. Please check it out and let me know what you think. Thanks in advance!

*UPD: This is how it would look now…*
<img width="334" alt="polished branch titles" src="https://cloud.githubusercontent.com/assets/163410/11325579/6ef960a2-9162-11e5-944a-8caa9b984df2.png">