### PR TITLE
Allow ⌘-W to close welcome window via NSWindow subclass

### DIFF
--- a/GitUp/Application/AppDelegate.m
+++ b/GitUp/Application/AppDelegate.m
@@ -41,6 +41,7 @@
 @end
 
 @interface AppDelegate () <NSUserNotificationCenterDelegate, CrashlyticsDelegate, SUUpdaterDelegate>
+- (IBAction)closeWelcomeWindow:(id)sender;
 @end
 
 @implementation WelcomeView
@@ -54,6 +55,25 @@
   CGContextSetRGBFillColor(context, 0.9, 0.9, 0.9, 1.0);
   GICGContextAddRoundedRect(context, bounds, kWelcomeWindowCornerRadius);
   CGContextFillPath(context);
+}
+
+@end
+
+@interface WelcomeWindow : NSWindow
+@end
+
+@implementation WelcomeWindow
+
+- (BOOL)validateMenuItem:(NSMenuItem*)menuItem {
+  return menuItem.action == @selector(performClose:) ? YES : [super validateMenuItem:menuItem];
+}
+
+- (void)performClose:(id)sender {
+  [[AppDelegate sharedDelegate] closeWelcomeWindow:sender];
+}
+
+- (BOOL)canBecomeKeyWindow {
+  return YES;
 }
 
 @end

--- a/GitUp/Application/en.lproj/MainMenu.xib
+++ b/GitUp/Application/en.lproj/MainMenu.xib
@@ -1100,7 +1100,7 @@ UI design by Wayne Fan</string>
             </view>
             <point key="canvasLocation" x="114" y="441.5"/>
         </window>
-        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="mjY-As-hbN" userLabel="Welcome">
+        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="mjY-As-hbN" userLabel="Welcome" customClass="WelcomeWindow">
             <rect key="contentRect" x="131" y="158" width="280" height="349"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" id="36m-6r-JT2" customClass="WelcomeView">


### PR DESCRIPTION
This enables both the File -> Close menu item and the ⌘-W keyboard
shortcut to close the welcome window. Windows without a titlebar close
button don't get this behavior for free, but since we have a button that
closes the window, it makes sense to add it.

Inspired by #73 to make the welcome window behave more like Xcode's

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT