### PR TITLE
Add "Show in Finder…" menu item for files and submodules

### DIFF
--- a/GitUpKit/Utilities/GIViewController+Utilities.h
+++ b/GitUpKit/Utilities/GIViewController+Utilities.h
@@ -54,6 +54,7 @@ extern NSString* const GIViewController_MergeTool;
 
 - (void)restoreFile:(NSString*)path toCommit:(GCCommit*)commit;  // Prompts user
 
+- (void)showFileInFinder:(NSString*)path;
 - (void)openFileWithDefaultEditor:(NSString*)path;
 - (void)openSubmoduleWithApp:(NSString*)path;
 - (void)viewDeltasInDiffTool:(NSArray*)deltas;

--- a/GitUpKit/Utilities/GIViewController+Utilities.m
+++ b/GitUpKit/Utilities/GIViewController+Utilities.m
@@ -301,6 +301,10 @@ static NSString* _diffTemporaryDirectoryPath = nil;
   [[NSWorkspace sharedWorkspace] openFile:[self.repository absolutePathForFile:path]];  // This will silently fail if the file doesn't exist in the working directory
 }
 
+- (void)showFileInFinder:(NSString*)path {
+  [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:@[[NSURL fileURLWithPath:[self.repository absolutePathForFile:path]]]];
+}
+
 - (void)openSubmoduleWithApp:(NSString*)path {
   NSError* error;
   GCSubmodule* submodule = [self.repository lookupSubmoduleWithName:path error:&error];
@@ -697,6 +701,10 @@ static NSString* _diffTemporaryDirectoryPath = nil;
         [self openFileWithDefaultEditor:delta.canonicalPath];
       }];
     }
+    
+    [menu addItemWithTitle:NSLocalizedString(@"Show in Finder…", nil) block:^{
+      [self showFileInFinder:delta.canonicalPath];
+    }];
   }
   
   return menu;


### PR DESCRIPTION
The option shows up when you tap on the gear on a modified file or submodule. Clicking it will show the file or submodule in the Finder.
<img src="https://cloud.githubusercontent.com/assets/4634735/13834731/b91cb782-ebc7-11e5-9ad1-5c10ee4a40af.png" width=400>

I find it useful to have easy access to files in the Finder when I have to, for instance, delete the files or replace them by another. What I usually did was open the file, then open the containing folder by right clicking on the title bar in the application, if available.

> I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT