### PR TITLE
Added support for Vim keystrokes while navigating commits.

### DIFF
--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -529,6 +529,42 @@ static const void* _associatedObjectDataKey = &_associatedObjectDataKey;
       return;
     
   }
+  
+  // Vim keystroke support
+  NSString* characters = event.charactersIgnoringModifiers;
+  if ([characters isEqualToString:@"h"]) {
+    if (_selectedNode) {
+      [self _selectPreviousSiblingNode];
+    } else {
+      [self _selectDefaultNode];
+    }
+    return;
+  }
+  else if ([characters isEqualToString:@"j"]) {
+    if (_selectedNode) {
+      [self _selectParentNode];
+    } else {
+      [self _selectDefaultNode];
+    }
+    return;
+  }
+  else if ([characters isEqualToString:@"k"]) {
+    if (_selectedNode) {
+      [self _selectChildNode];
+    } else {
+      [self _selectDefaultNode];
+    }
+    return;
+  }
+  else if ([characters isEqualToString:@"l"]) {
+    if (_selectedNode) {
+      [self _selectNextSiblingNode];
+    } else {
+      [self _selectDefaultNode];
+    }
+    return;
+  }
+  
   [self.nextResponder tryToPerform:@selector(keyDown:) with:event];
 }
 


### PR DESCRIPTION
Usual keystrokes, nothing fancy: "h" to go left, "j" to go up, "k" to go down and "l" to go right.