### PR TITLE
Font scale

### DIFF
--- a/GitUp/Application/AppDelegate.m
+++ b/GitUp/Application/AppDelegate.m
@@ -106,6 +106,7 @@
     GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters : @(YES),
     GICommitMessageViewUserDefaultKey_ShowMargins : @(YES),
     GICommitMessageViewUserDefaultKey_EnableSpellChecking : @(YES),
+    GIUserDefaultKey_FontSize : @(GIDefaultFontSize),
     kUserDefaultsKey_ReleaseChannel : kReleaseChannel_Stable,
     kUserDefaultsKey_CheckInterval : @(15 * 60),
     kUserDefaultsKey_FirstLaunch : @(YES),

--- a/GitUp/Application/FontSizeTransformer.h
+++ b/GitUp/Application/FontSizeTransformer.h
@@ -1,0 +1,21 @@
+//  Copyright (C) 2015-2017 Pierre-Olivier Latour <info@pol-online.net>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import <Foundation/Foundation.h>
+
+/// Transforms between the linear slider in Preferences to a non-linear list of font sizes matching the system font picker.
+@interface FontSizeTransformer : NSValueTransformer
+
+@end

--- a/GitUp/Application/FontSizeTransformer.m
+++ b/GitUp/Application/FontSizeTransformer.m
@@ -1,0 +1,55 @@
+//  Copyright (C) 2015-2017 Pierre-Olivier Latour <info@pol-online.net>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import "FontSizeTransformer.h"
+#import <GitUpKit/GIAppKit.h>
+
+static NSArray* sizes;
+
+@implementation FontSizeTransformer
+
++ (void)initialize {
+  // Match the system font picker
+  sizes = @[ @9, @10, @11, @12, @13, @14, @18, @24 ];
+}
+
++ (Class)transformedValueClass {
+  return [NSNumber class];
+}
+
++ (BOOL)allowsReverseTransformation {
+  return YES;
+}
+
+- (id)transformedValue:(id)fontSizeValue {
+  NSUInteger idx = [sizes indexOfObject:fontSizeValue];
+  if (idx == NSNotFound) {
+    // If the user default is set externally, fallback to the default index.
+    return @1;
+  }
+
+  return @(idx);
+}
+
+- (id)reverseTransformedValue:(id)indexValue {
+  NSUInteger idx = [indexValue unsignedIntegerValue];
+  if (idx >= sizes.count) {
+    return @(GIDefaultFontSize);
+  }
+
+  return sizes[idx];
+}
+
+@end

--- a/GitUp/Application/en.lproj/MainMenu.xib
+++ b/GitUp/Application/en.lproj/MainMenu.xib
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" customObjectInstantitationMethod="direct">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <development version="6300" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <capability name="box content view" minToolsVersion="7.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -1149,17 +1150,14 @@ UI design by Wayne Fan</string>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="zd1-ko-kkJ">
+                    <box verticalHuggingPriority="750" boxType="separator" id="zd1-ko-kkJ">
                         <rect key="frame" x="0.0" y="121" width="280" height="5"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                        <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                        <font key="titleFont" metaFont="system"/>
                     </box>
-                    <box autoresizesSubviews="NO" title="Box" boxType="custom" borderType="none" titlePosition="noTitle" id="Yk1-Lc-GjF">
+                    <box autoresizesSubviews="NO" boxType="custom" borderType="none" title="Box" titlePosition="noTitle" id="Yk1-Lc-GjF">
                         <rect key="frame" x="0.0" y="88" width="280" height="35"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <view key="contentView">
+                        <view key="contentView" id="sDO-dg-ir8">
                             <rect key="frame" x="0.0" y="0.0" width="280" height="35"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
@@ -1181,20 +1179,16 @@ UI design by Wayne Fan</string>
                                 </customView>
                             </subviews>
                         </view>
-                        <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                         <color key="fillColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </box>
-                    <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="FXE-km-lcD">
+                    <box verticalHuggingPriority="750" boxType="separator" id="FXE-km-lcD">
                         <rect key="frame" x="0.0" y="85" width="280" height="5"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                        <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                        <font key="titleFont" metaFont="system"/>
                     </box>
-                    <box autoresizesSubviews="NO" title="Box" boxType="custom" borderType="none" titlePosition="noTitle" id="ll1-UT-nBS">
+                    <box autoresizesSubviews="NO" boxType="custom" borderType="none" title="Box" titlePosition="noTitle" id="ll1-UT-nBS">
                         <rect key="frame" x="0.0" y="52" width="280" height="35"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <view key="contentView">
+                        <view key="contentView" id="J3B-5Z-dcx">
                             <rect key="frame" x="0.0" y="0.0" width="280" height="35"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
@@ -1214,15 +1208,11 @@ UI design by Wayne Fan</string>
                                 </popUpButton>
                             </subviews>
                         </view>
-                        <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                         <color key="fillColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </box>
-                    <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="3Ya-QW-NlZ">
+                    <box verticalHuggingPriority="750" boxType="separator" id="3Ya-QW-NlZ">
                         <rect key="frame" x="0.0" y="49" width="280" height="5"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                        <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                        <font key="titleFont" metaFont="system"/>
                     </box>
                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="TgX-Ty-AUa">
                         <rect key="frame" x="45" y="20" width="12" height="12"/>

--- a/GitUp/Application/en.lproj/MainMenu.xib
+++ b/GitUp/Application/en.lproj/MainMenu.xib
@@ -31,7 +31,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <font key="font" metaFont="system"/>
                         <tabViewItems>
-                            <tabViewItem label="{500, 388}" identifier="general" id="M8N-WY-xpP">
+                            <tabViewItem label="{500, 419}" identifier="general" id="M8N-WY-xpP">
                                 <view key="view" id="ZJf-t1-iGB">
                                     <rect key="frame" x="0.0" y="0.0" width="500" height="400"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -80,7 +80,7 @@
                                             </connections>
                                         </button>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="lyZ-cf-MT6">
-                                            <rect key="frame" x="12" y="173" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="133" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Commits:" id="6J8-35-XZI">
                                                 <font key="font" metaFont="system"/>
@@ -89,7 +89,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button id="CQY-oC-oQ8">
-                                            <rect key="frame" x="137" y="172" width="146" height="18"/>
+                                            <rect key="frame" x="137" y="132" width="146" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Use Simple mode" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="rMb-zc-NF1">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -106,7 +106,7 @@
                                             </connections>
                                         </button>
                                         <button id="T1B-3i-hRB">
-                                            <rect key="frame" x="137" y="82" width="191" height="18"/>
+                                            <rect key="frame" x="137" y="42" width="191" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Show invisible characters" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="omy-Qf-vg9">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -123,7 +123,7 @@
                                             </connections>
                                         </button>
                                         <button id="SyF-mN-F3q">
-                                            <rect key="frame" x="137" y="62" width="270" height="18"/>
+                                            <rect key="frame" x="137" y="22" width="270" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Show margins at 50 and 72 characters" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="AMR-Ne-0QY">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -140,7 +140,7 @@
                                             </connections>
                                         </button>
                                         <button id="ag6-rb-zPH">
-                                            <rect key="frame" x="137" y="42" width="176" height="18"/>
+                                            <rect key="frame" x="137" y="2" width="176" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Enable spell checking" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="G82-Jf-2sb">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -157,7 +157,7 @@
                                             </connections>
                                         </button>
                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="jee-vl-BUt">
-                                            <rect key="frame" x="137" y="110" width="345" height="56"/>
+                                            <rect key="frame" x="137" y="70" width="345" height="56"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="v99-tx-ohB">
                                                 <font key="font" metaFont="smallSystem"/>
@@ -168,7 +168,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="YZU-dx-gjr">
-                                            <rect key="frame" x="12" y="244" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="204" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Diffs Layout:" id="B0V-bN-usw">
                                                 <font key="font" metaFont="system"/>
@@ -177,7 +177,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <matrix verticalHuggingPriority="750" allowsEmptySelection="NO" autorecalculatesCellSize="YES" id="pP3-w2-KOs">
-                                            <rect key="frame" x="139" y="204" width="341" height="58"/>
+                                            <rect key="frame" x="139" y="164" width="341" height="58"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             <size key="cellSize" width="276" height="18"/>
@@ -213,7 +213,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </connections>
                                         </matrix>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="mC1-sE-MTH">
-                                            <rect key="frame" x="12" y="83" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="43" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Message Editor:" id="5Hr-DF-QKw">
                                                 <font key="font" metaFont="system"/>
@@ -222,7 +222,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="IO8-Wx-DRo">
-                                            <rect key="frame" x="12" y="318" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="278" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Diff Generation:" id="cxW-C3-fIQ">
                                                 <font key="font" metaFont="system"/>
@@ -231,7 +231,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <matrix verticalHuggingPriority="750" allowsEmptySelection="NO" autorecalculatesCellSize="YES" id="zwg-99-t9E">
-                                            <rect key="frame" x="139" y="278" width="341" height="58"/>
+                                            <rect key="frame" x="139" y="238" width="341" height="58"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             <size key="cellSize" width="268" height="18"/>
@@ -266,6 +266,48 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                                 </binding>
                                             </connections>
                                         </matrix>
+                                        <slider verticalHuggingPriority="750" id="rhi-3l-Hqe">
+                                            <rect key="frame" x="161" y="306" width="220" height="24"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <sliderCell key="cell" continuous="YES" state="on" alignment="left" maxValue="7" doubleValue="1" tickMarkPosition="below" numberOfTickMarks="8" allowsTickMarkValuesOnly="YES" sliderType="linear" id="l2k-ze-Mef"/>
+                                            <connections>
+                                                <binding destination="AR1-cq-KNa" name="value" keyPath="values.GIUserDefaultKey_FontSize" id="Qvl-2n-Mm7">
+                                                    <dictionary key="options">
+                                                        <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                        <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                        <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                                        <string key="NSValueTransformerName">FontSizeTransformer</string>
+                                                    </dictionary>
+                                                </binding>
+                                            </connections>
+                                        </slider>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="USF-fw-I4Y">
+                                            <rect key="frame" x="12" y="314" width="120" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Text Size:" id="i4L-0T-dLo">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="5aY-1Q-fPN">
+                                            <rect key="frame" x="137" y="310" width="20" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Aa" id="KQN-gV-qvd">
+                                                <font key="font" metaFont="system" size="10"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="Gtc-me-VZe">
+                                            <rect key="frame" x="385" y="312" width="29" height="24"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Aa" id="4Va-3A-rhV">
+                                                <font key="font" metaFont="system" size="20"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                     </subviews>
                                 </view>
                             </tabViewItem>

--- a/GitUp/GitUp.xcodeproj/project.pbxproj
+++ b/GitUp/GitUp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		165C32B61B95739700D2F894 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 165C32B51B95739700D2F894 /* QuartzCore.framework */; };
+		A53C6D0C1E61A9CF0070387E /* FontSizeTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = A53C6D0B1E61A9CF0070387E /* FontSizeTransformer.m */; };
 		E212A6DE1B92100E00F62B18 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E212A6DD1B92100E00F62B18 /* libiconv.dylib */; };
 		E21739F71A5080DD00EC6777 /* DocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = E21739F61A5080DD00EC6777 /* DocumentController.m */; };
 		E21DCAEB1B253847006424E8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E21DCAEA1B253847006424E8 /* main.m */; };
@@ -106,6 +107,8 @@
 
 /* Begin PBXFileReference section */
 		165C32B51B95739700D2F894 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		A53C6D0A1E61A9CF0070387E /* FontSizeTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FontSizeTransformer.h; sourceTree = "<group>"; };
+		A53C6D0B1E61A9CF0070387E /* FontSizeTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FontSizeTransformer.m; sourceTree = "<group>"; };
 		E212A6DD1B92100E00F62B18 /* libiconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
 		E21739F51A5080DD00EC6777 /* DocumentController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DocumentController.h; sourceTree = "<group>"; };
 		E21739F61A5080DD00EC6777 /* DocumentController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DocumentController.m; sourceTree = "<group>"; };
@@ -268,6 +271,8 @@
 				E2A5BE6E1A814970008DD47F /* Localizable.strings */,
 				E2C338B319F8562F00063D95 /* main.m */,
 				E2C338BD19F8562F00063D95 /* MainMenu.xib */,
+				A53C6D0A1E61A9CF0070387E /* FontSizeTransformer.h */,
+				A53C6D0B1E61A9CF0070387E /* FontSizeTransformer.m */,
 				E2C5672B1A6D98BC00ECFE07 /* WindowController.h */,
 				E2C5672C1A6D98BC00ECFE07 /* WindowController.m */,
 			);
@@ -422,6 +427,7 @@
 				E2E3C9A01D771E7600AA9A62 /* GARawTracker.m in Sources */,
 				E2C338B419F8562F00063D95 /* main.m in Sources */,
 				E2C5672D1A6D98BC00ECFE07 /* WindowController.m in Sources */,
+				A53C6D0C1E61A9CF0070387E /* FontSizeTransformer.m in Sources */,
 				E2C338B219F8562F00063D95 /* AppDelegate.m in Sources */,
 				E2C338B719F8562F00063D95 /* Document.m in Sources */,
 			);

--- a/GitUpKit/Components/GIDiffContentsViewController.m
+++ b/GitUpKit/Components/GIDiffContentsViewController.m
@@ -24,7 +24,8 @@
 #import "GCRepository+Index.h"
 #import "XLFacilityMacros.h"
 
-#define kMinSplitDiffViewWidth 1000
+// Units ems: a multiple of the font point size, so the width threshold is 100 * 10 = 1000 for a 10 point font.
+#define kMinSplitDiffViewWidthEms 100
 
 #define kContextualMenuOffsetX 0
 #define kContextualMenuOffsetY -6
@@ -228,6 +229,7 @@ static NSColor* _DimColor(NSColor* color) {
 - (instancetype)initWithRepository:(GCLiveRepository*)repository {
   if ((self = [super initWithRepository:repository])) {
     [[NSUserDefaults standardUserDefaults] addObserver:self forKeyPath:GIDiffContentsViewControllerUserDefaultKey_DiffViewMode options:0 context:(__bridge void*)[GIDiffContentsViewController class]];
+    [[NSUserDefaults standardUserDefaults] addObserver:self forKeyPath:GIUserDefaultKey_FontSize options:0 context:(__bridge void*)[GIDiffContentsViewController class]];
   }
   return self;
 }
@@ -235,6 +237,7 @@ static NSColor* _DimColor(NSColor* color) {
 - (void)dealloc {
   [[NSNotificationCenter defaultCenter] removeObserver:self name:NSViewBoundsDidChangeNotification object:_tableView.superview];
 
+  [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:GIUserDefaultKey_FontSize context:(__bridge void*)[GIDiffContentsViewController class]];
   [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:GIDiffContentsViewControllerUserDefaultKey_DiffViewMode context:(__bridge void*)[GIDiffContentsViewController class]];
 }
 
@@ -267,13 +270,13 @@ static NSColor* _DimColor(NSColor* color) {
     if ((change == kGCFileDiffChange_Untracked) || (change == kGCFileDiffChange_Added) || (change == kGCFileDiffChange_Deleted)) {
       return [GIUnifiedDiffView class];
     }
-    return self.view.bounds.size.width < kMinSplitDiffViewWidth ? [GIUnifiedDiffView class] : [GISplitDiffView class];
+    return self.view.bounds.size.width < kMinSplitDiffViewWidthEms * GIFontSize() ? [GIUnifiedDiffView class] : [GISplitDiffView class];
   }
   return mode > 0 ? [GISplitDiffView class] : [GIUnifiedDiffView class];
 }
 
-- (void)_updateDiffViews {
-  BOOL reload = NO;
+- (void)_updateDiffViewsForcingReload:(BOOL)forceReload {
+  BOOL reload = forceReload;
   for (GIDiffContentData* data in _data) {
     if (!data.diffView) {
       continue;
@@ -296,7 +299,7 @@ static NSColor* _DimColor(NSColor* color) {
 
 - (void)viewDidResize {
   if (self.viewVisible && !self.liveResizing) {
-    [self _updateDiffViews];
+    [self _updateDiffViewsForcingReload:NO];
     [NSAnimationContext beginGrouping];
     [[NSAnimationContext currentContext] setDuration:0.0];  // Prevent animations in case the view is actually not on screen yet (e.g. in a hidden tab)
     [_tableView noteHeightOfRowsWithIndexesChanged:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, [self numberOfRowsInTableView:_tableView])]];
@@ -305,15 +308,16 @@ static NSColor* _DimColor(NSColor* color) {
 }
 
 - (void)viewDidFinishLiveResize {
-  [self _updateDiffViews];
+  [self _updateDiffViewsForcingReload:NO];
   [_tableView noteHeightOfRowsWithIndexesChanged:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, [self numberOfRowsInTableView:_tableView])]];
 }
 
 // WARNING: This is called *several* times when the default has been changed
 - (void)observeValueForKeyPath:(NSString*)keyPath ofObject:(id)object change:(NSDictionary*)change context:(void*)context {
   if (context == (__bridge void*)[GIDiffContentsViewController class]) {
-    if (self.viewVisible) {
-      [self _updateDiffViews];  // This is idempotent
+    BOOL isFontSizeChange = [keyPath isEqualToString:GIUserDefaultKey_FontSize];
+    if (self.viewVisible || isFontSizeChange) {
+      [self _updateDiffViewsForcingReload:isFontSizeChange];  // This is idempotent
     }
   } else {
     [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];

--- a/GitUpKit/Interface/GIDiffView.h
+++ b/GitUpKit/Interface/GIDiffView.h
@@ -32,6 +32,12 @@
 @property(nonatomic, readonly, getter=isEmpty) BOOL empty;
 - (CGFloat)updateLayoutForWidth:(CGFloat)width;
 
+@property(nonatomic, readonly) CFDictionaryRef textAttributes;
+@property(nonatomic, readonly) CTLineRef addedLine;
+@property(nonatomic, readonly) CTLineRef deletedLine;
+@property(nonatomic, readonly) CGFloat lineHeight;
+@property(nonatomic, readonly) CGFloat lineDescent;
+
 @property(nonatomic, readonly) BOOL hasSelection;
 @property(nonatomic, readonly) BOOL hasSelectedText;
 @property(nonatomic, readonly) BOOL hasSelectedLines;

--- a/GitUpKit/Interface/GIPrivate.h
+++ b/GitUpKit/Interface/GIPrivate.h
@@ -19,14 +19,6 @@
 
 #if __GI_HAS_APPKIT__
 
-extern CFDictionaryRef GIDiffViewAttributes;
-
-extern CTLineRef GIDiffViewAddedLine;
-extern CTLineRef GIDiffViewDeletedLine;
-
-extern CGFloat GIDiffViewLineHeight;
-extern CGFloat GIDiffViewLineDescent;
-
 extern NSColor* GIDiffViewDeletedBackgroundColor;
 extern NSColor* GIDiffViewDeletedHighlightColor;
 extern NSColor* GIDiffViewAddedBackgroundColor;

--- a/GitUpKit/Interface/GISplitDiffView.m
+++ b/GitUpKit/Interface/GISplitDiffView.m
@@ -18,11 +18,25 @@
 #endif
 
 #import "GIPrivate.h"
+#import "GIAppKit.h"
 
-#define kTextLineNumberMargin (5 * 8)
-#define kTextInsetLeft 5
-#define kTextInsetRight 5
 #define kTextBottomPadding 0
+
+static CGFloat textLineNumberMargin(void) {
+  return roundf(4 * GIFontSize());
+}
+
+static CGFloat textInsetLeft(void) {
+  return roundf(1.5f * GIFontSize());
+}
+
+static CGFloat textInsetRight(void) {
+  return roundf(0.5f * GIFontSize());
+}
+
+static CGFloat textLineStartX(void) {
+  return textLineNumberMargin() + textInsetLeft();
+}
 
 typedef NS_ENUM(NSUInteger, DiffLineType) {
   kDiffLineType_Separator = 0,
@@ -127,7 +141,7 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
   if (self.patch && (NSInteger)width != (NSInteger)_size.width) {
     [_lines removeAllObjects];
 
-    CGFloat lineWidth = floor((width - 2 * kTextLineNumberMargin - 2 * kTextInsetLeft - 2 * kTextInsetRight) / 2);
+    CGFloat lineWidth = floor((width - 2 * textLineNumberMargin() - 2 * textInsetLeft() - 2 * textInsetRight()) / 2);
     __block NSUInteger lineIndex = NSNotFound;
     __block NSUInteger startIndex = NSNotFound;
     __block NSUInteger addedCount = 0;
@@ -182,7 +196,7 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
     [self.patch enumerateUsingBeginHunkHandler:^(NSUInteger oldLineNumber, NSUInteger oldLineCount, NSUInteger newLineNumber, NSUInteger newLineCount) {
 
       NSString* string = [[NSString alloc] initWithFormat:@"@@ -%lu,%lu +%lu,%lu @@", oldLineNumber, oldLineCount, newLineNumber, newLineCount];
-      CFAttributedStringRef attributedString = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)string, GIDiffViewAttributes);
+      CFAttributedStringRef attributedString = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)string, self.textAttributes);
       CTLineRef line = CTLineCreateWithAttributedString(attributedString);
       CFRelease(attributedString);
 
@@ -230,7 +244,7 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
               break;
           }
 
-          CFAttributedStringRef attributedString = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)string, GIDiffViewAttributes);
+          CFAttributedStringRef attributedString = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)string, self.textAttributes);
           CTTypesetterRef typeSetter = CTTypesetterCreateWithAttributedString(attributedString);
           CFIndex length = CFAttributedStringGetLength(attributedString);
           CFIndex offset = 0;
@@ -311,7 +325,7 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
           highlightBlock();
 
         }];
-    _size = NSMakeSize(width, _lines.count * GIDiffViewLineHeight + kTextBottomPadding);
+    _size = NSMakeSize(width, _lines.count * self.lineHeight + kTextBottomPadding);
   }
   return _size.height;
 }
@@ -319,6 +333,8 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
 - (void)drawRect:(NSRect)dirtyRect {
   NSRect bounds = self.bounds;
   CGFloat offset = floor(bounds.size.width / 2);
+  CGFloat lineStartX = textLineStartX();
+
   CGContextRef context = [[NSGraphicsContext currentContext] graphicsPort];
   CGContextSaveGState(context);
 
@@ -331,63 +347,63 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
     NSColor* selectedColor = self.window.keyWindow && (self.window.firstResponder == self) ? [NSColor selectedControlColor] : [NSColor secondarySelectedControlColor];
     CGContextSetTextMatrix(context, CGAffineTransformIdentity);
     NSUInteger count = _lines.count;
-    NSUInteger start = MIN(MAX(count - (dirtyRect.origin.y + dirtyRect.size.height - kTextBottomPadding) / GIDiffViewLineHeight, 0), count);
-    NSUInteger end = MIN(MAX(count - (dirtyRect.origin.y - kTextBottomPadding) / GIDiffViewLineHeight + 1, 0), count);
+    NSUInteger start = MIN(MAX(count - (dirtyRect.origin.y + dirtyRect.size.height - kTextBottomPadding) / self.lineHeight, 0), count);
+    NSUInteger end = MIN(MAX(count - (dirtyRect.origin.y - kTextBottomPadding) / self.lineHeight + 1, 0), count);
     for (NSUInteger i = start; i < end; ++i) {
       __unsafe_unretained GISplitDiffLine* diffLine = _lines[i];
       CTLineRef leftLine = diffLine.leftLine;
       CTLineRef rightLine = diffLine.rightLine;
-      CGFloat linePosition = (count - 1 - i) * GIDiffViewLineHeight + kTextBottomPadding;
-      CGFloat textPosition = linePosition + GIDiffViewLineDescent;
+      CGFloat linePosition = (count - 1 - i) * self.lineHeight + kTextBottomPadding;
+      CGFloat textPosition = linePosition + self.lineDescent;
       if (diffLine.type == kDiffLineType_Separator) {
         [GIDiffViewSeparatorBackgroundColor setFill];
-        CGContextFillRect(context, CGRectMake(0, linePosition + 1, bounds.size.width, GIDiffViewLineHeight - 1));
+        CGContextFillRect(context, CGRectMake(0, linePosition + 1, bounds.size.width, self.lineHeight - 1));
 
         [GIDiffViewSeparatorLineColor setStroke];
         CGContextMoveToPoint(context, 0, linePosition + 0.5);
         CGContextAddLineToPoint(context, bounds.size.width, linePosition + 0.5);
         CGContextStrokePath(context);
-        CGContextMoveToPoint(context, 0, linePosition + GIDiffViewLineHeight - 0.5);
-        CGContextAddLineToPoint(context, bounds.size.width, linePosition + GIDiffViewLineHeight - 0.5);
+        CGContextMoveToPoint(context, 0, linePosition + self.lineHeight - 0.5);
+        CGContextAddLineToPoint(context, bounds.size.width, linePosition + self.lineHeight - 0.5);
         CGContextStrokePath(context);
 
         [GIDiffViewSeparatorTextColor setFill];
-        CGContextSetTextPosition(context, kTextLineNumberMargin + 4, textPosition);
+        CGContextSetTextPosition(context, textLineNumberMargin() + roundf(0.4f * GIFontSize()), textPosition);
         CTLineDraw(leftLine, context);
       } else {
         if (leftLine) {
           if (!_rightSelection && [_selectedLines containsIndex:diffLine.leftNumber]) {
             [selectedColor setFill];
-            CGContextFillRect(context, CGRectMake(0, linePosition, offset, GIDiffViewLineHeight));
+            CGContextFillRect(context, CGRectMake(0, linePosition, offset, self.lineHeight));
           } else if (diffLine.type != kDiffLineType_Context) {
             [GIDiffViewDeletedBackgroundColor setFill];
-            CGContextFillRect(context, CGRectMake(0, linePosition, offset, GIDiffViewLineHeight));
+            CGContextFillRect(context, CGRectMake(0, linePosition, offset, self.lineHeight));
 
             CFRange highlighted = diffLine.leftHighlighted;
             if (highlighted.length) {
               [GIDiffViewDeletedHighlightColor setFill];
               CFRange range = CTLineGetStringRange(leftLine);
-              CGFloat startX = kTextLineNumberMargin + kTextInsetLeft + round(CTLineGetOffsetForStringIndex(leftLine, range.location + highlighted.location, NULL));
-              CGFloat endX = kTextLineNumberMargin + kTextInsetLeft + round(CTLineGetOffsetForStringIndex(leftLine, range.location + highlighted.location + highlighted.length, NULL));
-              CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, GIDiffViewLineHeight));
+              CGFloat startX = lineStartX + round(CTLineGetOffsetForStringIndex(leftLine, range.location + highlighted.location, NULL));
+              CGFloat endX = lineStartX + round(CTLineGetOffsetForStringIndex(leftLine, range.location + highlighted.location + highlighted.length, NULL));
+              CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, self.lineHeight));
             }
           }
         }
         if (rightLine) {
           if (_rightSelection && [_selectedLines containsIndex:diffLine.rightNumber]) {
             [selectedColor setFill];
-            CGContextFillRect(context, CGRectMake(offset, linePosition, bounds.size.width, GIDiffViewLineHeight));
+            CGContextFillRect(context, CGRectMake(offset, linePosition, bounds.size.width, self.lineHeight));
           } else if (diffLine.type != kDiffLineType_Context) {
             [GIDiffViewAddedBackgroundColor setFill];
-            CGContextFillRect(context, CGRectMake(offset, linePosition, bounds.size.width, GIDiffViewLineHeight));
+            CGContextFillRect(context, CGRectMake(offset, linePosition, bounds.size.width, self.lineHeight));
 
             CFRange highlighted = diffLine.rightHighlighted;
             if (highlighted.length) {
               [GIDiffViewAddedHighlightColor setFill];
               CFRange range = CTLineGetStringRange(rightLine);
-              CGFloat startX = offset + kTextLineNumberMargin + kTextInsetLeft + round(CTLineGetOffsetForStringIndex(rightLine, range.location + highlighted.location, NULL));
-              CGFloat endX = offset + kTextLineNumberMargin + kTextInsetLeft + round(CTLineGetOffsetForStringIndex(rightLine, range.location + highlighted.location + highlighted.length, NULL));
-              CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, GIDiffViewLineHeight));
+              CGFloat startX = offset + lineStartX + round(CTLineGetOffsetForStringIndex(rightLine, range.location + highlighted.location, NULL));
+              CGFloat endX = offset + lineStartX + round(CTLineGetOffsetForStringIndex(rightLine, range.location + highlighted.location + highlighted.length, NULL));
+              CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, self.lineHeight));
             }
           }
         }
@@ -395,7 +411,7 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
         if (leftLine) {
           if (!diffLine.leftWrapped) {
             [GIDiffViewLineNumberColor setFill];
-            CFAttributedStringRef string = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)(diffLine.leftNumber >= 100000 ? @"9999…" : [NSString stringWithFormat:@"%5lu", diffLine.leftNumber]), GIDiffViewAttributes);
+            CFAttributedStringRef string = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)(diffLine.leftNumber >= 100000 ? @"9999…" : [NSString stringWithFormat:@"%5lu", diffLine.leftNumber]), self.textAttributes);
             CTLineRef prefix = CTLineCreateWithAttributedString(string);
             CGContextSetTextPosition(context, 5, textPosition);
             CTLineDraw(prefix, context);
@@ -405,25 +421,25 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
 
           if (!_rightSelection && _selectedText.length && (i >= _selectedText.location) && (i < _selectedText.location + _selectedText.length)) {
             [selectedColor setFill];
-            CGFloat startX = kTextLineNumberMargin + kTextInsetLeft;
+            CGFloat startX = lineStartX;
             CGFloat endX = offset;
             if (i == _selectedText.location) {
-              startX = kTextLineNumberMargin + kTextInsetLeft + round(CTLineGetOffsetForStringIndex(leftLine, _selectedTextStart, NULL));
+              startX = lineStartX + round(CTLineGetOffsetForStringIndex(leftLine, _selectedTextStart, NULL));
             }
             if (i == _selectedText.location + _selectedText.length - 1) {
-              endX = kTextLineNumberMargin + kTextInsetLeft + round(CTLineGetOffsetForStringIndex(leftLine, _selectedTextEnd, NULL));
+              endX = lineStartX + round(CTLineGetOffsetForStringIndex(leftLine, _selectedTextEnd, NULL));
             }
-            CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, GIDiffViewLineHeight));
+            CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, self.lineHeight));
           }
 
           [GIDiffViewPlainTextColor set];
-          CGContextSetTextPosition(context, kTextLineNumberMargin + kTextInsetLeft, textPosition);
+          CGContextSetTextPosition(context, lineStartX, textPosition);
           CTLineDraw(leftLine, context);
         }
         if (rightLine) {
           if (!diffLine.rightWrapped) {
             [GIDiffViewLineNumberColor setFill];
-            CFAttributedStringRef string = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)(diffLine.rightNumber >= 100000 ? @"9999…" : [NSString stringWithFormat:@"%5lu", diffLine.rightNumber]), GIDiffViewAttributes);
+            CFAttributedStringRef string = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)(diffLine.rightNumber >= 100000 ? @"9999…" : [NSString stringWithFormat:@"%5lu", diffLine.rightNumber]), self.textAttributes);
             CTLineRef prefix = CTLineCreateWithAttributedString(string);
             CGContextSetTextPosition(context, offset + 5, textPosition);
             CTLineDraw(prefix, context);
@@ -433,19 +449,19 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
 
           if (_rightSelection && _selectedText.length && (i >= _selectedText.location) && (i < _selectedText.location + _selectedText.length)) {
             [selectedColor setFill];
-            CGFloat startX = offset + kTextLineNumberMargin + kTextInsetLeft;
+            CGFloat startX = offset + lineStartX;
             CGFloat endX = bounds.size.width;
             if (i == _selectedText.location) {
-              startX = offset + kTextLineNumberMargin + kTextInsetLeft + round(CTLineGetOffsetForStringIndex(rightLine, _selectedTextStart, NULL));
+              startX = offset + lineStartX + round(CTLineGetOffsetForStringIndex(rightLine, _selectedTextStart, NULL));
             }
             if (i == _selectedText.location + _selectedText.length - 1) {
-              endX = offset + kTextLineNumberMargin + kTextInsetLeft + round(CTLineGetOffsetForStringIndex(rightLine, _selectedTextEnd, NULL));
+              endX = offset + lineStartX + round(CTLineGetOffsetForStringIndex(rightLine, _selectedTextEnd, NULL));
             }
-            CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, GIDiffViewLineHeight));
+            CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, self.lineHeight));
           }
 
           [GIDiffViewPlainTextColor set];
-          CGContextSetTextPosition(context, offset + kTextLineNumberMargin + kTextInsetLeft, textPosition);
+          CGContextSetTextPosition(context, offset + lineStartX, textPosition);
           CTLineDraw(rightLine, context);
         }
       }
@@ -453,14 +469,14 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
   }
 
   [GIDiffViewVerticalLineColor setStroke];
-  CGContextMoveToPoint(context, kTextLineNumberMargin - 0.5, 0);
-  CGContextAddLineToPoint(context, kTextLineNumberMargin - 0.5, bounds.size.height);
+  CGContextMoveToPoint(context, textLineNumberMargin() - 0.5, 0);
+  CGContextAddLineToPoint(context, textLineNumberMargin() - 0.5, bounds.size.height);
   CGContextStrokePath(context);
   CGContextMoveToPoint(context, offset - 0.5, 0);
   CGContextAddLineToPoint(context, offset - 0.5, bounds.size.height);
   CGContextStrokePath(context);
-  CGContextMoveToPoint(context, offset + kTextLineNumberMargin - 0.5, 0);
-  CGContextAddLineToPoint(context, offset + kTextLineNumberMargin - 0.5, bounds.size.height);
+  CGContextMoveToPoint(context, offset + textLineNumberMargin() - 0.5, 0);
+  CGContextAddLineToPoint(context, offset + textLineNumberMargin() - 0.5, bounds.size.height);
   CGContextStrokePath(context);
 
   CGContextRestoreGState(context);
@@ -469,9 +485,10 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
 - (void)resetCursorRects {
   NSRect bounds = self.bounds;
   CGFloat offset = floor(bounds.size.width / 2);
-  [self addCursorRect:NSMakeRect(kTextLineNumberMargin + kTextInsetLeft, 0, offset - kTextLineNumberMargin - kTextInsetLeft, bounds.size.height)
+  CGFloat lineStartX = textLineStartX();
+  [self addCursorRect:NSMakeRect(lineStartX, 0, offset - lineStartX, bounds.size.height)
                cursor:[NSCursor IBeamCursor]];
-  [self addCursorRect:NSMakeRect(offset + kTextLineNumberMargin + kTextInsetLeft, 0, bounds.size.width - offset - kTextLineNumberMargin - kTextInsetLeft, bounds.size.height)
+  [self addCursorRect:NSMakeRect(offset + lineStartX, 0, bounds.size.width - offset - lineStartX, bounds.size.height)
                cursor:[NSCursor IBeamCursor]];
 }
 
@@ -573,7 +590,7 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
   }
 
   // Check if mouse is in the content area
-  NSInteger y = _lines.count - (location.y - kTextBottomPadding) / GIDiffViewLineHeight;
+  NSInteger y = _lines.count - (location.y - kTextBottomPadding) / self.lineHeight;
   if ((y >= 0) && (y < (NSInteger)_lines.count)) {
     GISplitDiffLine* diffLine = _lines[y];
 
@@ -594,8 +611,10 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
       _selectionMode = kSelectionMode_Replace;
     }
 
+    CGFloat lineStartX = textLineStartX();
+
     // Check if mouse is in the margin area
-    if (((location.x >= 0) && (location.x < kTextLineNumberMargin)) || ((location.x >= offset) && (location.x < offset + kTextLineNumberMargin))) {
+    if (((location.x >= 0) && (location.x < textLineNumberMargin())) || ((location.x >= offset) && (location.x < offset + textLineNumberMargin()))) {
       // Reset selection
       _selectedText.length = 0;
       if (_selectionMode == kSelectionMode_Replace) {
@@ -645,14 +664,14 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
 
     }
     // Otherwise check if mouse is is in the diff area
-    else if (((location.x >= kTextLineNumberMargin + kTextInsetLeft) && (location.x < offset)) || (location.x >= offset + kTextLineNumberMargin + kTextInsetLeft)) {
+    else if (((location.x >= lineStartX) && (location.x < offset)) || (location.x >= offset + lineStartX)) {
       // Reset selection
       _selectedText.length = 0;
       [_selectedLines removeAllIndexes];
 
       // Update selected text
       CTLineRef line = _rightSelection ? diffLine.rightLine : diffLine.leftLine;
-      CFIndex index = CTLineGetStringIndexForPosition(line, CGPointMake(location.x - ((_rightSelection ? offset : 0) + kTextLineNumberMargin + kTextInsetLeft), GIDiffViewLineHeight / 2));
+      CFIndex index = CTLineGetStringIndexForPosition(line, CGPointMake(location.x - ((_rightSelection ? offset : 0) + lineStartX), self.lineHeight / 2));
       if (index != kCFNotFound) {
         _startIndex = y;
         _startOffset = index;
@@ -697,7 +716,7 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
   NSPoint location = [self convertPoint:event.locationInWindow fromView:nil];
 
   // Check if mouse is in the content area
-  NSInteger y = _lines.count - (location.y - kTextBottomPadding) / GIDiffViewLineHeight;
+  NSInteger y = _lines.count - (location.y - kTextBottomPadding) / self.lineHeight;
   if ((y >= 0) && (y < (NSInteger)_lines.count)) {
     GISplitDiffLine* diffLine = _lines[y];
 
@@ -745,7 +764,7 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
     // Otherwise we are in text-selection mode
     else {
       CTLineRef line = _rightSelection ? diffLine.rightLine : diffLine.leftLine;
-      CFIndex index = CTLineGetStringIndexForPosition(line, CGPointMake(location.x - ((_rightSelection ? offset : 0) + kTextLineNumberMargin + kTextInsetLeft), GIDiffViewLineHeight / 2));
+      CFIndex index = CTLineGetStringIndexForPosition(line, CGPointMake(location.x - ((_rightSelection ? offset : 0) + textLineStartX()), self.lineHeight / 2));
       if (index != kCFNotFound) {
         // Update selected text
         if ((NSUInteger)y > _startIndex) {

--- a/GitUpKit/Interface/GIUnifiedDiffView.m
+++ b/GitUpKit/Interface/GIUnifiedDiffView.m
@@ -18,11 +18,25 @@
 #endif
 
 #import "GIPrivate.h"
+#import "GIAppKit.h"
 
-#define kTextLineNumberMargin (5 * 8)
-#define kTextInsetLeft 15
-#define kTextInsetRight 5
 #define kTextBottomPadding 0
+
+static CGFloat textLineNumberMargin(void) {
+  return roundf(4 * GIFontSize());
+}
+
+static CGFloat textInsetLeft(void) {
+  return roundf(1.5f * GIFontSize());
+}
+
+static CGFloat textInsetRight(void) {
+  return roundf(0.5f * GIFontSize());
+}
+
+static CGFloat textLineStartX(void) {
+  return 2 * textLineNumberMargin() + textInsetLeft();
+}
 
 typedef NS_ENUM(NSUInteger, SelectionMode) {
   kSelectionMode_None = 0,
@@ -200,20 +214,22 @@ typedef struct {
 }
 
 - (CGFloat)updateLayoutForWidth:(CGFloat)width {
-  if (_string && (NSInteger)width != (NSInteger)_size.width) {
+  if (_string &&
+      ((NSInteger)width != (NSInteger)_size.width ||
+       (CFAttributedStringGetLength(_string) > 0 && !CFEqual(CFAttributedStringGetAttributes(_string, 0, NULL), self.textAttributes)))) {
     if (_frame) {
       CFRelease(_frame);
     }
     if (_framesetter) {
       CFRelease(_framesetter);
     }
-    CFAttributedStringSetAttributes(_string, CFRangeMake(0, CFAttributedStringGetLength(_string)), GIDiffViewAttributes, false);
+    CFAttributedStringSetAttributes(_string, CFRangeMake(0, CFAttributedStringGetLength(_string)), self.textAttributes, false);
     _framesetter = CTFramesetterCreateWithAttributedString(_string);
-    CGFloat textWidth = width - 2 * kTextLineNumberMargin - kTextInsetLeft - kTextInsetRight;
+    CGFloat textWidth = width - 2 * textLineNumberMargin() - textInsetLeft() - textInsetRight();
     CGPathRef path = CGPathCreateWithRect(CGRectMake(0, 0, textWidth, CGFLOAT_MAX), NULL);
     _frame = CTFramesetterCreateFrame(_framesetter, CFRangeMake(0, CFAttributedStringGetLength(_string)), path, NULL);
     CGPathRelease(path);
-    _size = NSMakeSize(width, CFArrayGetCount(CTFrameGetLines(_frame)) * GIDiffViewLineHeight + kTextBottomPadding);
+    _size = NSMakeSize(width, CFArrayGetCount(CTFrameGetLines(_frame)) * self.lineHeight + kTextBottomPadding);
   }
   return _size.height;
 }
@@ -245,19 +261,22 @@ typedef struct {
   [self.backgroundColor setFill];
   CGContextFillRect(context, dirtyRect);
 
+  CGFloat lineNumberMargin = textLineNumberMargin();
+  CGFloat lineStartX = textLineStartX();
+
   if (_frame) {
     NSColor* selectedColor = self.window.keyWindow && (self.window.firstResponder == self) ? [NSColor selectedControlColor] : [NSColor secondarySelectedControlColor];
     CGContextSetTextMatrix(context, CGAffineTransformIdentity);
     CFArrayRef lines = CTFrameGetLines(_frame);
     CFIndex count = CFArrayGetCount(lines);
-    CFIndex start = MIN(MAX(count - (dirtyRect.origin.y + dirtyRect.size.height - kTextBottomPadding) / GIDiffViewLineHeight, 0), count);
-    CFIndex end = MIN(MAX(count - (dirtyRect.origin.y - kTextBottomPadding) / GIDiffViewLineHeight + 1, 0), count);
+    CFIndex start = MIN(MAX(count - (dirtyRect.origin.y + dirtyRect.size.height - kTextBottomPadding) / self.lineHeight, 0), count);
+    CFIndex end = MIN(MAX(count - (dirtyRect.origin.y - kTextBottomPadding) / self.lineHeight + 1, 0), count);
     const LineInfo* info = NULL;
     for (CFIndex i = start; i < end; ++i) {
       CTLineRef line = CFArrayGetValueAtIndex(lines, i);
       CFRange lineRange = CTLineGetStringRange(line);
-      CGFloat linePosition = (count - 1 - i) * GIDiffViewLineHeight + kTextBottomPadding;
-      CGFloat textPosition = linePosition + GIDiffViewLineDescent;
+      CGFloat linePosition = (count - 1 - i) * self.lineHeight + kTextBottomPadding;
+      CGFloat textPosition = linePosition + self.lineDescent;
 
       if (info) {
         while (lineRange.location >= info->range.location + info->range.length) {
@@ -274,14 +293,14 @@ typedef struct {
       if ((NSUInteger)info->change != NSNotFound) {
         if ([_selectedLines containsIndex:info->index]) {
           [selectedColor setFill];
-          CGContextFillRect(context, CGRectMake(0, linePosition, bounds.size.width, GIDiffViewLineHeight));
+          CGContextFillRect(context, CGRectMake(0, linePosition, bounds.size.width, self.lineHeight));
         } else if (info->change != kGCLineDiffChange_Unmodified) {
           if (info->change == kGCLineDiffChange_Deleted) {
             [GIDiffViewDeletedBackgroundColor setFill];
           } else {
             [GIDiffViewAddedBackgroundColor setFill];
           }
-          CGContextFillRect(context, CGRectMake(0, linePosition, bounds.size.width, GIDiffViewLineHeight));
+          CGContextFillRect(context, CGRectMake(0, linePosition, bounds.size.width, self.lineHeight));
 
           if (info->highlighted.length) {
             if (info->change == kGCLineDiffChange_Deleted) {
@@ -292,82 +311,86 @@ typedef struct {
             CGFloat startX = CTLineGetOffsetForStringIndex(line, info->range.location + info->highlighted.location, NULL);
             CGFloat endX = CTLineGetOffsetForStringIndex(line, info->range.location + info->highlighted.location + info->highlighted.length, NULL);
             if (endX > startX) {
-              startX = 2 * kTextLineNumberMargin + kTextInsetLeft + round(startX);
-              endX = 2 * kTextLineNumberMargin + kTextInsetLeft + round(endX);
-              CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, GIDiffViewLineHeight));
+              startX = lineStartX + round(startX);
+              endX = lineStartX + round(endX);
+              CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, self.lineHeight));
             }
           }
         }
 
+        CGFloat lineNumberTextInset = roundf(0.5f * GIFontSize());
+        CGFloat plusMinusInset = roundf(0.4f * GIFontSize());
+
         [GIDiffViewLineNumberColor setFill];
         if ((lineRange.location == info->range.location) && (info->oldLineNumber != NSNotFound)) {
-          CFAttributedStringRef string = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)(info->oldLineNumber >= 100000 ? @"9999…" : [NSString stringWithFormat:@"%5lu", info->oldLineNumber]), GIDiffViewAttributes);
+          CFAttributedStringRef string = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)(info->oldLineNumber >= 100000 ? @"9999…" : [NSString stringWithFormat:@"%5lu", info->oldLineNumber]), self.textAttributes);
           CTLineRef prefix = CTLineCreateWithAttributedString(string);
-          CGContextSetTextPosition(context, 5, textPosition);
+          CGContextSetTextPosition(context, lineNumberTextInset, textPosition);
           CTLineDraw(prefix, context);
           CFRelease(prefix);
           CFRelease(string);
 
           if (info->change == kGCLineDiffChange_Deleted) {
-            CGContextSetTextPosition(context, 2 * kTextLineNumberMargin + 4, textPosition);
-            CTLineDraw(GIDiffViewDeletedLine, context);
+            CGContextSetTextPosition(context, 2 * lineNumberMargin + plusMinusInset, textPosition);
+            CTLineDraw(self.deletedLine, context);
           }
         }
         if ((lineRange.location == info->range.location) && (info->newLineNumber != NSNotFound)) {
-          CFAttributedStringRef string = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)(info->newLineNumber >= 100000 ? @"9999…" : [NSString stringWithFormat:@"%5lu", info->newLineNumber]), GIDiffViewAttributes);
+          CFAttributedStringRef string = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)(info->newLineNumber >= 100000 ? @"9999…" : [NSString stringWithFormat:@"%5lu", info->newLineNumber]), self.textAttributes);
           CTLineRef prefix = CTLineCreateWithAttributedString(string);
-          CGContextSetTextPosition(context, kTextLineNumberMargin + 5, textPosition);
+          CGContextSetTextPosition(context, lineNumberMargin + lineNumberTextInset, textPosition);
           CTLineDraw(prefix, context);
           CFRelease(prefix);
           CFRelease(string);
 
           if (info->change == kGCLineDiffChange_Added) {
-            CGContextSetTextPosition(context, 2 * kTextLineNumberMargin + 4, textPosition);
-            CTLineDraw(GIDiffViewAddedLine, context);
+            CGContextSetTextPosition(context, 2 * lineNumberMargin + plusMinusInset, textPosition);
+            CTLineDraw(self.addedLine, context);
           }
         }
 
         if (_selectedText.length && (_selectedText.location < lineRange.location + lineRange.length) && (_selectedText.location + _selectedText.length > lineRange.location)) {
           [selectedColor setFill];
-          CGFloat startX = 2 * kTextLineNumberMargin + kTextInsetLeft;
+          CGFloat startX = lineStartX;
           CGFloat endX = bounds.size.width;
           if (_selectedText.location > lineRange.location) {
-            startX = 2 * kTextLineNumberMargin + kTextInsetLeft + round(CTLineGetOffsetForStringIndex(line, _selectedText.location, NULL));
+            startX = lineStartX + round(CTLineGetOffsetForStringIndex(line, _selectedText.location, NULL));
           }
           if (_selectedText.location + _selectedText.length < lineRange.location + lineRange.length) {
-            endX = 2 * kTextLineNumberMargin + kTextInsetLeft + round(CTLineGetOffsetForStringIndex(line, _selectedText.location + _selectedText.length, NULL));
+            endX = lineStartX + round(CTLineGetOffsetForStringIndex(line, _selectedText.location + _selectedText.length, NULL));
           }
-          CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, GIDiffViewLineHeight));
+          CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, self.lineHeight));
         }
 
         [GIDiffViewPlainTextColor set];
-        CGContextSetTextPosition(context, 2 * kTextLineNumberMargin + kTextInsetLeft, textPosition);
+        CGContextSetTextPosition(context, lineStartX, textPosition);
         CTLineDraw(line, context);
       } else {
         [GIDiffViewSeparatorBackgroundColor setFill];
-        CGContextFillRect(context, CGRectMake(0, linePosition + 1, bounds.size.width, GIDiffViewLineHeight - 1));
+        CGContextFillRect(context, CGRectMake(0, linePosition + 1, bounds.size.width, self.lineHeight - 1));
 
         [GIDiffViewSeparatorLineColor setStroke];
         CGContextMoveToPoint(context, 0, linePosition + 0.5);
         CGContextAddLineToPoint(context, bounds.size.width, linePosition + 0.5);
         CGContextStrokePath(context);
-        CGContextMoveToPoint(context, 0, linePosition + GIDiffViewLineHeight - 0.5);
-        CGContextAddLineToPoint(context, bounds.size.width, linePosition + GIDiffViewLineHeight - 0.5);
+        CGContextMoveToPoint(context, 0, linePosition + self.lineHeight - 0.5);
+        CGContextAddLineToPoint(context, bounds.size.width, linePosition + self.lineHeight - 0.5);
         CGContextStrokePath(context);
 
         [GIDiffViewSeparatorTextColor setFill];
-        CGContextSetTextPosition(context, 2 * kTextLineNumberMargin + 4, textPosition);
+        CGContextSetTextPosition(context, 2 * lineNumberMargin + roundf(0.4f * GIFontSize()), textPosition);
         CTLineDraw(line, context);
       }
     }
   }
 
   [GIDiffViewVerticalLineColor setStroke];
-  CGContextMoveToPoint(context, kTextLineNumberMargin - 0.5, 0);
-  CGContextAddLineToPoint(context, kTextLineNumberMargin - 0.5, bounds.size.height);
+  CGFloat lineHorizontalPosition = lineNumberMargin - 0.5;
+  CGContextMoveToPoint(context, lineHorizontalPosition, 0);
+  CGContextAddLineToPoint(context, lineHorizontalPosition, bounds.size.height);
   CGContextStrokePath(context);
-  CGContextMoveToPoint(context, 2 * kTextLineNumberMargin - 0.5, 0);
-  CGContextAddLineToPoint(context, 2 * kTextLineNumberMargin - 0.5, bounds.size.height);
+  CGContextMoveToPoint(context, 2 * lineHorizontalPosition, 0);
+  CGContextAddLineToPoint(context, 2 * lineHorizontalPosition, bounds.size.height);
   CGContextStrokePath(context);
 
   CGContextRestoreGState(context);
@@ -375,7 +398,8 @@ typedef struct {
 
 - (void)resetCursorRects {
   NSRect bounds = self.bounds;
-  [self addCursorRect:NSMakeRect(2 * kTextLineNumberMargin + kTextInsetLeft, 0, bounds.size.width - 2 * kTextLineNumberMargin - kTextInsetLeft, bounds.size.height)
+  CGFloat lineNumberMargin = textLineNumberMargin();
+  [self addCursorRect:NSMakeRect(textLineStartX(), 0, bounds.size.width - 2 * lineNumberMargin - textInsetLeft(), bounds.size.height)
                cursor:[NSCursor IBeamCursor]];
 }
 
@@ -452,7 +476,7 @@ typedef struct {
 
   // Check if mouse is in the content area
   CFArrayRef lines = CTFrameGetLines(_frame);
-  CFIndex index = CFArrayGetCount(lines) - (location.y - kTextBottomPadding) / GIDiffViewLineHeight;
+  CFIndex index = CFArrayGetCount(lines) - (location.y - kTextBottomPadding) / self.lineHeight;
   if ((index >= 0) && (index < CFArrayGetCount(lines))) {
     CTLineRef line = CFArrayGetValueAtIndex(lines, index);
 
@@ -465,8 +489,10 @@ typedef struct {
       _selectionMode = kSelectionMode_Replace;
     }
 
+    CGFloat lineNumberMargin = textLineNumberMargin();
+
     // Check if mouse is in the margin area
-    if (location.x < 2 * kTextLineNumberMargin) {
+    if (location.x < 2 * lineNumberMargin) {
       // Reset selection
       _selectedText.length = 0;
       if (_selectionMode == kSelectionMode_Replace) {
@@ -516,13 +542,13 @@ typedef struct {
 
     }
     // Otherwise check if mouse is is in the diff area
-    else if (location.x >= 2 * kTextLineNumberMargin + kTextInsetLeft) {
+    else if (location.x >= textLineStartX()) {
       // Reset selection
       _selectedText.length = 0;
       [_selectedLines removeAllIndexes];
 
       // Update selected text
-      index = CTLineGetStringIndexForPosition(line, CGPointMake(location.x - (2 * kTextLineNumberMargin + kTextInsetLeft), GIDiffViewLineHeight / 2));
+      index = CTLineGetStringIndexForPosition(line, CGPointMake(location.x - (textLineStartX()), self.lineHeight / 2));
       if (index != kCFNotFound) {
         _deletedIndex = index;
         if (event.clickCount > 1) {
@@ -562,7 +588,7 @@ typedef struct {
 
   // Check if mouse is in the content area
   CFArrayRef lines = CTFrameGetLines(_frame);
-  CFIndex index = CFArrayGetCount(lines) - (location.y - kTextBottomPadding) / GIDiffViewLineHeight;
+  CFIndex index = CFArrayGetCount(lines) - (location.y - kTextBottomPadding) / self.lineHeight;
   if ((index >= 0) && (index < CFArrayGetCount(lines))) {
     CTLineRef line = CFArrayGetValueAtIndex(lines, index);
 
@@ -607,7 +633,7 @@ typedef struct {
     }
     // Otherwise we are in text-selection mode
     else {
-      index = CTLineGetStringIndexForPosition(line, CGPointMake(location.x - (2 * kTextLineNumberMargin + kTextInsetLeft), GIDiffViewLineHeight / 2));
+      index = CTLineGetStringIndexForPosition(line, CGPointMake(location.x - (textLineStartX()), self.lineHeight / 2));
       if (index != kCFNotFound) {
         // Update selected text
         if (index > (CFIndex)_deletedIndex) {

--- a/GitUpKit/Utilities/GIAppKit.h
+++ b/GitUpKit/Utilities/GIAppKit.h
@@ -25,6 +25,11 @@ typedef NS_ENUM(NSUInteger, GIAlertType) {
 extern NSString* const GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters;
 extern NSString* const GICommitMessageViewUserDefaultKey_ShowMargins;
 extern NSString* const GICommitMessageViewUserDefaultKey_EnableSpellChecking;
+extern NSString* const GIUserDefaultKey_FontSize;  // NSNumber. Base font size for user interface text. Read this with GIFontSize() to always get a valid value.
+
+extern CGFloat const GIDefaultFontSize;
+
+FOUNDATION_EXPORT CGFloat GIFontSize(void);  // Reads GIUserDefaultKey_FontSize, falling back to GIDefaultFontSize if the user defaults value is not usable.
 
 @interface NSMutableAttributedString (GIAppKit)
 - (void)appendString:(NSString*)string withAttributes:(NSDictionary*)attributes;

--- a/GitUpKit/Utilities/GIAppKit.m
+++ b/GitUpKit/Utilities/GIAppKit.m
@@ -33,6 +33,14 @@
 NSString* const GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters = @"GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters";
 NSString* const GICommitMessageViewUserDefaultKey_ShowMargins = @"GICommitMessageViewUserDefaultKey_ShowMargins";
 NSString* const GICommitMessageViewUserDefaultKey_EnableSpellChecking = @"GICommitMessageViewUserDefaultKey_EnableSpellChecking";
+NSString* const GIUserDefaultKey_FontSize = @"GIUserDefaultKey_FontSize";
+
+CGFloat const GIDefaultFontSize = 10;
+
+CGFloat GIFontSize(void) {
+  CGFloat size = [[NSUserDefaults standardUserDefaults] floatForKey:GIUserDefaultKey_FontSize];
+  return size > 0 ? size : GIDefaultFontSize;
+}
 
 static const void* _associatedObjectCommitKey = &_associatedObjectCommitKey;
 static NSColor* _separatorColor = nil;

--- a/GitUpKit/Utilities/GIAppKit.m
+++ b/GitUpKit/Utilities/GIAppKit.m
@@ -161,6 +161,7 @@ static NSColor* _separatorColor = nil;
 @implementation GICommitMessageView
 
 - (void)dealloc {
+  [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:GIUserDefaultKey_FontSize context:(__bridge void*)[GICommitMessageView class]];
   [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:GICommitMessageViewUserDefaultKey_EnableSpellChecking context:(__bridge void*)[GICommitMessageView class]];
   [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:GICommitMessageViewUserDefaultKey_ShowMargins context:(__bridge void*)[GICommitMessageView class]];
   [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters context:(__bridge void*)[GICommitMessageView class]];
@@ -169,7 +170,7 @@ static NSColor* _separatorColor = nil;
 - (void)awakeFromNib {
   [super awakeFromNib];
 
-  self.font = [NSFont userFixedPitchFontOfSize:11];
+  [self updateFont];
   self.continuousSpellCheckingEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:GICommitMessageViewUserDefaultKey_EnableSpellChecking];
   self.automaticSpellingCorrectionEnabled = NO;  // Don't trust IB
   self.grammarCheckingEnabled = NO;  // Don't trust IB
@@ -184,6 +185,13 @@ static NSColor* _separatorColor = nil;
   [[NSUserDefaults standardUserDefaults] addObserver:self forKeyPath:GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters options:0 context:(__bridge void*)[GICommitMessageView class]];
   [[NSUserDefaults standardUserDefaults] addObserver:self forKeyPath:GICommitMessageViewUserDefaultKey_ShowMargins options:0 context:(__bridge void*)[GICommitMessageView class]];
   [[NSUserDefaults standardUserDefaults] addObserver:self forKeyPath:GICommitMessageViewUserDefaultKey_EnableSpellChecking options:0 context:(__bridge void*)[GICommitMessageView class]];
+  [[NSUserDefaults standardUserDefaults] addObserver:self forKeyPath:GIUserDefaultKey_FontSize options:0 context:(__bridge void*)[GICommitMessageView class]];
+}
+
+- (void)updateFont {
+  // To match the original design, the commit message font should be 10% larger than the diff view font.
+  self.font = [NSFont userFixedPitchFontOfSize:roundf(1.1 * GIFontSize())];
+  [self setNeedsDisplay:YES];
 }
 
 - (void)drawRect:(NSRect)dirtyRect {
@@ -233,6 +241,8 @@ static NSColor* _separatorColor = nil;
         self.continuousSpellCheckingEnabled = flag;
         [self setNeedsDisplay:YES];  // TODO: Why is this needed to refresh?
       }
+    } else if ([keyPath isEqualToString:GIUserDefaultKey_FontSize]) {
+      [self updateFont];
     } else {
       XLOG_DEBUG_UNREACHABLE();
     }


### PR DESCRIPTION
I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT

This branch adds a slider to let users change the font size of the diff and commit message views.

<img width="612" alt="prefs" src="https://cloud.githubusercontent.com/assets/2149061/23335702/2110c212-fbbb-11e6-8e7f-d33c2ce05b88.png">

![size changes](https://cloud.githubusercontent.com/assets/2149061/23335703/21407fc0-fbbb-11e6-8555-9de7f9d51569.gif)

This addresses the font size requests in the comments of https://github.com/git-up/GitUp/issues/87 — but not changing the typeface itself which is what the original comment is about. See also the alternative PR https://github.com/git-up/GitUp/pull/265 while adds very similar functionality, including changing the typeface. I’m making this pull request because I think my branch has some advantages over other the other PR.

## Design goals

Users should be able to control how large text on computers because software authors can’t know in advance what size would be most comfortable for the user to read due to factors such as visual impairments, screen pixel density and the distance between the screen and the user.

This branch aims to lay a flexible foundation for allowing any part of GitUp to be scalable, and implements scalability in the diff and commit edit views, because I think these are the two views where readability is most important. Using the same scaling in other views is open as possible future work.

Letting the user specify a scale but the application specify the typefaces and relative sizes seems like the best trade-off between allowing the user to see the app comfortably without asking them to be the designer. Also different views have use different fonts and relative sizes. Therefore, the user does not set an explicit typeface name or numerical size and instead a slider without value labels has been added to General Preferences to set the scale. This (deliberately) results in the exact size used being hard to find.

The scale factor is stored in user defaults and this value happens to match the font size of the diff view. Users with unusual requirements for especially large (or small) text can set this to any value using the `defaults` tool.

## Implementation notes

One limitation of storing the font size in the standard user defaults is that this is global state so an app using GitUpKit that wants to show two diff views at the same time would not be able to make them use different font sizes. I don’t think this use case is particularly important.

As a framework, GitUpKit should not register default values in user defaults, and it can’t guarantee that the app using GitUpKit registers a sensible default for this key. Therefore I made GitUpKit always read the font size from user defaults wrapped in a `GIFontSize()` function which ensures the value is greater than zero.

I put the `GIFontSize` function in `GIAppKit.h/m` because that’s where other GitUpKit user defaults keys are defined. I didn’t think this fits in in `GIFunctions` because it’s only available in the Mac version of GitUpKit. Putting it in `GIFunctions` wrapped in `#if __GI_HAS_APPKIT__` would work too but makes less sense to me.

I thought it would be messy to do the `#ifdef __cplusplus` like in `GIFunctions` for this one function, so I used `FOUNDATION_EXPORT`. (My preferred way to do this would be to drop the `#ifdef __cplusplus` from `GIFunctions` and define a `GIEXPORT` used for every public function.)

Naming of the user defaults key: I mirrored `GICommitMessageViewUserDefaultKey_ShowMargins` but removed the `CommitMessageView` part because this one is more general.

I decided to store the most obvious thing in user defaults: the font size used in the diff view in points. This simplicity comes at the cost of making the slider in preferences more complicated as a linear slider would not be very good: the difference between 10 and 11 points is much more important than the difference between 18 and 19 points. A value transformer is used to map between the discrete slider value and a non-linear array of font sizes that match the preset sizes in the Mac system font picker.