### PR TITLE
Fix new tab behaviour by implementing newWindowForTab

### DIFF
--- a/GitUp/Application/AppDelegate.h
+++ b/GitUp/Application/AppDelegate.h
@@ -46,6 +46,7 @@
 - (void)repository:(GCRepository*)repository willStartTransferWithURL:(NSURL*)url;
 - (BOOL)repository:(GCRepository*)repository requiresPlainTextAuthenticationForURL:(NSURL*)url user:(NSString*)user username:(NSString**)username password:(NSString**)password;
 - (void)repository:(GCRepository*)repository didFinishTransferWithURL:(NSURL*)url success:(BOOL)success;
+- (IBAction)newRepository:(id)sender;
 
 - (void)handleDocumentCountChanged;
 @end

--- a/GitUp/Application/DocumentController.m
+++ b/GitUp/Application/DocumentController.m
@@ -43,6 +43,10 @@
   return [super willPresentError:error];
 }
 
+- (void)newWindowForTab:(id)sender {
+  [[AppDelegate sharedDelegate] newRepository:sender];
+}
+
 - (void)addDocument:(NSDocument*)document {
   [super addDocument:document];
 


### PR DESCRIPTION
Fix for https://github.com/git-up/GitUp/issues/397

I use tabs in GitUp all the time so I disagree with disabling tabs altogether to fix the odd new tab button behaviour.

To fix the issue I simply implemented the `newWindowForTab:` method in NSDocumentController and linked it to the "newRepository" method in the app delegate.

A future improvement might be to show the welcome window instead to open a recent repository rather than create a new one ?

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT