### PR TITLE
Make various text fields single line

### DIFF
--- a/GitUpKit/Views/en.lproj/GIMapViewController.xib
+++ b/GitUpKit/Views/en.lproj/GIMapViewController.xib
@@ -224,7 +224,7 @@ CA
                 <textField verticalHuggingPriority="750" id="REx-8D-wmk">
                     <rect key="frame" x="133" y="165" width="280" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" id="vz0-21-YpX">
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" usesSingleLineMode="YES" id="vz0-21-YpX">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -394,7 +394,7 @@ Gw
                 <textField verticalHuggingPriority="750" id="0A5-t1-c3Z">
                     <rect key="frame" x="100" y="59" width="240" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" id="hOm-T2-MUD">
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" usesSingleLineMode="YES" id="hOm-T2-MUD">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/GitUpKit/Views/en.lproj/GIMapViewController.xib
+++ b/GitUpKit/Views/en.lproj/GIMapViewController.xib
@@ -338,7 +338,7 @@ Gw
                 <textField verticalHuggingPriority="750" id="fnf-HO-J16">
                     <rect key="frame" x="124" y="59" width="240" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" id="tS2-TD-tB5">
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" usesSingleLineMode="YES" id="tS2-TD-tB5">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
This pull request is a continuation of #288.

The patch makes text fields in the following dialogs single-line:

* Create tag
* Rename tag
* Rename branch

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT