### PR TITLE
Keep table position when dropping a stash

### DIFF
--- a/GitUpKit/Views/GIStashListViewController.m
+++ b/GitUpKit/Views/GIStashListViewController.m
@@ -307,6 +307,9 @@
       [self.undoManager setActionName:NSLocalizedString(@"Drop Stash", nil)];
       [[self.undoManager prepareWithInvocationTarget:self] _undoDropStashWithPreviousState:currentState ignore:NO];  // TODO: We should really use the built-in undo mechanism from GCLiveRepository
       [self.repository notifyRepositoryChanged];
+      if (row > 0) {
+        [_tableView selectRowIndexes:[NSIndexSet indexSetWithIndex:(row - 1)] byExtendingSelection:NO];
+      }
     } else {
       [self presentError:error];
     }


### PR DESCRIPTION
For example, when you select the last row and then delete it, your selection goes all the way to the top of the table. This change means that if you select the last row and delete it, it will go to the row next up from the bottom.