### PR TITLE
Fixed an issue where escape key didn’t dismiss modal views when overlays or sidebars were visible

### DIFF
--- a/GitUpKit/Utilities/GIWindowController.m
+++ b/GitUpKit/Utilities/GIWindowController.m
@@ -135,7 +135,10 @@ static void _WalkViewTree(NSView* view, NSMutableArray* array) {
 }
 
 - (void)sendEvent:(NSEvent*)event {
-  if ((event.type == NSKeyDown) && (event.keyCode == kGIKeyCode_Esc) && self.windowController.overlayVisible) {
+  BOOL escapeKeyDown = (event.type == NSKeyDown) && (event.keyCode == kGIKeyCode_Esc);
+  if (escapeKeyDown && self.windowController.hasModalView) {
+    [self.windowController stopModalView:NO];
+  } else if (escapeKeyDown && self.windowController.overlayVisible) {
     [self.windowController hideOverlay];
   } else {
     [super sendEvent:event];


### PR DESCRIPTION
Fixed an issue where escape key didn’t dismiss modal views when overlays or sidebars were visible.

---

Steps to reproduce:
1. Open tree view
2. Open Reflogs
3. Select a commit in tree view
4. Edit commit message
5. Press <kbd>esc</kbd>

Expected results:
Commit message modal view is dismissed

Actual results:
Reflogs view is dismissed

---

Steps to reproduce:
1. Open tree view
2. Fetch all branches
3. Select a commit in tree view
4. Edit commit message
5. Press <kbd>esc</kbd>

Expected results:
Commit message modal view is dismissed

Actual results:
“2 remote branches have been updated” overlay is dismissed

---

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT