### PR TITLE
Add namespace to methods in categories on Apple classes

### DIFF
--- a/GitUp/Application/AppDelegate.m
+++ b/GitUp/Application/AppDelegate.m
@@ -387,7 +387,7 @@
                                      alternateButton:NSLocalizedString(@"Not Now", nil)
                                          otherButton:nil
                            informativeTextWithFormat:NSLocalizedString(@"GitUp can install a companion command line tool at \"%@\" which lets you control GitUp from the terminal.\n\nYou can install it at any time from the GitUp menu.", nil), kToolInstallPath];
-      alert.type = kGIAlertType_Note;
+      [alert gi_setType:kGIAlertType_Note];
       alert.showsSuppressionButton = YES;
       if ([alert runModal] == NSAlertDefaultReturn) {
         [self installTool:nil];
@@ -684,7 +684,7 @@ static CFDataRef _MessagePortCallBack(CFMessagePortRef local, SInt32 msgid, CFDa
                                          alternateButton:nil
                                              otherButton:nil
                                informativeTextWithFormat:NSLocalizedString(@"The tool has been installed at \"%@\".\nRun \"gitup help\" in Terminal to learn more.", nil), kToolInstallPath];
-          alert.type = kGIAlertType_Note;
+          [alert gi_setType:kGIAlertType_Note];
           [alert runModal];
         } else {
           status = -1;  // Code doesn't matter
@@ -770,7 +770,7 @@ static CFDataRef _MessagePortCallBack(CFMessagePortRef local, SInt32 msgid, CFDa
                                    alternateButton:nil
                                        otherButton:nil
                          informativeTextWithFormat:NSLocalizedString(@"The update will download automatically in the background and be installed when you quit GitUp.", nil)];
-    alert.type = kGIAlertType_Note;
+    [alert gi_setType:kGIAlertType_Note];
     [alert runModal];
   }
 }
@@ -784,7 +784,7 @@ static CFDataRef _MessagePortCallBack(CFMessagePortRef local, SInt32 msgid, CFDa
                                    alternateButton:nil
                                        otherButton:nil
                          informativeTextWithFormat:@""];
-    alert.type = kGIAlertType_Note;
+    [alert gi_setType:kGIAlertType_Note];
     [alert runModal];
   }
 }

--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -305,7 +305,7 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
 
   _mapViewController = [[GIMapViewController alloc] initWithRepository:_repository];
   _mapViewController.delegate = self;
-  [_mapControllerView replaceWithView:_mapViewController.view];
+  [_mapControllerView gi_replaceWithView:_mapViewController.view];
   _mapView.frame = _mapContainerView.bounds;
   [_mapContainerView addSubview:_mapView];
   XLOG_DEBUG_CHECK(_mapContainerView.subviews.firstObject == _mapView);
@@ -314,24 +314,24 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
   _tagsViewController = [[GICommitListViewController alloc] initWithRepository:_repository];
   _tagsViewController.delegate = self;
   _tagsViewController.emptyLabel = NSLocalizedString(@"No Tags", nil);
-  [_tagsControllerView replaceWithView:_tagsViewController.view];
+  [_tagsControllerView gi_replaceWithView:_tagsViewController.view];
 
   _snapshotListViewController = [[GISnapshotListViewController alloc] initWithRepository:_repository];
   _snapshotListViewController.delegate = self;
-  [_snapshotsControllerView replaceWithView:_snapshotListViewController.view];
+  [_snapshotsControllerView gi_replaceWithView:_snapshotListViewController.view];
 
   _unifiedReflogViewController = [[GIUnifiedReflogViewController alloc] initWithRepository:_repository];
   _unifiedReflogViewController.delegate = self;
-  [_reflogControllerView replaceWithView:_unifiedReflogViewController.view];
+  [_reflogControllerView gi_replaceWithView:_unifiedReflogViewController.view];
 
   _ancestorsViewController = [[GICommitListViewController alloc] initWithRepository:_repository];
   _ancestorsViewController.delegate = self;
-  [_ancestorsControllerView replaceWithView:_ancestorsViewController.view];
+  [_ancestorsControllerView gi_replaceWithView:_ancestorsViewController.view];
 
   _searchResultsViewController = [[GICommitListViewController alloc] initWithRepository:_repository];
   _searchResultsViewController.delegate = self;
   _searchResultsViewController.emptyLabel = NSLocalizedString(@"No Results", nil);
-  [_searchControllerView replaceWithView:_searchResultsViewController.view];
+  [_searchControllerView gi_replaceWithView:_searchResultsViewController.view];
 
   _quickViewController = [[GIQuickViewController alloc] initWithRepository:_repository];
   NSTabViewItem* quickItem = [_mainTabView tabViewItemAtIndex:[_mainTabView indexOfTabViewItemWithIdentifier:kWindowModeString_Map_QuickView]];
@@ -343,19 +343,19 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
 
   _commitRewriterViewController = [[GICommitRewriterViewController alloc] initWithRepository:_repository];
   _commitRewriterViewController.delegate = self;
-  [_rewriteControllerView replaceWithView:_commitRewriterViewController.view];
+  [_rewriteControllerView gi_replaceWithView:_commitRewriterViewController.view];
   NSTabViewItem* rewriteItem = [_mainTabView tabViewItemAtIndex:[_mainTabView indexOfTabViewItemWithIdentifier:kWindowModeString_Map_Rewrite]];
   rewriteItem.view = _rewriteView;
 
   _commitSplitterViewController = [[GICommitSplitterViewController alloc] initWithRepository:_repository];
   _commitSplitterViewController.delegate = self;
-  [_splitControllerView replaceWithView:_commitSplitterViewController.view];
+  [_splitControllerView gi_replaceWithView:_commitSplitterViewController.view];
   NSTabViewItem* splitItem = [_mainTabView tabViewItemAtIndex:[_mainTabView indexOfTabViewItemWithIdentifier:kWindowModeString_Map_Split]];
   splitItem.view = _splitView;
 
   _conflictResolverViewController = [[GIConflictResolverViewController alloc] initWithRepository:_repository];
   _conflictResolverViewController.delegate = self;
-  [_resolveControllerView replaceWithView:_conflictResolverViewController.view];
+  [_resolveControllerView gi_replaceWithView:_conflictResolverViewController.view];
   NSTabViewItem* resolveItem = [_mainTabView tabViewItemAtIndex:[_mainTabView indexOfTabViewItemWithIdentifier:kWindowModeString_Map_Resolve]];
   resolveItem.view = _resolveView;
 
@@ -414,8 +414,8 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
                                    alternateButton:nil
                                        otherButton:nil
                          informativeTextWithFormat:NSLocalizedString(@"If using an SSH remote, make sure you have added your key to the ssh-agent, then try again.", nil)];
-    alert.type = kGIAlertType_Stop;
-    [alert beginSheetModalForWindow:_mainWindow withCompletionHandler:NULL];
+    [alert gi_setType:kGIAlertType_Stop];
+    [alert gi_beginSheetModalForWindow:_mainWindow withCompletionHandler:NULL];
     return NO;
   }
 
@@ -558,9 +558,9 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
     if (![_repository checkAllSubmodulesInitialized:YES error:&error]) {
       if ([error.domain isEqualToString:GCErrorDomain] && (error.code == kGCErrorCode_SubmoduleUninitialized)) {
         NSAlert* alert = [NSAlert alertWithMessageText:NSLocalizedString(@"Do you want to initialize submodules?", nil) defaultButton:NSLocalizedString(@"Initialize", nil) alternateButton:NSLocalizedString(@"Cancel", nil) otherButton:nil informativeTextWithFormat:@"One or more submodules in this repository are uninitialized."];
-        alert.type = kGIAlertType_Caution;
+        [alert gi_setType:kGIAlertType_Caution];
         alert.showsSuppressionButton = YES;
-        [alert beginSheetModalForWindow:_mainWindow
+        [alert gi_beginSheetModalForWindow:_mainWindow
                   withCompletionHandler:^(NSInteger returnCode) {
 
                     if (alert.suppressionButton.state) {
@@ -660,10 +660,10 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
         CGFloat fontSize = _infoTextField1.font.pointSize;
         NSMutableAttributedString* string = [[NSMutableAttributedString alloc] init];
         [string beginEditing];
-        [string appendString:NSLocalizedString(@"On branch ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
-        [string appendString:branch.name withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
-        [string appendString:NSLocalizedString(@" • tracking upstream ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
-        [string appendString:upstream.name withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
+        [string gi_appendString:NSLocalizedString(@"On branch ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
+        [string gi_appendString:branch.name withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
+        [string gi_appendString:NSLocalizedString(@" • tracking upstream ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
+        [string gi_appendString:upstream.name withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
         [string setAlignment:NSCenterTextAlignment range:NSMakeRange(0, string.length)];
         [string endEditing];
         _infoTextField1.attributedStringValue = string;
@@ -707,8 +707,8 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
         CGFloat fontSize = _infoTextField1.font.pointSize;
         NSMutableAttributedString* string = [[NSMutableAttributedString alloc] init];
         [string beginEditing];
-        [string appendString:NSLocalizedString(@"On branch ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
-        [string appendString:branch.name withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
+        [string gi_appendString:NSLocalizedString(@"On branch ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
+        [string gi_appendString:branch.name withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
         [string setAlignment:NSCenterTextAlignment range:NSMakeRange(0, string.length)];
         [string endEditing];
         _infoTextField1.attributedStringValue = string;
@@ -885,7 +885,7 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
                                    alternateButton:NSLocalizedString(@"Cancel", nil)
                                        otherButton:nil
                          informativeTextWithFormat:NSLocalizedString(@"The repository \"%@\" is still being prepared for search. This can take up to a few minutes for large repositories.", nil), self.displayName];
-    alert.type = kGIAlertType_Caution;
+    [alert gi_setType:kGIAlertType_Caution];
     if ([alert runModal] == NSAlertAlternateReturn) {
       return NO;
     }
@@ -1009,13 +1009,13 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
   if (animationInFlight) {
     transitionBlock();
   } else if (appearing) {
-    _fixedSnapshotLayer.contents = [_contentView takeSnapshot];
+    _fixedSnapshotLayer.contents = [_contentView gi_takeSnapshot];
     transitionBlock();
-    _animatingSnapshotLayer.contents = [_contentView takeSnapshot];
+    _animatingSnapshotLayer.contents = [_contentView gi_takeSnapshot];
   } else {
-    _animatingSnapshotLayer.contents = [_contentView takeSnapshot];
+    _animatingSnapshotLayer.contents = [_contentView gi_takeSnapshot];
     transitionBlock();
-    _fixedSnapshotLayer.contents = [_contentView takeSnapshot];
+    _fixedSnapshotLayer.contents = [_contentView gi_takeSnapshot];
   }
 
   [_contentView.layer addSublayer:_fixedSnapshotLayer];
@@ -1792,13 +1792,13 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
 - (IBAction)resetHard:(id)sender {
   _untrackedButton.state = NSOffState;
   NSAlert* alert = [[NSAlert alloc] init];
-  alert.type = kGIAlertType_Stop;
+  [alert gi_setType:kGIAlertType_Stop];
   alert.messageText = NSLocalizedString(@"Are you sure you want to reset the index and working directory to the current checkout?", nil);
   alert.informativeText = NSLocalizedString(@"Any operation in progress (merge, rebase, etc...) will be aborted, and any uncommitted change, including in submodules, will be discarded.\n\nThis action cannot be undone.", nil);
   alert.accessoryView = _resetView;
   [alert addButtonWithTitle:NSLocalizedString(@"Reset", nil)];
   [alert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
-  [alert beginSheetModalForWindow:_mainWindow
+  [alert gi_beginSheetModalForWindow:_mainWindow
             withCompletionHandler:^(NSInteger returnCode) {
 
               if (returnCode == NSAlertFirstButtonReturn) {

--- a/GitUp/GitUp.xcodeproj/project.pbxproj
+++ b/GitUp/GitUp.xcodeproj/project.pbxproj
@@ -338,7 +338,6 @@
 					};
 					E2C338AA19F8562F00063D95 = {
 						CreatedOnToolsVersion = 6.1;
-						DevelopmentTeam = 88W3E55T4B;
 					};
 				};
 			};
@@ -531,6 +530,7 @@
 				BUNDLE_VERSION = 0;
 				BUNDLE_VERSION_STRING = 1.0.9;
 				CODE_SIGN_IDENTITY = "Mac Developer";
+				DEVELOPMENT_TEAM = AXL96AEQK3;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/Third-Party";
 				GCC_DYNAMIC_NO_PIC = YES;
 				INFOPLIST_FILE = Application/Info.plist;
@@ -548,6 +548,7 @@
 				BUNDLE_VERSION = 0;
 				BUNDLE_VERSION_STRING = 1.0.9;
 				CODE_SIGN_IDENTITY = "Mac Developer";
+				DEVELOPMENT_TEAM = AXL96AEQK3;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/Third-Party";
 				GCC_DYNAMIC_NO_PIC = YES;
 				INFOPLIST_FILE = Application/Info.plist;

--- a/GitUpKit/Components/GICommitListViewController.m
+++ b/GitUpKit/Components/GICommitListViewController.m
@@ -186,9 +186,9 @@
     NSMutableAttributedString* author = [[NSMutableAttributedString alloc] init];
     CGFloat fontSize = view.authorTextField.font.pointSize;
     [author beginEditing];
-    [author appendString:commit.authorName withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
-    [author appendString:@" " withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
-    [author appendString:commit.authorEmail withAttributes:nil];
+    [author gi_appendString:commit.authorName withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
+    [author gi_appendString:@" " withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
+    [author gi_appendString:commit.authorEmail withAttributes:nil];
     [author endEditing];
     view.authorTextField.attributedStringValue = author;
     return view;

--- a/GitUpKit/Components/GIUnifiedReflogViewController.m
+++ b/GitUpKit/Components/GIUnifiedReflogViewController.m
@@ -141,11 +141,11 @@ static NSAttributedString* _AttributedStringFromReflogEntry(GCReflogEntry* entry
       message = [message substringFromIndex:(sizeof(kGCReflogCustomPrefix) - 1)];
     }
     GCReference* reference = entry.references[i];
-    [string appendString:reference.name withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
-    [string appendString:@" • " withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
-    [string appendString:message withAttributes:nil];
+    [string gi_appendString:reference.name withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
+    [string gi_appendString:@" • " withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
+    [string gi_appendString:message withAttributes:nil];
     if (i < count - 1) {
-      [string appendString:@"\n" withAttributes:nil];
+      [string gi_appendString:@"\n" withAttributes:nil];
     }
   }
   [string addAttribute:NSParagraphStyleAttributeName value:style range:NSMakeRange(0, string.length)];
@@ -271,7 +271,7 @@ static NSString* _StringFromActions(GCReflogActions actions) {
   }
   _nameTextField.stringValue = @"";
   NSAlert* alert = [[NSAlert alloc] init];
-  alert.type = kGIAlertType_Note;
+  [alert gi_setType:kGIAlertType_Note];
   alert.messageText = NSLocalizedString(@"Create New Branch for Reflog Entry", nil);
   alert.informativeText = NSLocalizedString(@"This will create and checkout a new local branch at the commit of the selected reflog entry, making it reachable again.", nil);
   alert.accessoryView = _restoreView;

--- a/GitUpKit/Utilities/GIAppKit.h
+++ b/GitUpKit/Utilities/GIAppKit.h
@@ -27,22 +27,22 @@ extern NSString* const GICommitMessageViewUserDefaultKey_ShowMargins;
 extern NSString* const GICommitMessageViewUserDefaultKey_EnableSpellChecking;
 
 @interface NSMutableAttributedString (GIAppKit)
-- (void)appendString:(NSString*)string withAttributes:(NSDictionary*)attributes;
+- (void)gi_appendString:(NSString*)string withAttributes:(NSDictionary*)attributes;
 @end
 
 @interface NSAlert (GIAppKit)
-- (void)beginSheetModalForWindow:(NSWindow*)window withCompletionHandler:(void (^)(NSInteger returnCode))handler;  // AppKit version is 10.9+ only
-- (void)setType:(GIAlertType)type;  // Set the alert icon
+- (void)gi_beginSheetModalForWindow:(NSWindow*)window withCompletionHandler:(void (^)(NSInteger returnCode))handler;  // AppKit version is 10.9+ only
+- (void)gi_setType:(GIAlertType)type;  // Set the alert icon
 @end
 
 @interface NSView (GIAppKit)
-- (void)replaceWithView:(NSView*)view;  // Preserves frame and autoresizing mask
-- (NSImage*)takeSnapshot;
+- (void)gi_replaceWithView:(NSView*)view;  // Preserves frame and autoresizing mask
+- (NSImage*)gi_takeSnapshot;
 @end
 
 @interface NSMenu (GIAppKit)
-- (NSMenuItem*)addItemWithTitle:(NSString*)title block:(dispatch_block_t)block;
-- (NSMenuItem*)addItemWithTitle:(NSString*)title keyEquivalent:(unichar)code modifierMask:(NSUInteger)mask block:(dispatch_block_t)block;  // Pass a NULL block to add a disabled item
+- (NSMenuItem*)gi_addItemWithTitle:(NSString*)title block:(dispatch_block_t)block;
+- (NSMenuItem*)gi_addItemWithTitle:(NSString*)title keyEquivalent:(unichar)code modifierMask:(NSUInteger)mask block:(dispatch_block_t)block;  // Pass a NULL block to add a disabled item
 @end
 
 @interface GIFlippedView : NSView

--- a/GitUpKit/Utilities/GIAppKit.m
+++ b/GitUpKit/Utilities/GIAppKit.m
@@ -39,7 +39,7 @@ static NSColor* _separatorColor = nil;
 
 @implementation NSMutableAttributedString (GIAppKit)
 
-- (void)appendString:(NSString*)string withAttributes:(NSDictionary*)attributes {
+- (void)gi_appendString:(NSString*)string withAttributes:(NSDictionary*)attributes {
   if (string.length) {
     NSInteger length = self.length;
     [self replaceCharactersInRange:NSMakeRange(length, 0) withString:string];
@@ -53,7 +53,7 @@ static NSColor* _separatorColor = nil;
 
 @implementation NSAlert (GIAppKit)
 
-+ (void)_alertDidEnd:(NSAlert*)alert returnCode:(NSInteger)returnCode contextInfo:(void*)contextInfo {
++ (void)gi_alertDidEnd:(NSAlert*)alert returnCode:(NSInteger)returnCode contextInfo:(void*)contextInfo {
   void (^handler)(NSInteger) = contextInfo ? CFBridgingRelease(contextInfo) : NULL;
   [alert.window orderOut:nil];  // Dismiss the alert window before the handler might chain another one
   if (handler) {
@@ -61,11 +61,11 @@ static NSColor* _separatorColor = nil;
   }
 }
 
-- (void)beginSheetModalForWindow:(NSWindow*)window withCompletionHandler:(void (^)(NSInteger returnCode))handler {
-  [self beginSheetModalForWindow:window modalDelegate:[NSAlert class] didEndSelector:@selector(_alertDidEnd:returnCode:contextInfo:) contextInfo:(handler ? (void*)CFBridgingRetain(handler) : NULL)];
+- (void)gi_beginSheetModalForWindow:(NSWindow*)window withCompletionHandler:(void (^)(NSInteger returnCode))handler {
+  [self beginSheetModalForWindow:window modalDelegate:[NSAlert class] didEndSelector:@selector(gi_alertDidEnd:returnCode:contextInfo:) contextInfo:(handler ? (void*)CFBridgingRetain(handler) : NULL)];
 }
 
-- (void)setType:(GIAlertType)type {
+- (void)gi_setType:(GIAlertType)type {
   switch (type) {
     case kGIAlertType_Note:
       self.icon = [[NSBundle bundleForClass:[GILayoutManager class]] imageForResource:@"icon_alert_note"];
@@ -84,14 +84,14 @@ static NSColor* _separatorColor = nil;
 
 @implementation NSView (GIAppKit)
 
-- (void)replaceWithView:(NSView*)view {
+- (void)gi_replaceWithView:(NSView*)view {
   XLOG_DEBUG_CHECK(self.superview);
   view.frame = self.frame;
   view.autoresizingMask = self.autoresizingMask;
   [self.superview replaceSubview:self with:view];
 }
 
-- (NSImage*)takeSnapshot {
+- (NSImage*)gi_takeSnapshot {
   NSBitmapImageRep* rep = [self bitmapImageRepForCachingDisplayInRect:self.bounds];
   [self cacheDisplayInRect:self.bounds toBitmapImageRep:rep];
   NSImage* image = [[NSImage alloc] initWithSize:rep.size];
@@ -103,20 +103,20 @@ static NSColor* _separatorColor = nil;
 
 @implementation NSMenu (GIAppKit)
 
-- (NSMenuItem*)addItemWithTitle:(NSString*)title block:(dispatch_block_t)block {
-  return [self addItemWithTitle:title keyEquivalent:0 modifierMask:0 block:block];
+- (NSMenuItem*)gi_addItemWithTitle:(NSString*)title block:(dispatch_block_t)block {
+  return [self gi_addItemWithTitle:title keyEquivalent:0 modifierMask:0 block:block];
 }
 
-- (void)_blockAction:(NSMenuItem*)sender {
+- (void)gi_blockAction:(NSMenuItem*)sender {
   dispatch_block_t block = sender.representedObject;
   block();
 }
 
-- (NSMenuItem*)addItemWithTitle:(NSString*)title keyEquivalent:(unichar)code modifierMask:(NSUInteger)mask block:(dispatch_block_t)block {
+- (NSMenuItem*)gi_addItemWithTitle:(NSString*)title keyEquivalent:(unichar)code modifierMask:(NSUInteger)mask block:(dispatch_block_t)block {
   NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:title action:NULL keyEquivalent:(code ? [NSString stringWithCharacters:&code length:1] : @"")];
   if (block) {
     item.target = self;
-    item.action = @selector(_blockAction:);
+    item.action = @selector(gi_blockAction:);
     item.representedObject = [block copy];
   }
   item.keyEquivalentModifierMask = mask;

--- a/GitUpKit/Utilities/GIViewController+Utilities.m
+++ b/GitUpKit/Utilities/GIViewController+Utilities.m
@@ -680,22 +680,22 @@ static NSString* _diffTemporaryDirectoryPath = nil;
   NSMenu* menu = [[NSMenu alloc] initWithTitle:@""];
 
   if (conflict) {
-    [menu addItemWithTitle:NSLocalizedString(@"Resolve in Merge Tool…", nil)
+    [menu gi_addItemWithTitle:NSLocalizedString(@"Resolve in Merge Tool…", nil)
                      block:^{
                        [self resolveConflictInMergeTool:conflict];
                      }];
-    [menu addItemWithTitle:NSLocalizedString(@"Mark as Resolved", nil)
+    [menu gi_addItemWithTitle:NSLocalizedString(@"Mark as Resolved", nil)
                      block:^{
                        [self markConflictAsResolved:conflict];
                      }];
   } else {
     if (GC_FILE_MODE_IS_FILE(delta.oldFile.mode) && GC_FILE_MODE_IS_FILE(delta.newFile.mode)) {
-      [menu addItemWithTitle:NSLocalizedString(@"View in Diff Tool…", nil)
+      [menu gi_addItemWithTitle:NSLocalizedString(@"View in Diff Tool…", nil)
                        block:^{
                          [self viewDeltasInDiffTool:@[ delta ]];
                        }];
     } else {
-      [menu addItemWithTitle:NSLocalizedString(@"View in Diff Tool…", nil) block:NULL];
+      [menu gi_addItemWithTitle:NSLocalizedString(@"View in Diff Tool…", nil) block:NULL];
     }
   }
 
@@ -703,18 +703,18 @@ static NSString* _diffTemporaryDirectoryPath = nil;
     [menu addItem:[NSMenuItem separatorItem]];
 
     if (delta.submodule) {
-      [menu addItemWithTitle:NSLocalizedString(@"Open Submodule…", nil)
+      [menu gi_addItemWithTitle:NSLocalizedString(@"Open Submodule…", nil)
                        block:^{
                          [self openSubmoduleWithApp:delta.canonicalPath];
                        }];
     } else {
-      [menu addItemWithTitle:NSLocalizedString(@"Open File…", nil)
+      [menu gi_addItemWithTitle:NSLocalizedString(@"Open File…", nil)
                        block:^{
                          [self openFileWithDefaultEditor:delta.canonicalPath];
                        }];
     }
 
-    [menu addItemWithTitle:NSLocalizedString(@"Show in Finder…", nil)
+    [menu gi_addItemWithTitle:NSLocalizedString(@"Show in Finder…", nil)
                      block:^{
                        [self showFileInFinder:delta.canonicalPath];
                      }];

--- a/GitUpKit/Utilities/GIViewController.m
+++ b/GitUpKit/Utilities/GIViewController.m
@@ -183,7 +183,7 @@
 }
 
 - (void)presentAlert:(NSAlert*)alert completionHandler:(void (^)(NSInteger returnCode))handler {
-  [alert beginSheetModalForWindow:self.view.window withCompletionHandler:handler];
+  [alert gi_beginSheetModalForWindow:self.view.window withCompletionHandler:handler];
 }
 
 #pragma mark - NSTextFieldDelegate
@@ -247,7 +247,7 @@
 #pragma clang diagnostic ignored "-Wformat-security"
   NSAlert* alert = [NSAlert alertWithMessageText:title defaultButton:NSLocalizedString(@"OK", nil) alternateButton:nil otherButton:nil informativeTextWithFormat:(message ? message : @"")];
 #pragma clang diagnostic pop
-  alert.type = type;
+  [alert gi_setType:type];
   [self presentAlert:alert completionHandler:NULL];
 }
 
@@ -261,7 +261,7 @@
     block();
   } else {
     NSAlert* alert = [[NSAlert alloc] init];
-    alert.type = type;
+    [alert gi_setType:type];
     alert.messageText = title;
     alert.informativeText = message;
     alert.showsSuppressionButton = key ? YES : NO;

--- a/GitUpKit/Views/GIAdvancedCommitViewController.m
+++ b/GitUpKit/Views/GIAdvancedCommitViewController.m
@@ -54,18 +54,18 @@
   _workdirFilesViewController.delegate = self;
   _workdirFilesViewController.allowsMultipleSelection = YES;
   _workdirFilesViewController.emptyLabel = NSLocalizedString(@"No changes in working directory", nil);
-  [_workdirFilesView replaceWithView:_workdirFilesViewController.view];
+  [_workdirFilesView gi_replaceWithView:_workdirFilesViewController.view];
 
   _indexFilesViewController = [[GIDiffFilesViewController alloc] initWithRepository:self.repository];
   _indexFilesViewController.delegate = self;
   _indexFilesViewController.allowsMultipleSelection = YES;
   _indexFilesViewController.emptyLabel = NSLocalizedString(@"No changes in index", nil);
-  [_indexFilesView replaceWithView:_indexFilesViewController.view];
+  [_indexFilesView gi_replaceWithView:_indexFilesViewController.view];
 
   _diffContentsViewController = [[GIDiffContentsViewController alloc] initWithRepository:self.repository];
   _diffContentsViewController.delegate = self;
   _diffContentsViewController.emptyLabel = NSLocalizedString(@"No file selected", nil);
-  [_diffContentsView replaceWithView:_diffContentsViewController.view];
+  [_diffContentsView gi_replaceWithView:_diffContentsViewController.view];
 
   self.messageTextView.string = @"";
 }
@@ -501,13 +501,13 @@
 
     if (GC_FILE_MODE_IS_FILE(delta.oldFile.mode) || GC_FILE_MODE_IS_FILE(delta.newFile.mode)) {
       if (delta.change == kGCFileDiffChange_Untracked) {
-        [menu addItemWithTitle:NSLocalizedString(@"Delete File…", nil)
+        [menu gi_addItemWithTitle:NSLocalizedString(@"Delete File…", nil)
                          block:^{
                            [self deleteUntrackedFile:delta.canonicalPath];
                          }];
       } else {
         if ([controller getSelectedLinesForDelta:delta oldLines:NULL newLines:NULL]) {
-          [menu addItemWithTitle:NSLocalizedString(@"Discard Line Changes…", nil)
+          [menu gi_addItemWithTitle:NSLocalizedString(@"Discard Line Changes…", nil)
                            block:^{
                              NSIndexSet* oldLines;
                              NSIndexSet* newLines;
@@ -515,14 +515,14 @@
                              [self discardSelectedChangesForFile:delta.canonicalPath oldLines:oldLines newLines:newLines resetIndex:NO];
                            }];
         } else {
-          [menu addItemWithTitle:NSLocalizedString(@"Discard File Changes…", nil)
+          [menu gi_addItemWithTitle:NSLocalizedString(@"Discard File Changes…", nil)
                            block:^{
                              [self discardAllChangesForFile:delta.canonicalPath resetIndex:NO];
                            }];
         }
       }
     } else if (delta.submodule) {
-      [menu addItemWithTitle:NSLocalizedString(@"Discard Submodule Changes…", nil)
+      [menu gi_addItemWithTitle:NSLocalizedString(@"Discard Submodule Changes…", nil)
                        block:^{
                          [self discardSubmoduleAtPath:delta.canonicalPath resetIndex:NO];
                        }];

--- a/GitUpKit/Views/GICommitRewriterViewController.m
+++ b/GitUpKit/Views/GICommitRewriterViewController.m
@@ -66,13 +66,13 @@
   _diffContentsViewController.delegate = self;
   _diffContentsViewController.showsUntrackedAsAdded = YES;
   _diffContentsViewController.emptyLabel = NSLocalizedString(@"No changes in working directory", nil);
-  [_contentsView replaceWithView:_diffContentsViewController.view];
+  [_contentsView gi_replaceWithView:_diffContentsViewController.view];
 
   _diffFilesViewController = [[GIDiffFilesViewController alloc] initWithRepository:self.repository];
   _diffFilesViewController.delegate = self;
   _diffFilesViewController.showsUntrackedAsAdded = YES;
   _diffFilesViewController.emptyLabel = NSLocalizedString(@"No changes in working directory", nil);
-  [_filesView replaceWithView:_diffFilesViewController.view];
+  [_filesView gi_replaceWithView:_diffFilesViewController.view];
 }
 
 - (void)viewWillShow {

--- a/GitUpKit/Views/GICommitSplitterViewController.m
+++ b/GitUpKit/Views/GICommitSplitterViewController.m
@@ -69,18 +69,18 @@
   _filesViewControllerNew.delegate = self;
   _filesViewControllerNew.allowsMultipleSelection = YES;
   _filesViewControllerNew.emptyLabel = NSLocalizedString(@"No changes in commit", nil);
-  [_filesViewNew replaceWithView:_filesViewControllerNew.view];
+  [_filesViewNew gi_replaceWithView:_filesViewControllerNew.view];
 
   _filesViewControllerOld = [[GIDiffFilesViewController alloc] initWithRepository:self.repository];
   _filesViewControllerOld.delegate = self;
   _filesViewControllerOld.allowsMultipleSelection = YES;
   _filesViewControllerOld.emptyLabel = NSLocalizedString(@"No changes in commit", nil);
-  [_filesViewOld replaceWithView:_filesViewControllerOld.view];
+  [_filesViewOld gi_replaceWithView:_filesViewControllerOld.view];
 
   _diffContentsViewController = [[GIDiffContentsViewController alloc] initWithRepository:self.repository];
   _diffContentsViewController.delegate = self;
   _diffContentsViewController.emptyLabel = NSLocalizedString(@"No file selected", nil);
-  [_diffContentsView replaceWithView:_diffContentsViewController.view];
+  [_diffContentsView gi_replaceWithView:_diffContentsViewController.view];
 }
 
 - (void)viewWillShow {

--- a/GitUpKit/Views/GICommitViewController.m
+++ b/GitUpKit/Views/GICommitViewController.m
@@ -54,41 +54,41 @@
   NSMutableAttributedString* string = [[NSMutableAttributedString alloc] init];
   [string beginEditing];
   if (_showsBranchInfo) {
-    [string appendString:NSLocalizedString(@"Committing", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
+    [string gi_appendString:NSLocalizedString(@"Committing", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
     switch (self.repository.state) {
       case kGCRepositoryState_Merge:
-        [string appendString:NSLocalizedString(@" merge", nil) withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
+        [string gi_appendString:NSLocalizedString(@" merge", nil) withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
         break;
 
       case kGCRepositoryState_Revert:
-        [string appendString:NSLocalizedString(@" revert", nil) withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
+        [string gi_appendString:NSLocalizedString(@" revert", nil) withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
         break;
 
       case kGCRepositoryState_CherryPick:
-        [string appendString:NSLocalizedString(@" cherry-pick", nil) withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
+        [string gi_appendString:NSLocalizedString(@" cherry-pick", nil) withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
         break;
 
       case kGCRepositoryState_Rebase:
       case kGCRepositoryState_RebaseInteractive:
       case kGCRepositoryState_RebaseMerge:
-        [string appendString:NSLocalizedString(@" rebase", nil) withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
+        [string gi_appendString:NSLocalizedString(@" rebase", nil) withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
         break;
 
       default:
         break;
     }
-    [string appendString:NSLocalizedString(@" as ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
-    [string appendString:user withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
+    [string gi_appendString:NSLocalizedString(@" as ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
+    [string gi_appendString:user withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
     if (branch) {
-      [string appendString:NSLocalizedString(@" on branch ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
-      [string appendString:branch.name withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
+      [string gi_appendString:NSLocalizedString(@" on branch ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
+      [string gi_appendString:branch.name withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
     } else {
-      [string appendString:NSLocalizedString(@" on ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
-      [string appendString:NSLocalizedString(@"detached HEAD", nil) withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
+      [string gi_appendString:NSLocalizedString(@" on ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
+      [string gi_appendString:NSLocalizedString(@"detached HEAD", nil) withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
     }
   } else {
-    [string appendString:NSLocalizedString(@"Committing as ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
-    [string appendString:user withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
+    [string gi_appendString:NSLocalizedString(@"Committing as ", nil) withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:fontSize]}];
+    [string gi_appendString:user withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:fontSize]}];
   }
   [string setAlignment:NSCenterTextAlignment range:NSMakeRange(0, string.length)];
   [string endEditing];

--- a/GitUpKit/Views/GIConfigViewController.m
+++ b/GitUpKit/Views/GIConfigViewController.m
@@ -239,9 +239,9 @@ static NSMutableDictionary* _patternHelp = nil;
       break;
   }
   NSMutableAttributedString* string = [[NSMutableAttributedString alloc] init];
-  [string appendString:option.variable withAttributes:_optionAttributes];
-  [string appendString:@" = " withAttributes:_separatorAttributes];
-  [string appendString:option.value withAttributes:_valueAttributes];
+  [string gi_appendString:option.variable withAttributes:_optionAttributes];
+  [string gi_appendString:@" = " withAttributes:_separatorAttributes];
+  [string gi_appendString:option.value withAttributes:_valueAttributes];
   view.optionTextField.attributedStringValue = string;
   view.helpTextField.attributedStringValue = [[NSAttributedString alloc] initWithString:[self.class helpForVariable:option.variable] attributes:_helpAttributes];
   return view;

--- a/GitUpKit/Views/GIConflictResolverViewController.m
+++ b/GitUpKit/Views/GIConflictResolverViewController.m
@@ -48,13 +48,13 @@
   _diffContentsViewController.delegate = self;
   _diffContentsViewController.showsUntrackedAsAdded = YES;
   _diffContentsViewController.emptyLabel = NSLocalizedString(@"No changes in working directory", nil);
-  [_contentsView replaceWithView:_diffContentsViewController.view];
+  [_contentsView gi_replaceWithView:_diffContentsViewController.view];
 
   _diffFilesViewController = [[GIDiffFilesViewController alloc] initWithRepository:self.repository];
   _diffFilesViewController.delegate = self;
   _diffFilesViewController.showsUntrackedAsAdded = YES;
   _diffFilesViewController.emptyLabel = NSLocalizedString(@"No changes in working directory", nil);
-  [_filesView replaceWithView:_diffFilesViewController.view];
+  [_filesView gi_replaceWithView:_diffFilesViewController.view];
 }
 
 - (void)viewWillShow {

--- a/GitUpKit/Views/GIDiffViewController.m
+++ b/GitUpKit/Views/GIDiffViewController.m
@@ -53,11 +53,11 @@
   _diffContentsViewController = [[GIDiffContentsViewController alloc] initWithRepository:self.repository];
   _diffContentsViewController.delegate = self;
   _diffContentsViewController.emptyLabel = NSLocalizedString(@"No differences", nil);
-  [_contentsView replaceWithView:_diffContentsViewController.view];
+  [_contentsView gi_replaceWithView:_diffContentsViewController.view];
 
   _diffFilesViewController = [[GIDiffFilesViewController alloc] initWithRepository:self.repository];
   _diffFilesViewController.delegate = self;
-  [_filesView replaceWithView:_diffFilesViewController.view];
+  [_filesView gi_replaceWithView:_diffFilesViewController.view];
 }
 
 - (void)setCommit:(GCCommit*)commit withParentCommit:(GCCommit*)parentCommit {

--- a/GitUpKit/Views/GIMapViewController+Operations.m
+++ b/GitUpKit/Views/GIMapViewController+Operations.m
@@ -777,7 +777,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                        alternateButton:NSLocalizedString(@"Cancel", nil)
                                            otherButton:NSLocalizedString(@"Merge", nil)
                              informativeTextWithFormat:NSLocalizedString(@"Do you want to still create a merge or just fast-forward?", nil)];
-        alert.type = kGIAlertType_Note;
+        [alert gi_setType:kGIAlertType_Note];
         [self presentAlert:alert
             completionHandler:^(NSInteger returnCode) {
 
@@ -1253,7 +1253,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                                                               alternateButton:NSLocalizedString(@"Cancel", nil)
                                                                                   otherButton:NSLocalizedString(@"Merge", nil)
                                                                     informativeTextWithFormat:NSLocalizedString(@"The branch \"%@\" has diverged from its upstream and cannot be fast-forwarded.", nil), branch.name];
-                                               alert.type = kGIAlertType_Note;
+                                               [alert gi_setType:kGIAlertType_Note];
                                                [self presentAlert:alert
                                                    completionHandler:^(NSInteger returnCode) {
 

--- a/GitUpKit/Views/GIMapViewController.m
+++ b/GitUpKit/Views/GIMapViewController.m
@@ -878,7 +878,7 @@ static NSColor* _patternColor = nil;
                                      alternateButton:NSLocalizedString(@"Cancel", nil)
                                          otherButton:NSLocalizedString(@"Checkout Commit", nil)
                            informativeTextWithFormat:NSLocalizedString(@"The selected commit is also the tip of the remote branch \"%@\".", nil), branch.name];
-      alert.type = kGIAlertType_Note;
+      [alert gi_setType:kGIAlertType_Note];
       [self presentAlert:alert
           completionHandler:^(NSInteger returnCode) {
 
@@ -951,7 +951,7 @@ static NSColor* _patternColor = nil;
                                    alternateButton:NSLocalizedString(@"Cancel", nil)
                                        otherButton:NSLocalizedString(@"Delete Commit", nil)
                          informativeTextWithFormat:NSLocalizedString(@"The selected commit is also the tip of the local branch \"%@\".", nil), localBranch.name];
-    alert.type = kGIAlertType_Note;
+    [alert gi_setType:kGIAlertType_Note];
     [self presentAlert:alert
         completionHandler:^(NSInteger returnCode) {
 

--- a/GitUpKit/Views/GIQuickViewController.m
+++ b/GitUpKit/Views/GIQuickViewController.m
@@ -81,11 +81,11 @@
   _diffContentsViewController = [[GIDiffContentsViewController alloc] initWithRepository:self.repository];
   _diffContentsViewController.delegate = self;
   _diffContentsViewController.emptyLabel = NSLocalizedString(@"No differences", nil);
-  [_contentsView replaceWithView:_diffContentsViewController.view];
+  [_contentsView gi_replaceWithView:_diffContentsViewController.view];
 
   _diffFilesViewController = [[GIDiffFilesViewController alloc] initWithRepository:self.repository];
   _diffFilesViewController.delegate = self;
-  [_filesView replaceWithView:_diffFilesViewController.view];
+  [_filesView gi_replaceWithView:_diffFilesViewController.view];
 
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_splitViewDidResizeSubviews:) name:NSSplitViewDidResizeSubviewsNotification object:_mainSplitView];
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_splitViewDidResizeSubviews:) name:NSSplitViewDidResizeSubviewsNotification object:_infoSplitView];
@@ -153,18 +153,18 @@ static NSString* _CleanUpCommitMessage(NSString* message) {
       CGFloat authorFontSize = _authorTextField.font.pointSize;
       NSMutableAttributedString* author = [[NSMutableAttributedString alloc] init];
       [author beginEditing];
-      [author appendString:_commit.authorName withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:authorFontSize]}];
-      [author appendString:@" " withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:authorFontSize]}];
-      [author appendString:_commit.authorEmail withAttributes:nil];
+      [author gi_appendString:_commit.authorName withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:authorFontSize]}];
+      [author gi_appendString:@" " withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:authorFontSize]}];
+      [author gi_appendString:_commit.authorEmail withAttributes:nil];
       [author endEditing];
       _authorTextField.attributedStringValue = author;
 
       CGFloat committerFontSize = _committerTextField.font.pointSize;
       NSMutableAttributedString* committer = [[NSMutableAttributedString alloc] init];
       [committer beginEditing];
-      [committer appendString:_commit.committerName withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:committerFontSize]}];
-      [committer appendString:@" " withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:committerFontSize]}];
-      [committer appendString:_commit.committerEmail withAttributes:nil];
+      [committer gi_appendString:_commit.committerName withAttributes:@{NSFontAttributeName : [NSFont boldSystemFontOfSize:committerFontSize]}];
+      [committer gi_appendString:@" " withAttributes:@{NSFontAttributeName : [NSFont systemFontOfSize:committerFontSize]}];
+      [committer gi_appendString:_commit.committerEmail withAttributes:nil];
       [committer endEditing];
       _committerTextField.attributedStringValue = committer;
 
@@ -211,12 +211,12 @@ static NSString* _CleanUpCommitMessage(NSString* message) {
   [menu addItem:[NSMenuItem separatorItem]];
 
   if (GC_FILE_MODE_IS_FILE(delta.newFile.mode)) {
-    [menu addItemWithTitle:NSLocalizedString(@"Restore File to This Version…", nil)
+    [menu gi_addItemWithTitle:NSLocalizedString(@"Restore File to This Version…", nil)
                      block:^{
                        [self restoreFile:delta.canonicalPath toCommit:_commit];
                      }];
   } else {
-    [menu addItemWithTitle:NSLocalizedString(@"Restore File to This Version…", nil) block:NULL];
+    [menu gi_addItemWithTitle:NSLocalizedString(@"Restore File to This Version…", nil) block:NULL];
   }
 
   return menu;

--- a/GitUpKit/Views/GISimpleCommitViewController.m
+++ b/GitUpKit/Views/GISimpleCommitViewController.m
@@ -47,13 +47,13 @@
   _diffContentsViewController.delegate = self;
   _diffContentsViewController.showsUntrackedAsAdded = YES;
   _diffContentsViewController.emptyLabel = NSLocalizedString(@"No changes in working directory", nil);
-  [_contentsView replaceWithView:_diffContentsViewController.view];
+  [_contentsView gi_replaceWithView:_diffContentsViewController.view];
 
   _diffFilesViewController = [[GIDiffFilesViewController alloc] initWithRepository:self.repository];
   _diffFilesViewController.delegate = self;
   _diffFilesViewController.showsUntrackedAsAdded = YES;
   _diffFilesViewController.emptyLabel = NSLocalizedString(@"No changes in working directory", nil);
-  [_filesView replaceWithView:_diffFilesViewController.view];
+  [_filesView gi_replaceWithView:_diffFilesViewController.view];
 
   self.messageTextView.string = @"";
 }

--- a/GitUpKit/Views/GIStashListViewController.m
+++ b/GitUpKit/Views/GIStashListViewController.m
@@ -76,7 +76,7 @@
 
   _diffContentsViewController = [[GIDiffContentsViewController alloc] initWithRepository:self.repository];
   _diffContentsViewController.emptyLabel = NSLocalizedString(@"No differences", nil);
-  [_diffView replaceWithView:_diffContentsViewController.view];
+  [_diffView gi_replaceWithView:_diffContentsViewController.view];
 
   _cachedCellView = [_tableView makeViewWithIdentifier:[_tableView.tableColumns[0] identifier] owner:self];
 


### PR DESCRIPTION
In my experience it is a safer practice to namespace category methods on classes you don't own, especially in frameworks and libraries.

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT