### PR TITLE
By default, do not show invisible characters in the commit message area.

### DIFF
--- a/GitUp/Application/AppDelegate.m
+++ b/GitUp/Application/AppDelegate.m
@@ -103,7 +103,7 @@
 
 + (void)initialize {
   NSDictionary* defaults = @{
-    GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters : @(YES),
+    GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters : @(NO),
     GICommitMessageViewUserDefaultKey_ShowMargins : @(YES),
     GICommitMessageViewUserDefaultKey_EnableSpellChecking : @(YES),
     kUserDefaultsKey_ReleaseChannel : kReleaseChannel_Stable,


### PR DESCRIPTION
I think the special characters in the message area of commits are irritating and should at least be disabled by default, so that adventurous users can enable them :)

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT