### PR TITLE
Check if volume supports exchangedata before use

### DIFF
--- a/GitUpKit/Core/GCFunctions.h
+++ b/GitUpKit/Core/GCFunctions.h
@@ -39,6 +39,8 @@ NSString* GCFileSystemPathFromGitPath(const char* string);
 NSURL* GCURLFromGitURL(NSString* url);
 NSString* GCGitURLFromURL(NSURL* url);
 
+int GCExchangeFileData(const char* path1, const char* path2);
+
 void GCArrayApplyBlock(CFArrayRef array, void (^block)(const void* value));
 void GCSetApplyBlock(CFSetRef set, void (^block)(const void* value));
 void GCDictionaryApplyBlock(CFDictionaryRef dict, void (^block)(const void* key, const void* value));

--- a/GitUpKit/Core/GCFunctions.m
+++ b/GitUpKit/Core/GCFunctions.m
@@ -19,6 +19,10 @@
 
 #import "GCPrivate.h"
 
+#import <sys/stat.h>
+#import <sys/attr.h>
+#import <sys/mount.h>
+
 NSString* const GCErrorDomain = @"GCErrorDomain";
 
 NSError* GCNewError(NSInteger code, NSString* message) {
@@ -130,6 +134,25 @@ NSString* GCGitURLFromURL(NSURL* url) {
   }
   return url.absoluteString;
 }
+
+int GCExchangeFileData(const char* path1, const char* path2) {
+  struct statfs stat;
+  int statStatus = statfs(path2, &stat);
+  if (statStatus != 0) {
+    return statStatus;
+  }
+  struct attrlist attrList = { ATTR_BIT_MAP_COUNT, 0, 0, ATTR_VOL_CAPABILITIES, 0, 0, 0 };
+  struct { u_int32_t length; vol_capabilities_attr_t attr; } attrBuf;
+  int attrListStatus = getattrlist(stat.f_mntonname, &attrList, &attrBuf, sizeof(attrBuf), 0);
+  if (attrListStatus != 0) {
+    return attrListStatus;
+  }
+  if ((attrBuf.attr.capabilities[VOL_CAPABILITIES_INTERFACES] & VOL_CAP_INT_EXCHANGEDATA) == VOL_CAP_INT_EXCHANGEDATA) {
+    return exchangedata(path1, path2, FSOPT_NOFOLLOW);
+  } else {
+    return rename(path1, path2);
+  }
+};
 
 GCFileMode GCFileModeFromMode(git_filemode_t mode) {
   switch (mode) {

--- a/GitUpKit/Core/GCIndex.m
+++ b/GitUpKit/Core/GCIndex.m
@@ -577,12 +577,13 @@ cleanup:
 
   // Copy file metadata onto the temporary copy
   copyfile_state_t state = copyfile_state_alloc();
-  int status = copyfile(fullPath, tempPath, state, COPYFILE_METADATA);
+  int copyStatus = copyfile(fullPath, tempPath, state, COPYFILE_METADATA);
   copyfile_state_free(state);
-  CHECK_POSIX_FUNCTION_CALL(goto cleanup, status, == 0);
+  CHECK_POSIX_FUNCTION_CALL(goto cleanup, copyStatus, == 0);
 
   // Swap temporary copy and original file
-  CALL_POSIX_FUNCTION_GOTO(cleanup, exchangedata, fullPath, tempPath, FSOPT_NOFOLLOW);
+  int exchangeStatus = GCExchangeFileData(tempPath, fullPath);
+  CHECK_POSIX_FUNCTION_CALL(goto cleanup, exchangeStatus, == 0);
   CALL_POSIX_FUNCTION_GOTO(cleanup, utimes, fullPath, NULL);  // Touch file to make sure any cached information in the index gets invalidated
 
   success = YES;

--- a/GitUpKit/Core/GCLiveRepository.m
+++ b/GitUpKit/Core/GCLiveRepository.m
@@ -500,15 +500,10 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
   if (path) {
     NSString* tempPath = [path stringByAppendingString:@"~"];
     if ([NSKeyedArchiver archiveRootObject:_snapshots toFile:tempPath]) {
-      struct stat info;
-      if (lstat(path.fileSystemRepresentation, &info) == 0) {
-        if (exchangedata(tempPath.fileSystemRepresentation, path.fileSystemRepresentation, FSOPT_NOFOLLOW) == 0) {
-          success = YES;
-        }
-      } else {
-        if (rename(tempPath.fileSystemRepresentation, path.fileSystemRepresentation) == 0) {
-          success = YES;
-        }
+      if (GCExchangeFileData(tempPath.fileSystemRepresentation, path.fileSystemRepresentation) == 0) {
+        success = YES;
+      } else if (rename(tempPath.fileSystemRepresentation, path.fileSystemRepresentation) == 0) {
+        success = YES;
       }
       if (!success) {
         XLOG_ERROR(@"Failed archiving snapshots: %s", strerror(errno));


### PR DESCRIPTION
This fixes incompatibility with APFS. As suggested in #320, I extracted a C function. If you’d like to see anything else changed, let me know.

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT.