### PR TITLE
Avoid using exchangedata entirely

### DIFF
--- a/GitUpKit/Core/GCIndex.m
+++ b/GitUpKit/Core/GCIndex.m
@@ -581,8 +581,8 @@ cleanup:
   copyfile_state_free(state);
   CHECK_POSIX_FUNCTION_CALL(goto cleanup, status, == 0);
 
-  // Swap temporary copy and original file
-  CALL_POSIX_FUNCTION_GOTO(cleanup, exchangedata, fullPath, tempPath, FSOPT_NOFOLLOW);
+  // Move temporary copy.
+  CALL_POSIX_FUNCTION_GOTO(cleanup, rename, tempPath, fullPath);
   CALL_POSIX_FUNCTION_GOTO(cleanup, utimes, fullPath, NULL);  // Touch file to make sure any cached information in the index gets invalidated
 
   success = YES;

--- a/GitUpKit/Core/GCLiveRepository.m
+++ b/GitUpKit/Core/GCLiveRepository.m
@@ -498,21 +498,10 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
   BOOL success = NO;
   NSString* path = [self.privateAppDirectoryPath stringByAppendingPathComponent:kSnapshotsFileName];
   if (path) {
-    NSString* tempPath = [path stringByAppendingString:@"~"];
-    if ([NSKeyedArchiver archiveRootObject:_snapshots toFile:tempPath]) {
-      struct stat info;
-      if (lstat(path.fileSystemRepresentation, &info) == 0) {
-        if (exchangedata(tempPath.fileSystemRepresentation, path.fileSystemRepresentation, FSOPT_NOFOLLOW) == 0) {
-          success = YES;
-        }
-      } else {
-        if (rename(tempPath.fileSystemRepresentation, path.fileSystemRepresentation) == 0) {
-          success = YES;
-        }
-      }
-      if (!success) {
-        XLOG_ERROR(@"Failed archiving snapshots: %s", strerror(errno));
-      }
+    NSError* error = nil;
+    success = [[NSKeyedArchiver archivedDataWithRootObject:_snapshots] writeToFile:path options:NSDataWritingAtomic error:&error];
+    if (!success) {
+      XLOG_ERROR(@"Failed archiving snapshots: %@", error);
     }
   }
   if (!success && [self.delegate respondsToSelector:@selector(repository:snapshotsUpdateDidFailWithError:)]) {


### PR DESCRIPTION
Alternative to #320. Would also close #144.

Fully atomic filesystem operations aren't worth the overhead in added complexity in checking for filesystem capabilities, now with APFS superseding atomic content replacement with atomic renaming; using a temporary file and moving into place practically works around any conflicts that may arise.

As far as using the non-streaming `NSKeyedArchiver`, I've opened a few large repos of mine and I haven't noticed any problems. I could be talked into using `NSFileManager` to do the move instead.