### PR TITLE
Fixed snapshots on APFS

### DIFF
--- a/GitUpKit/Core/GCFoundation.h
+++ b/GitUpKit/Core/GCFoundation.h
@@ -18,6 +18,8 @@
 @interface NSFileManager (GCFoundation)
 - (BOOL)fileExistsAtPath:(NSString*)path followLastSymlink:(BOOL)followLastSymlink;
 
+- (BOOL)swapFileAtPath:(NSString*)path1 withFileAtPath:(NSString*)path2;
+
 #if !TARGET_OS_IPHONE
 
 - (BOOL)moveItemAtPathToTrash:(NSString*)path error:(NSError**)error;

--- a/GitUpKit/Core/GCFoundation.m
+++ b/GitUpKit/Core/GCFoundation.m
@@ -17,6 +17,7 @@
 #error This file requires ARC
 #endif
 
+#import <sys/attr.h>
 #import "GCPrivate.h"
 
 @implementation NSFileManager (GCFoundation)
@@ -34,6 +35,22 @@
   }
 
   return pathAttributes != nil;
+}
+
+
+- (BOOL)swapFileAtPath:(NSString*)path1 withFileAtPath:(NSString*)path2
+{
+  NSNumber *swappingSupported = @NO;
+  if (NSURLVolumeSupportsSwapRenamingKey) {
+    [[NSURL fileURLWithPath:path1] getResourceValue:&swappingSupported
+                                             forKey:NSURLVolumeSupportsSwapRenamingKey
+                                              error:NULL];
+  }
+  if (swappingSupported.boolValue) {
+    return renamex_np(path1.fileSystemRepresentation, path2.fileSystemRepresentation, RENAME_SWAP) == 0;
+  } else {
+    return exchangedata(path1.fileSystemRepresentation, path2.fileSystemRepresentation, FSOPT_NOFOLLOW) == 0;
+  }
 }
 
 #if !TARGET_OS_IPHONE

--- a/GitUpKit/Core/GCIndex.m
+++ b/GitUpKit/Core/GCIndex.m
@@ -582,7 +582,9 @@ cleanup:
   CHECK_POSIX_FUNCTION_CALL(goto cleanup, status, == 0);
 
   // Swap temporary copy and original file
-  CALL_POSIX_FUNCTION_GOTO(cleanup, exchangedata, fullPath, tempPath, FSOPT_NOFOLLOW);
+  if (![[NSFileManager defaultManager] swapFileAtPath:@(fullPath) withFileAtPath:@(tempPath)]) {
+    goto cleanup;
+  }
   CALL_POSIX_FUNCTION_GOTO(cleanup, utimes, fullPath, NULL);  // Touch file to make sure any cached information in the index gets invalidated
 
   success = YES;

--- a/GitUpKit/Core/GCLiveRepository.m
+++ b/GitUpKit/Core/GCLiveRepository.m
@@ -502,7 +502,7 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
     if ([NSKeyedArchiver archiveRootObject:_snapshots toFile:tempPath]) {
       struct stat info;
       if (lstat(path.fileSystemRepresentation, &info) == 0) {
-        if (exchangedata(tempPath.fileSystemRepresentation, path.fileSystemRepresentation, FSOPT_NOFOLLOW) == 0) {
+        if ([[NSFileManager defaultManager] swapFileAtPath:tempPath withFileAtPath:path]) {
           success = YES;
         }
       } else {


### PR DESCRIPTION
This changes swapping to use `renamex_np` with `RENAME_SWAP` if available, otherwise falling back to `exchangedata`. I don't have a pre-sierra, nor one with an HFS+ volume to test on. So this has only been tested using High Sierra & APFS.