### PR TITLE
Allow double-click in title bar to zoom the window

### DIFF
--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -1173,7 +1173,7 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
 
 - (NSArray*)toolbarDefaultItemIdentifiers:(NSToolbar*)toolbar {
   if (_unifiedToolbar) {
-    return @[ kToolbarItem_Left, kToolbarItem_Title, NSToolbarSpaceItemIdentifier, kToolbarItem_Right ];
+    return @[ kToolbarItem_Left, kToolbarItem_Title, kToolbarItem_Right ];
   }
   return @[ kToolbarItem_Left, NSToolbarFlexibleSpaceItemIdentifier, kToolbarItem_Right ];
 }

--- a/GitUp/Application/ToolbarItemWrapperView.h
+++ b/GitUp/Application/ToolbarItemWrapperView.h
@@ -1,0 +1,20 @@
+//  Copyright (C) 2018 Rob Mayoff <gitup@rob.dqd.com>.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import <AppKit/AppKit.h>
+
+@interface ToolbarItemWrapperView : NSView
+
+@end

--- a/GitUp/Application/ToolbarItemWrapperView.m
+++ b/GitUp/Application/ToolbarItemWrapperView.m
@@ -1,0 +1,43 @@
+//  Copyright (C) 2018 Rob Mayoff <gitup@rob.dqd.com>.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import "ToolbarItemWrapperView.h"
+
+@implementation ToolbarItemWrapperView
+
+- (NSView*)hitTest:(NSPoint)point {
+  // Normally, a double-click in a window title bar zooms the window on the second mouse-up. In a unified title/toolbar window, if a mouse-up hit-tests into a subview of a toolbar item, the mouse-up cannot zoom the window. This subclass selectively suppresses hits to allow a double-click to zoom its window.
+  id hit = [super hitTest:point];
+
+  if ([hit isKindOfClass:[NSTextField class]]) {
+    NSTextField* field = hit;
+    return field.selectable ? field : nil;
+  }
+
+  if ([hit isKindOfClass:[NSControl class]]) {
+    NSControl* control = hit;
+    return control.isEnabled ? control : nil;
+  }
+
+  if ([hit isKindOfClass:[NSTextView class]]) {
+    // The search field adds the field editor, an NSTextView, as a subview when it's being edited.
+    NSTextView* textView = hit;
+    return textView.selectable ? textView : nil;
+  }
+
+  return nil;
+}
+
+@end

--- a/GitUp/Application/en.lproj/Document.xib
+++ b/GitUp/Application/en.lproj/Document.xib
@@ -501,7 +501,7 @@ Adjust settings in Show menu</string>
             </subviews>
             <point key="canvasLocation" x="-512.5" y="1242"/>
         </customView>
-        <customView id="ghu-yR-ohT" userLabel="Title View">
+        <customView id="ghu-yR-ohT" userLabel="Title View" customClass="ToolbarItemWrapperView">
             <rect key="frame" x="0.0" y="0.0" width="320" height="32"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
@@ -526,7 +526,7 @@ Adjust settings in Show menu</string>
             </subviews>
             <point key="canvasLocation" x="200" y="408"/>
         </customView>
-        <customView id="d4D-Mc-I9O" userLabel="Left View">
+        <customView id="d4D-Mc-I9O" userLabel="Left View" customClass="ToolbarItemWrapperView">
             <rect key="frame" x="0.0" y="0.0" width="220" height="32"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
@@ -580,7 +580,7 @@ Adjust settings in Show menu</string>
             </subviews>
             <point key="canvasLocation" x="469" y="496"/>
         </customView>
-        <customView id="kfr-yg-mn6" userLabel="Right View">
+        <customView id="kfr-yg-mn6" userLabel="Right View" customClass="ToolbarItemWrapperView">
             <rect key="frame" x="0.0" y="0.0" width="220" height="32"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>

--- a/GitUp/Application/en.lproj/Document.xib
+++ b/GitUp/Application/en.lproj/Document.xib
@@ -580,13 +580,13 @@ Adjust settings in Show menu</string>
             </subviews>
             <point key="canvasLocation" x="469" y="496"/>
         </customView>
-        <customView id="kfr-yg-mn6" userLabel="Right View" customClass="ToolbarItemWrapperView">
-            <rect key="frame" x="0.0" y="0.0" width="220" height="32"/>
+        <customView misplaced="YES" id="kfr-yg-mn6" userLabel="Right View" customClass="ToolbarItemWrapperView">
+            <rect key="frame" x="0.0" y="0.0" width="260" height="32"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
                 <searchField toolTip="Search repository" wantsLayer="YES" verticalHuggingPriority="750" id="mcD-hz-JrS">
-                    <rect key="frame" x="37" y="5" width="180" height="22"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <rect key="frame" x="77" y="5" width="180" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                     <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" allowsUndo="NO" borderStyle="bezel" placeholderString="" usesSingleLineMode="YES" bezelStyle="round" id="3QH-Xd-ctD">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -598,8 +598,8 @@ Adjust settings in Show menu</string>
                     </connections>
                 </searchField>
                 <button toolTip="Show or hide Snapshots" verticalHuggingPriority="750" id="yWu-L8-6Ms">
-                    <rect key="frame" x="3" y="3" width="25" height="25"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <rect key="frame" x="43" y="3" width="25" height="25"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="icon_nav_snapshot" imagePosition="only" alignment="center" alternateImage="icon_nav_snapshot_pressed" borderStyle="border" inset="2" id="rrq-JQ-Zyn">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -609,7 +609,7 @@ Adjust settings in Show menu</string>
                     </connections>
                 </button>
                 <button id="FEG-0e-0JW">
-                    <rect key="frame" x="206" y="9" width="12" height="15"/>
+                    <rect key="frame" x="246" y="9" width="12" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="bevel" bezelStyle="regularSquare" image="icon_nav_min" imagePosition="overlaps" alignment="center" alternateImage="icon_nav_min_pressed" inset="2" id="x0U-ct-UgO">
                         <behavior key="behavior" lightByContents="YES"/>
@@ -620,7 +620,7 @@ Adjust settings in Show menu</string>
                     </connections>
                 </button>
             </subviews>
-            <point key="canvasLocation" x="197.5" y="496"/>
+            <point key="canvasLocation" x="150" y="496"/>
         </customView>
         <customView id="ifo-84-dTf" userLabel="Reset View">
             <rect key="frame" x="0.0" y="0.0" width="300" height="19"/>

--- a/GitUp/GitUp.xcodeproj/project.pbxproj
+++ b/GitUp/GitUp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		165C32B61B95739700D2F894 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 165C32B51B95739700D2F894 /* QuartzCore.framework */; };
+		31CD50E3203E2E2800360B3A /* ToolbarItemWrapperView.m in Sources */ = {isa = PBXBuildFile; fileRef = 31CD50E2203E2E2800360B3A /* ToolbarItemWrapperView.m */; };
 		E212A6DE1B92100E00F62B18 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E212A6DD1B92100E00F62B18 /* libiconv.dylib */; };
 		E21739F71A5080DD00EC6777 /* DocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = E21739F61A5080DD00EC6777 /* DocumentController.m */; };
 		E21DCAEB1B253847006424E8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E21DCAEA1B253847006424E8 /* main.m */; };
@@ -106,6 +107,8 @@
 
 /* Begin PBXFileReference section */
 		165C32B51B95739700D2F894 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		31CD50E1203E2E2800360B3A /* ToolbarItemWrapperView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ToolbarItemWrapperView.h; sourceTree = "<group>"; };
+		31CD50E2203E2E2800360B3A /* ToolbarItemWrapperView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ToolbarItemWrapperView.m; sourceTree = "<group>"; };
 		E212A6DD1B92100E00F62B18 /* libiconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
 		E21739F51A5080DD00EC6777 /* DocumentController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DocumentController.h; sourceTree = "<group>"; };
 		E21739F61A5080DD00EC6777 /* DocumentController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DocumentController.m; sourceTree = "<group>"; };
@@ -268,6 +271,8 @@
 				E2C338BD19F8562F00063D95 /* MainMenu.xib */,
 				E2C5672B1A6D98BC00ECFE07 /* WindowController.h */,
 				E2C5672C1A6D98BC00ECFE07 /* WindowController.m */,
+				31CD50E1203E2E2800360B3A /* ToolbarItemWrapperView.h */,
+				31CD50E2203E2E2800360B3A /* ToolbarItemWrapperView.m */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -422,6 +427,7 @@
 				E2C5672D1A6D98BC00ECFE07 /* WindowController.m in Sources */,
 				E2C338B219F8562F00063D95 /* AppDelegate.m in Sources */,
 				E2C338B719F8562F00063D95 /* Document.m in Sources */,
+				31CD50E3203E2E2800360B3A /* ToolbarItemWrapperView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Standard macOS behavior, when the user double-clicks in a window title bar, is to zoom (or unzoom) the window.

Double-cilck-to-zoom doesn't work for most of GitUp's title bar.

These patches make double-clicking GitUp's title bar zoom the window.

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT.