### PR TITLE
Safer remote operations

### DIFF
--- a/GitUp/Application/en.lproj/MainMenu.xib
+++ b/GitUp/Application/en.lproj/MainMenu.xib
@@ -163,7 +163,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             <rect key="frame" x="139" y="216" width="299" height="58"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            <size key="cellSize" width="299" height="18"/>
+                                            <size key="cellSize" width="276" height="18"/>
                                             <size key="intercellSpacing" width="4" height="2"/>
                                             <buttonCell key="prototype" type="radio" title="Radio" imagePosition="left" alignment="left" inset="2" id="S4o-dE-O99">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -252,13 +252,13 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                     </subviews>
                                 </view>
                             </tabViewItem>
-                            <tabViewItem label="{500, 206}" identifier="advanced" id="Qdl-lQ-O4q">
+                            <tabViewItem label="{500, 265}" identifier="advanced" id="Qdl-lQ-O4q">
                                 <view key="view" id="8CG-H0-Xhk">
                                     <rect key="frame" x="0.0" y="0.0" width="500" height="400"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <popUpButton verticalHuggingPriority="750" id="7N4-S9-iWL">
-                                            <rect key="frame" x="136" y="248" width="200" height="26"/>
+                                            <rect key="frame" x="136" y="189" width="200" height="26"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <popUpButtonCell key="cell" type="push" title="&lt;RELEASE CHANNEL&gt;" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" autoenablesItems="NO" selectedItem="xdx-IX-FK6" id="Sdr-Ep-kPW">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -276,7 +276,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </connections>
                                         </popUpButton>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="mi3-Eg-51i">
-                                            <rect key="frame" x="12" y="254" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="195" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Release Channel:" id="M0A-b6-dhN">
                                                 <font key="font" metaFont="system"/>
@@ -294,7 +294,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="PtA-hG-Qmn">
-                                            <rect key="frame" x="137" y="210" width="345" height="34"/>
+                                            <rect key="frame" x="137" y="151" width="345" height="34"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="The &quot;Continuous&quot; release channel installs builds directly from GitUp Continuous Integration. Use at your own risks!" id="qB2-E4-Yuu">
                                                 <font key="font" metaFont="smallSystem"/>
@@ -303,7 +303,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="w2N-io-xkS">
-                                            <rect key="frame" x="137" y="295" width="130" height="17"/>
+                                            <rect key="frame" x="137" y="236" width="130" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Automatically check" id="X1v-BK-dAQ">
                                                 <font key="font" metaFont="system"/>
@@ -312,7 +312,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <popUpButton verticalHuggingPriority="750" id="ZYX-Yt-1fl">
-                                            <rect key="frame" x="271" y="289" width="145" height="26"/>
+                                            <rect key="frame" x="271" y="230" width="145" height="26"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <popUpButtonCell key="cell" type="push" title="Never" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" autoenablesItems="NO" altersStateOfSelectedItem="NO" selectedItem="KgR-3b-gT5" id="Pdg-S3-YXJ">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -408,6 +408,26 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                                 </binding>
                                             </connections>
                                         </popUpButton>
+                                        <button id="Xxa-CO-ELY">
+                                            <rect key="frame" x="136" y="294" width="346" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Allow quick confirmation of dangerous operations" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="uJq-iS-sPr">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <binding destination="AR1-cq-KNa" name="value" keyPath="values.GIMapViewController_AllowReturnKeyForDangerousRemoteOperations" id="c8T-9g-4KN"/>
+                                            </connections>
+                                        </button>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="Ad9-ef-Jqv">
+                                            <rect key="frame" x="137" y="262" width="345" height="28"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="This allows dangerous operations on remotes, like force push, to be confirmed by pressing the Return key in dialogs." id="LQY-Xb-bQ5">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                     </subviews>
                                 </view>
                             </tabViewItem>

--- a/GitUp/GitUp.xcodeproj/project.pbxproj
+++ b/GitUp/GitUp.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 			indentWidth = 2;
 			sourceTree = "<group>";
 			tabWidth = 2;
+			usesTabs = 0;
 		};
 		E2C338AC19F8562F00063D95 /* Products */ = {
 			isa = PBXGroup;

--- a/GitUpKit/Utilities/GIAppKit.h
+++ b/GitUpKit/Utilities/GIAppKit.h
@@ -18,7 +18,8 @@
 typedef NS_ENUM(NSUInteger, GIAlertType) {
   kGIAlertType_Note = 0,
   kGIAlertType_Caution,
-  kGIAlertType_Stop
+  kGIAlertType_Stop,
+  kGIAlertType_Danger
 };
 
 extern NSString* const GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters;

--- a/GitUpKit/Utilities/GIAppKit.m
+++ b/GitUpKit/Utilities/GIAppKit.m
@@ -69,7 +69,7 @@ static NSColor* _separatorColor = nil;
   switch (type) {
     case kGIAlertType_Note: self.icon = [[NSBundle bundleForClass:[GILayoutManager class]] imageForResource:@"icon_alert_note"]; break;  // TODO: Image is not cached
     case kGIAlertType_Caution: self.icon = [[NSBundle bundleForClass:[GILayoutManager class]] imageForResource:@"icon_alert_caution"]; break;  // TODO: Image is not cached
-    case kGIAlertType_Stop: self.icon = [[NSBundle bundleForClass:[GILayoutManager class]] imageForResource:@"icon_alert_stop"]; break;  // TODO: Image is not cached
+    case kGIAlertType_Stop: case kGIAlertType_Danger: self.icon = [[NSBundle bundleForClass:[GILayoutManager class]] imageForResource:@"icon_alert_stop"]; break;  // TODO: Image is not cached
   }
 }
 

--- a/GitUpKit/Utilities/GIViewController.m
+++ b/GitUpKit/Utilities/GIViewController.m
@@ -265,7 +265,10 @@
     alert.messageText = title;
     alert.informativeText = message;
     alert.showsSuppressionButton = key ? YES : NO;
-    [alert addButtonWithTitle:button];
+    NSButton* defaultButton = [alert addButtonWithTitle:button];
+    if (type == kGIAlertType_Danger) {
+      defaultButton.keyEquivalent = @"";
+    }
     [alert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
     [self presentAlert:alert completionHandler:^(NSModalResponse returnCode) {
       


### PR DESCRIPTION
I find it too easy to accidentally break remote (force push, delete branches etc.). This PR adds small tweak for such alerts so that confirm button is not marked as default. Instead user needs to either use mouse or tab+space to confirm, so gets more time to make sure that's what they want. This is off by default, so existing users are not affected, needs to be explicitly enabled.

Changes:

- Added `kGIAlertType_Danger` type which is used for potential data loss changes (mainly remote).
- Added `GIViewControllerUserDefaultKey_SaferRemoteConfirmations` user default which enables/disabled this behavior (default = false).
- Added preferences UI in advanced settings that changes above user default.

As far as UI change goes, it's convenient but can remain hidden preference with no UI as far as I'm concerned, set by handling `defaults` in Terminal - it's not something that will be tweaked daily. That's why I split PR into 2 commits; if UI change is not desired, I can remove last one, but having an option for preventing too easy data loss on remote is something I find crucial...

The reasoning behind this is: all GitUp alerts are confirmable simply by pressing enter. While all dangerous operations are guarded behind additional alert and use stop icon to differentiate, the behavior is still the same - just press enter to confirm. This behavior makes GitUp different from git command line - all "force" operations need to be explicitly invoked by user (by adding `--force` flag for example). Thus it's too easy to accidentally hit enter as a matter of habit when alert appears. This is additionally dangerous when user is expecting there will be 2 alerts, but there's only one. For example delete remote branch when there's no local counterpart - GitUp shows local and remote branches together at the top of the view, using the same font and color, the only difference is presence of slash symbol for remotes, and it's not as pronounced in angled as it would be in horizontal text (I find this aspect better with https://github.com/git-up/GitUp/pull/23).