### PR TITLE
Resolve name conflicts caused by symlinks while moving items to trash

### DIFF
--- a/GitUp/Application/AppDelegate.m
+++ b/GitUp/Application/AppDelegate.m
@@ -562,7 +562,7 @@ static CFDataRef _MessagePortCallBack(CFMessagePortRef local, SInt32 msgid, CFDa
   if ([savePanel runModal] == NSFileHandlingPanelOKButton) {
     NSString* path = savePanel.URL.path;
     NSError* error;
-    if (![[NSFileManager defaultManager] fileExistsAtPath:path] || [[NSFileManager defaultManager] moveItemAtPathToTrash:path error:&error]) {
+    if (![[NSFileManager defaultManager] fileExistsAtPath:path followLastSymlink:NO] || [[NSFileManager defaultManager] moveItemAtPathToTrash:path error:&error]) {
       GCRepository* repository = [[GCRepository alloc] initWithNewLocalRepository:path bare:NO error:&error];
       if (repository) {
         [self _openRepositoryWithURL:[NSURL fileURLWithPath:repository.workingDirectoryPath] withCloneMode:kCloneMode_None windowModeID:NSNotFound];
@@ -593,7 +593,7 @@ static CFDataRef _MessagePortCallBack(CFMessagePortRef local, SInt32 msgid, CFDa
       if ([savePanel runModal] == NSFileHandlingPanelOKButton) {
         NSString* path = savePanel.URL.path;
         NSError* error;
-        if (![[NSFileManager defaultManager] fileExistsAtPath:path] || [[NSFileManager defaultManager] moveItemAtPathToTrash:path error:&error]) {
+        if (![[NSFileManager defaultManager] fileExistsAtPath:path followLastSymlink:NO] || [[NSFileManager defaultManager] moveItemAtPathToTrash:path error:&error]) {
           GCRepository* repository = [[GCRepository alloc] initWithNewLocalRepository:path bare:NO error:&error];
           if (repository) {
             if ([repository addRemoteWithName:@"origin" url:url error:&error]) {

--- a/GitUpKit/Core/GCFoundation-Tests.m
+++ b/GitUpKit/Core/GCFoundation-Tests.m
@@ -1,0 +1,168 @@
+//  Copyright (C) 2015 Pierre-Olivier Latour <info@pol-online.net>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import <XCTest/XCTest.h>
+#import "GCFoundation.h"
+
+@interface GCFoundation_Tests : XCTestCase
+
+@end
+
+@implementation GCFoundation_Tests {
+  NSFileManager* _fileManager;
+  NSString* _sandboxPath;
+  NSString* _realFilePath;
+  NSString* _absentFilePath;
+  NSString* _symlinkPath;
+  NSString* _symlinkToSymlinkPath;
+}
+
+- (void)createSymlinkAtPath:(NSString*)symlinkPath toPath:(NSString*)sourcePath {
+  NSError *error;
+  XCTAssertTrue([_fileManager createSymbolicLinkAtPath:symlinkPath
+                                   withDestinationPath:sourcePath
+                                                 error:&error],
+                @"Couldn't create symlink due to an error %@", error);
+}
+
+- (void)createFileAtPath:(NSString *)path {
+  XCTAssertTrue([_fileManager createFileAtPath:path
+                                      contents:nil
+                                    attributes:nil],
+                @"Couldn't create file at path '%@' due to to an error", path);
+}
+
+- (void)createDirectoryAtPath:(NSString*)path {
+  NSError* error;
+  XCTAssertTrue([_fileManager createDirectoryAtPath:path
+                        withIntermediateDirectories:NO
+                                         attributes:NULL
+                                              error:&error],
+                @"Couldn't create directory at path '%@' due to an error %@", path, error);
+
+}
+
+- (void)setUp {
+  [super setUp];
+
+  _fileManager = [NSFileManager new];
+
+  NSUUID* uuid = [NSUUID UUID];
+  _sandboxPath = [NSTemporaryDirectory() stringByAppendingPathComponent:uuid.UUIDString];
+  [self createDirectoryAtPath:_sandboxPath];
+
+  _realFilePath = [_sandboxPath stringByAppendingPathComponent:@"file"];
+  [self createFileAtPath:_realFilePath];
+
+  _absentFilePath = [_sandboxPath stringByAppendingPathComponent:@"absent"];
+  _symlinkPath = [_sandboxPath stringByAppendingPathComponent:@"symlink"];
+  _symlinkToSymlinkPath = [_sandboxPath stringByAppendingPathComponent:@"symlink_to_symlink"];
+}
+
+- (void)tearDown {
+  [_fileManager removeItemAtPath:_sandboxPath error:NULL];
+
+  [super tearDown];
+}
+
+#pragma mark - File
+
+- (void)testFileExistsAtPath_FollowLastSymlink_ExistingFile_returnsYES {
+  XCTAssertTrue([_fileManager fileExistsAtPath:_realFilePath followLastSymlink:YES]);
+}
+
+- (void)testFileExistsAtPath_DoNotFollowLastSymlink_ExistingFile_returnsYES {
+  XCTAssertTrue([_fileManager fileExistsAtPath:_realFilePath followLastSymlink:NO]);
+}
+
+- (void)testFileExistsAtPath_AbsentFile_returnsNO {
+  XCTAssertFalse([_fileManager fileExistsAtPath:_absentFilePath followLastSymlink:NO]);
+  XCTAssertFalse([_fileManager fileExistsAtPath:_absentFilePath followLastSymlink:YES]);
+}
+
+#pragma mark - Symlink to file
+
+- (void)testFileExistsAtPath_FollowLastSymlink_ExistingSymlink_ExistingSymlinkDestination_returnsYES {
+  [self createSymlinkAtPath:_symlinkPath toPath:_realFilePath];
+
+  XCTAssertTrue([_fileManager fileExistsAtPath:_symlinkPath followLastSymlink:YES]);
+}
+
+- (void)testFileExistsAtPath_FollowLastSymlink_ExistingSymlink_MadeUpSymlinkDestination_returnsNO {
+  [self createSymlinkAtPath:_symlinkPath toPath:_absentFilePath];
+
+  XCTAssertFalse([_fileManager fileExistsAtPath:_symlinkPath followLastSymlink:YES]);
+}
+
+- (void)testFileExistsAtPath_DoNotFollowLastSymlink_ExistingSymlink_MadeUpSymlinkDestination_returnsYES {
+  [self createSymlinkAtPath:_symlinkPath toPath:_absentFilePath];
+
+  XCTAssertTrue([_fileManager fileExistsAtPath:_symlinkPath followLastSymlink:NO]);
+}
+
+- (void)testFileExistsAtPath_AbsentSymlink_returnsNO {
+  XCTAssertFalse([_fileManager fileExistsAtPath:_symlinkPath followLastSymlink:NO]);
+  XCTAssertFalse([_fileManager fileExistsAtPath:_symlinkPath followLastSymlink:YES]);
+}
+
+#pragma mark - Symlink to symlink to file
+
+- (void)testFileExistsAtPath_FollowLastSymlink_ExistingSymlinkToSymlink_ExistingFinalSymlinkDestination_returnsYES {
+  NSString* lastSymlinkPath = _symlinkPath;
+  NSString* firstSymlinkPath = _symlinkToSymlinkPath;
+
+  [self createSymlinkAtPath:lastSymlinkPath toPath:_realFilePath];
+  [self createSymlinkAtPath:firstSymlinkPath toPath:lastSymlinkPath];
+
+  XCTAssertTrue([_fileManager fileExistsAtPath:firstSymlinkPath followLastSymlink:YES]);
+}
+
+- (void)testFileExistsAtPath_FollowLastSymlink_ExistingSymlinkToSymlink_AbsentFinalSymlinkDestination_returnsNO {
+  NSString* lastSymlinkPath = _symlinkPath;
+  NSString* firstSymlinkPath = _symlinkToSymlinkPath;
+
+  [self createSymlinkAtPath:lastSymlinkPath toPath:_absentFilePath];
+  [self createSymlinkAtPath:firstSymlinkPath toPath:lastSymlinkPath];
+
+  XCTAssertFalse([_fileManager fileExistsAtPath:firstSymlinkPath followLastSymlink:YES]);
+}
+
+- (void)testFileExistsAtPath_DoesNotFollowLastSymlink_ExistingSymlinkToSymlink_returnsYES {
+  NSString* lastSymlinkPath = _symlinkPath;
+  NSString* firstSymlinkPath = _symlinkToSymlinkPath;
+
+  [self createSymlinkAtPath:lastSymlinkPath toPath:_absentFilePath];
+  [self createSymlinkAtPath:firstSymlinkPath toPath:lastSymlinkPath];
+
+  XCTAssertTrue([_fileManager fileExistsAtPath:firstSymlinkPath followLastSymlink:NO]);
+}
+
+#pragma mark - Intermediate symlink
+
+- (void)testFileExistsAtPath_PathWithIntermediateSymlink_AlwaysFollowsIntermediateSymlink {
+  NSString* directoryPath = [_sandboxPath stringByAppendingPathComponent:@"folder"];
+  NSString* fileInDirectoryPath = [directoryPath stringByAppendingPathComponent:@"file"];
+
+  [self createDirectoryAtPath:directoryPath];
+  [self createFileAtPath:fileInDirectoryPath];
+  [self createSymlinkAtPath:_symlinkPath toPath:directoryPath];
+
+  NSString* filePathWithSymlink = [_symlinkPath stringByAppendingPathComponent:@"file"];
+
+  XCTAssertTrue([_fileManager fileExistsAtPath:filePathWithSymlink followLastSymlink:NO]);
+  XCTAssertTrue([_fileManager fileExistsAtPath:filePathWithSymlink followLastSymlink:YES]);
+}
+
+@end

--- a/GitUpKit/Core/GCFoundation.h
+++ b/GitUpKit/Core/GCFoundation.h
@@ -15,10 +15,12 @@
 
 #import <Foundation/Foundation.h>
 
+@interface NSFileManager (GCFoundation)
+- (BOOL)fileExistsAtPath:(NSString*)path followLastSymlink:(BOOL)followLastSymlink;
+
 #if !TARGET_OS_IPHONE
 
-@interface NSFileManager (GCFoundation)
 - (BOOL)moveItemAtPathToTrash:(NSString*)path error:(NSError**)error;
-@end
 
 #endif
+@end

--- a/GitUpKit/Core/GCFoundation.m
+++ b/GitUpKit/Core/GCFoundation.m
@@ -19,9 +19,24 @@
 
 #import "GCPrivate.h"
 
-#if !TARGET_OS_IPHONE
-
 @implementation NSFileManager (GCFoundation)
+
+- (BOOL)fileExistsAtPath:(NSString*)path followLastSymlink:(BOOL)followLastSymlink {
+  NSDictionary* pathAttributes = [self attributesOfItemAtPath:path error:NULL];
+
+  if (followLastSymlink && [[pathAttributes fileType] isEqualToString:NSFileTypeSymbolicLink]) {
+    path = [self destinationOfSymbolicLinkAtPath:path error:NULL];
+    if (!path) {
+      return NO;
+    }
+
+    return [self fileExistsAtPath:path followLastSymlink:YES];
+  }
+
+  return pathAttributes != nil;
+}
+
+#if !TARGET_OS_IPHONE
 
 - (BOOL)moveItemAtPathToTrash:(NSString*)path error:(NSError**)error {
   NSString* trashPath = [NSSearchPathForDirectoriesInDomains(NSTrashDirectory, NSUserDomainMask, YES) firstObject];
@@ -33,12 +48,12 @@
   NSString* name = [path.lastPathComponent stringByDeletingPathExtension];
   NSString* destinationPath = [trashPath stringByAppendingPathComponent:[name stringByAppendingPathExtension:extension]];
   NSUInteger counter = 0;
-  while ([self fileExistsAtPath:destinationPath]) {
+  while ([self fileExistsAtPath:destinationPath followLastSymlink:NO]) {
     destinationPath = [trashPath stringByAppendingPathComponent:[[NSString stringWithFormat:@"%@ (%lu)", name, ++counter] stringByAppendingPathExtension:extension]];
   }
   return [self moveItemAtPath:path toPath:destinationPath error:error];
 }
 
-@end
-
 #endif
+
+@end

--- a/GitUpKit/Core/GCLiveRepository.m
+++ b/GitUpKit/Core/GCLiveRepository.m
@@ -521,7 +521,7 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
 - (void)_readSnapshots {
   NSString* path = [self.privateAppDirectoryPath stringByAppendingPathComponent:kSnapshotsFileName];
   if (path) {
-    if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
+    if ([[NSFileManager defaultManager] fileExistsAtPath:path followLastSymlink:NO]) {
       NSArray* array = [NSKeyedUnarchiver unarchiveObjectWithFile:path];
       if (array) {
         [_snapshots addObjectsFromArray:array];

--- a/GitUpKit/Core/GCSubmodule.m
+++ b/GitUpKit/Core/GCSubmodule.m
@@ -155,7 +155,7 @@ cleanup:
   XLOG_DEBUG_CHECK(![self checkSubmoduleInitialized:submodule error:NULL]);
   
   NSString* modulePath = [[self.repositoryPath stringByAppendingPathComponent:@"modules"] stringByAppendingPathComponent:submodule.path];
-  if ([[NSFileManager defaultManager] fileExistsAtPath:modulePath] && ![[NSFileManager defaultManager] removeItemAtPath:modulePath error:error]) {
+  if ([[NSFileManager defaultManager] fileExistsAtPath:modulePath followLastSymlink:NO] && ![[NSFileManager defaultManager] removeItemAtPath:modulePath error:error]) {
     return NO;
   }
   

--- a/GitUpKit/Core/GCTestCase.m
+++ b/GitUpKit/Core/GCTestCase.m
@@ -137,7 +137,7 @@ static const void* _associatedObjectKey = &_associatedObjectKey;
   } else {
     _temporaryPath = @"/tmp/gitup";
   }
-  if ([[NSFileManager defaultManager] fileExistsAtPath:_temporaryPath]) {
+  if ([[NSFileManager defaultManager] fileExistsAtPath:_temporaryPath followLastSymlink:NO]) {
     XCTAssertTrue([[NSFileManager defaultManager] removeItemAtPath:_temporaryPath error:NULL]);
   }
   XCTAssertTrue([[NSFileManager defaultManager] createDirectoryAtPath:_temporaryPath withIntermediateDirectories:NO attributes:nil error:NULL]);

--- a/GitUpKit/Extensions/GCRepository+Index.m
+++ b/GitUpKit/Extensions/GCRepository+Index.m
@@ -116,7 +116,7 @@
   if (index == nil) {
     return NO;
   }
-  if ([[NSFileManager defaultManager] fileExistsAtPath:[self absolutePathForFile:path]] && ![self addFileInWorkingDirectory:path toIndex:index error:error]) {
+  if ([[NSFileManager defaultManager] fileExistsAtPath:[self absolutePathForFile:path] followLastSymlink:NO] && ![self addFileInWorkingDirectory:path toIndex:index error:error]) {
     return NO;
   }
   return [self clearConflictForFile:path inIndex:index error:error] && [self writeRepositoryIndex:index error:error];

--- a/GitUpKit/Extensions/GCRepository+Utilities-Tests.m
+++ b/GitUpKit/Extensions/GCRepository+Utilities-Tests.m
@@ -94,7 +94,7 @@
   XCTAssertTrue([self.repository addFileToIndex:@"file1" error:NULL]);
   [self updateFileAtPath:@"file2" withString:@"2"];
   XCTAssertTrue([self.repository cleanWorkingDirectory:NULL]);
-  XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:[self.repository.workingDirectoryPath stringByAppendingPathComponent:@"file1"]]);
+  XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:[self.repository.workingDirectoryPath stringByAppendingPathComponent:@"file1"] followLastSymlink:NO]);
   XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:[self.repository.workingDirectoryPath stringByAppendingPathComponent:@"file2"]]);
 }
 

--- a/GitUpKit/Extensions/GCRepository+Utilities.m
+++ b/GitUpKit/Extensions/GCRepository+Utilities.m
@@ -512,7 +512,7 @@ NSString* GCNameFromHostingService(GCHostingService service) {
 }
 
 - (BOOL)safeDeleteFileIfExists:(NSString*)path error:(NSError**)error {
-  return ![[NSFileManager defaultManager] fileExistsAtPath:[self absolutePathForFile:path]] || [self safeDeleteFile:path error:error];
+  return ![[NSFileManager defaultManager] fileExistsAtPath:[self absolutePathForFile:path] followLastSymlink:NO] || [self safeDeleteFile:path error:error];
 }
 
 - (NSMutableDictionary*)_readUserInfo {

--- a/GitUpKit/GitUpKit.xcodeproj/project.pbxproj
+++ b/GitUpKit/GitUpKit.xcodeproj/project.pbxproj
@@ -369,6 +369,7 @@
 		E2C3394919F85D8700063D95 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C3394419F85D4B00063D95 /* libz.dylib */; };
 		E2C3394C19F85D8700063D95 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C3393E19F85D2A00063D95 /* libiconv.dylib */; };
 		E2C3AA5C19FF0B0600BA89F3 /* GCRepository+Bare.m in Sources */ = {isa = PBXBuildFile; fileRef = E2C3AA5A19FF0B0600BA89F3 /* GCRepository+Bare.m */; };
+		E2C56CC41D71B3730011960D /* GCFoundation-Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E2C56CC31D71B3730011960D /* GCFoundation-Tests.m */; };
 		E2D4148C1A02D68700B99634 /* GCHistory+Rewrite.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D4148A1A02D68700B99634 /* GCHistory+Rewrite.m */; };
 		E2F5C27F1A8171C900C30739 /* GCSnapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F5C27D1A8171C900C30739 /* GCSnapshot.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		E2F5C2811A8186C200C30739 /* GCSnapshot-Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F5C2801A8186C200C30739 /* GCSnapshot-Tests.m */; };
@@ -612,6 +613,7 @@
 		E2C3394619F85D5100063D95 /* libheimdal-asn1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libheimdal-asn1.dylib"; path = "usr/lib/libheimdal-asn1.dylib"; sourceTree = SDKROOT; };
 		E2C3AA5919FF0B0600BA89F3 /* GCRepository+Bare.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GCRepository+Bare.h"; sourceTree = "<group>"; };
 		E2C3AA5A19FF0B0600BA89F3 /* GCRepository+Bare.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "GCRepository+Bare.m"; sourceTree = "<group>"; };
+		E2C56CC31D71B3730011960D /* GCFoundation-Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "GCFoundation-Tests.m"; sourceTree = "<group>"; };
 		E2C9FF861AA510170051B2AE /* GIUnifiedDiffView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GIUnifiedDiffView.h; sourceTree = "<group>"; };
 		E2C9FF871AA510170051B2AE /* GIUnifiedDiffView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GIUnifiedDiffView.m; sourceTree = "<group>"; };
 		E2D414891A02D68700B99634 /* GCHistory+Rewrite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GCHistory+Rewrite.h"; sourceTree = "<group>"; };
@@ -922,6 +924,7 @@
 				E2146C901A58849F00F4550B /* GCError.h */,
 				E2790D401ACB1B1100965A98 /* GCFoundation.h */,
 				E2790D411ACB1B1100965A98 /* GCFoundation.m */,
+				E2C56CC31D71B3730011960D /* GCFoundation-Tests.m */,
 				E21739F11A4FE39E00EC6777 /* GCFunctions.h */,
 				E21739F21A4FE39E00EC6777 /* GCFunctions.m */,
 				E259C2D21A64F9FF0079616B /* GCHistory-Tests.m */,
@@ -1538,6 +1541,7 @@
 				74EDB5D61B84E06500F00E79 /* GCOrderedSet-Tests.m in Sources */,
 				E27E43031A74A96000D04ED1 /* GIBranch.m in Sources */,
 				E27E43081A74A96000D04ED1 /* GINode.m in Sources */,
+				E2C56CC41D71B3730011960D /* GCFoundation-Tests.m in Sources */,
 				E299D0161A749D27005035F7 /* GCRepository+Mock-Tests.m in Sources */,
 				E2D4148C1A02D68700B99634 /* GCHistory+Rewrite.m in Sources */,
 				E2146C8F1A57F3BC00F4550B /* GCObject.m in Sources */,

--- a/GitUpKit/Utilities/GIViewController+Utilities.m
+++ b/GitUpKit/Utilities/GIViewController+Utilities.m
@@ -139,7 +139,7 @@ static NSString* _diffTemporaryDirectoryPath = nil;
 
 - (void)stageAllChangesForFile:(NSString*)path {
   NSError* error;
-  BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:[self.repository absolutePathForFile:path]];
+  BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:[self.repository absolutePathForFile:path] followLastSymlink:NO];
   if ((fileExists && [self.repository addFileToIndex:path error:&error]) || (!fileExists && [self.repository removeFileFromIndex:path error:&error])) {
     [self.repository notifyRepositoryChanged];
   } else {


### PR DESCRIPTION
Without the fix "Discard All" action could fail in the middle if there's a symlink in Trash with the same name as one of the items being discarded.

This scenario is pretty common when working with CocoaPods (iOS/Mac dependency management tool).

I'm not sure if this is a good solution performance-wise. Another option is to use`stat()` instead of `-fileExistsAtPath:`.

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT

`-fileExistsAtPath:` checklist:

- [x] https://github.com/git-up/GitUp/blob/59ab927d0a3f86671ce5045ab5c47131bba4a199/GitUp/Application/AppDelegate.m#L563 — switched to `-fileOrSymlinkExistsAtPath:`
- [x] https://github.com/git-up/GitUp/blob/59ab927d0a3f86671ce5045ab5c47131bba4a199/GitUp/Application/AppDelegate.m#L594 — switched to `-fileOrSymlinkExistsAtPath:`
- [x] https://github.com/git-up/GitUp/blob/59ab927d0a3f86671ce5045ab5c47131bba4a199/GitUpKit/Core/GCLiveRepository.m#L524 — snapshot loading, files aren't supposed to be symlink
- [ ] https://github.com/git-up/GitUp/blob/59ab927d0a3f86671ce5045ab5c47131bba4a199/GitUpKit/Extensions/GCRepository+Index.m#L119 — I don't know how does conflict resolving work for symlinks.
- [ ] https://github.com/git-up/GitUp/blob/59ab927d0a3f86671ce5045ab5c47131bba4a199/GitUpKit/Extensions/GCRepository+Utilities.m#L144 — I'm not sure how to handle moving of symlinks.
- [x] https://github.com/git-up/GitUp/blob/59ab927d0a3f86671ce5045ab5c47131bba4a199/GitUpKit/Extensions/GCRepository+Utilities.m#L515
- [x] https://github.com/git-up/GitUp/blob/59ab927d0a3f86671ce5045ab5c47131bba4a199/GitUpKit/Core/GCRepository.m#L208 — private app data path getter, symlinks aren't expected
- [ ] https://github.com/git-up/GitUp/blob/59ab927d0a3f86671ce5045ab5c47131bba4a199/GitUpKit/Core/GCSubmodule.m#L158 — the check is faulty if there's a symlink at the path of submodule, but I've found that `-[GCSubmodule checkSubmoduleInitialized:error:]` also doesn't like symlinks and decided not to touch it this check at all.
- [x] https://github.com/git-up/GitUp/blob/59ab927d0a3f86671ce5045ab5c47131bba4a199/GitUpKit/Utilities/GIViewController+Utilities.m#L142 — broken symlinks are staged & committed.