### PR TITLE
Always show welcome when clicking on dock icon

### DIFF
--- a/GitUp/Application/AppDelegate.m
+++ b/GitUp/Application/AppDelegate.m
@@ -391,6 +391,14 @@
   return NO;
 }
 
+- (BOOL)applicationShouldHandleReopen:(NSApplication*)theApplication hasVisibleWindows:(BOOL)hasVisibleWindows {
+  if (!hasVisibleWindows) {
+    _allowWelcome = 1; // Always show welcome when clicking on dock icon
+    [self handleDocumentCountChanged];
+  }
+  return YES;
+}
+
 - (void)applicationDidBecomeActive:(NSNotification*)notification {
   if (_allowWelcome < 0) {
     _allowWelcome = 1;


### PR DESCRIPTION
Before this change, if the (x) button was clicked to close the welcome
window, then clicking on the app icon in the dock did nothing and there
was no way to show the welcome window again. Now, clicking on the dock
icon will show the welcome window if there are no other visible windows.

This is how Xcode behaves, which seems like a good standard to emulate
and something many GitUp users would expect.