### PR TITLE
Add 30% horizontal space between branch lines

### DIFF
--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -30,7 +30,7 @@
 #define __DEBUG_DESCENDANTS__ 0
 #define __DEBUG_ANCESTORS__ 0
 
-#define kSpacingX 30
+#define kSpacingX 40
 #define kSpacingY 30
 
 #define kMainLineWidth 8


### PR DESCRIPTION
New format for branch titles is more compact, so adding some horizontal space does not affect layout too much, but makes it look cleaner.