### PR TITLE
Allow searching single file history with prefix "/" 

### DIFF
--- a/GitUp/Application/AppDelegate.m
+++ b/GitUp/Application/AppDelegate.m
@@ -210,7 +210,6 @@
   [[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:url
                                                                          display:YES
                                                                completionHandler:^(NSDocument* document, BOOL documentWasAlreadyOpen, NSError* openError) {
-
                                                                  if (document) {
                                                                    if (documentWasAlreadyOpen) {
                                                                      if ((NSUInteger)windowModeID != NSNotFound) {
@@ -226,7 +225,6 @@
                                                                  } else {
                                                                    [[NSDocumentController sharedDocumentController] presentError:openError];
                                                                  }
-
                                                                }];
 }
 

--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -441,19 +441,15 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
   [_repository performOperationInBackgroundWithReason:@"clone"
       argument:nil
       usingOperationBlock:^BOOL(GCRepository* repository, NSError** outError) {
-
         return [repository cloneUsingRemote:remote recursive:recursive error:outError];
-
       }
       completionBlock:^(BOOL success, NSError* error) {
-
         [_repository resumeHistoryUpdates];
         if (!success) {
           [self presentError:error];
         }
         [self _prepareSearch];
         [self _resetCheckTimer];
-
       }];
 }
 
@@ -461,17 +457,13 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
   [_repository performOperationInBackgroundWithReason:nil
       argument:nil
       usingOperationBlock:^BOOL(GCRepository* repository, NSError** outError) {
-
         return [repository initializeAllSubmodules:YES error:outError];
-
       }
       completionBlock:^(BOOL success, NSError* error) {
-
         if (!success) {
           [self presentError:error];
         }
         [self _resetCheckTimer];
-
       }];
 }
 
@@ -484,7 +476,6 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
   __block CFTimeInterval lastTime = 0.0;
   [_repository prepareSearchInBackground:[[_repository userInfoForKey:kRepositoryUserInfoKey_IndexDiffs] boolValue]
       withProgressHandler:^BOOL(BOOL firstUpdate, NSUInteger addedCommits, NSUInteger removedCommits) {
-
         if (firstUpdate) {
           float progress = MIN(roundf(1000 * (float)addedCommits / (float)totalCount) / 10, 100.0);
           if (progress > lastProgress) {
@@ -503,10 +494,8 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
           }
         }
         return !_abortIndexing;
-
       }
       completion:^(BOOL success, NSError* error) {
-
         if (!_abortIndexing) {  // If indexing has been aborted, this means the document has already been closed, so don't attempt to do *anything*
           if (success) {
             _searchReady = YES;
@@ -519,7 +508,6 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
           [[NSProcessInfo processInfo] enableSuddenTermination];
           _indexing = NO;
         }
-
       }];
 }
 
@@ -556,14 +544,12 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
         alert.showsSuppressionButton = YES;
         [alert beginSheetModalForWindow:_mainWindow
                   withCompletionHandler:^(NSInteger returnCode) {
-
                     if (alert.suppressionButton.state) {
                       [_repository setUserInfo:@(YES) forKey:kRepositoryUserInfoKey_SkipSubmoduleCheck];
                     }
                     if (returnCode == NSAlertDefaultReturn) {
                       [self _initializeSubmodules];
                     }
-
                   }];
         return;  // Don't do anything else
       } else {
@@ -1671,7 +1657,6 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
   [alert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
   [alert beginSheetModalForWindow:_mainWindow
             withCompletionHandler:^(NSInteger returnCode) {
-
               if (returnCode == NSAlertFirstButtonReturn) {
                 NSError* error;
                 if (![_repository resetToHEAD:kGCResetMode_Hard error:&error] || (_untrackedButton.state && ![_repository cleanWorkingDirectory:&error]) || ![_repository updateAllSubmodulesResursively:YES error:&error]) {
@@ -1679,7 +1664,6 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
                 }
                 [_repository notifyRepositoryChanged];
               }
-
             }];
 }
 
@@ -1909,7 +1893,6 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
     _checkingForChanges = YES;
     NSString* path = _repository.repositoryPath;  // Avoid race-condition in case _repository is set to nil before block is executed
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-
       NSMutableDictionary* updatedReferences = [[NSMutableDictionary alloc] init];
       GCRepository* repository = [[GCRepository alloc] initWithExistingLocalRepository:path error:NULL];
       repository.delegate = (id<GCRepositoryDelegate>)self.class;  // Don't use self as we don't want to show progress UI nor authentication prompts
@@ -1927,7 +1910,6 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
         }
       }
       dispatch_async(dispatch_get_main_queue(), ^{
-
         if (_repository) {
           _updatedReferences = updatedReferences;
           if (_updatedReferences.count) {
@@ -1946,9 +1928,7 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
         } else {
           XLOG_WARNING(@"Remote check completed after document was closed");
         }
-
       });
-
     });
   } else {
     XLOG_DEBUG_UNREACHABLE();  // Not sure how this can happen but it has in the field

--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -1173,7 +1173,7 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
 
 - (NSArray*)toolbarDefaultItemIdentifiers:(NSToolbar*)toolbar {
   if (_unifiedToolbar) {
-    return @[ kToolbarItem_Left, kToolbarItem_Title, NSToolbarSpaceItemIdentifier, kToolbarItem_Right ];
+    return @[ kToolbarItem_Left, kToolbarItem_Title, kToolbarItem_Right ];
   }
   return @[ kToolbarItem_Left, NSToolbarFlexibleSpaceItemIdentifier, kToolbarItem_Right ];
 }

--- a/GitUp/Application/ToolbarItemWrapperView.h
+++ b/GitUp/Application/ToolbarItemWrapperView.h
@@ -1,0 +1,20 @@
+//  Copyright (C) 2018 Rob Mayoff <gitup@rob.dqd.com>.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import <AppKit/AppKit.h>
+
+@interface ToolbarItemWrapperView : NSView
+
+@end

--- a/GitUp/Application/ToolbarItemWrapperView.m
+++ b/GitUp/Application/ToolbarItemWrapperView.m
@@ -1,0 +1,43 @@
+//  Copyright (C) 2018 Rob Mayoff <gitup@rob.dqd.com>.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import "ToolbarItemWrapperView.h"
+
+@implementation ToolbarItemWrapperView
+
+- (NSView*)hitTest:(NSPoint)point {
+  // Normally, a double-click in a window title bar zooms the window on the second mouse-up. In a unified title/toolbar window, if a mouse-up hit-tests into a subview of a toolbar item, the mouse-up cannot zoom the window. This subclass selectively suppresses hits to allow a double-click to zoom its window.
+  id hit = [super hitTest:point];
+
+  if ([hit isKindOfClass:[NSTextField class]]) {
+    NSTextField* field = hit;
+    return field.selectable ? field : nil;
+  }
+
+  if ([hit isKindOfClass:[NSControl class]]) {
+    NSControl* control = hit;
+    return control.isEnabled ? control : nil;
+  }
+
+  if ([hit isKindOfClass:[NSTextView class]]) {
+    // The search field adds the field editor, an NSTextView, as a subview when it's being edited.
+    NSTextView* textView = hit;
+    return textView.selectable ? textView : nil;
+  }
+
+  return nil;
+}
+
+@end

--- a/GitUp/Application/en.lproj/Document.xib
+++ b/GitUp/Application/en.lproj/Document.xib
@@ -501,7 +501,7 @@ Adjust settings in Show menu</string>
             </subviews>
             <point key="canvasLocation" x="-512.5" y="1242"/>
         </customView>
-        <customView id="ghu-yR-ohT" userLabel="Title View">
+        <customView id="ghu-yR-ohT" userLabel="Title View" customClass="ToolbarItemWrapperView">
             <rect key="frame" x="0.0" y="0.0" width="320" height="32"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
@@ -526,7 +526,7 @@ Adjust settings in Show menu</string>
             </subviews>
             <point key="canvasLocation" x="200" y="408"/>
         </customView>
-        <customView id="d4D-Mc-I9O" userLabel="Left View">
+        <customView id="d4D-Mc-I9O" userLabel="Left View" customClass="ToolbarItemWrapperView">
             <rect key="frame" x="0.0" y="0.0" width="220" height="32"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
@@ -580,13 +580,13 @@ Adjust settings in Show menu</string>
             </subviews>
             <point key="canvasLocation" x="469" y="496"/>
         </customView>
-        <customView id="kfr-yg-mn6" userLabel="Right View">
-            <rect key="frame" x="0.0" y="0.0" width="220" height="32"/>
+        <customView misplaced="YES" id="kfr-yg-mn6" userLabel="Right View" customClass="ToolbarItemWrapperView">
+            <rect key="frame" x="0.0" y="0.0" width="260" height="32"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
                 <searchField toolTip="Search repository" wantsLayer="YES" verticalHuggingPriority="750" id="mcD-hz-JrS">
-                    <rect key="frame" x="37" y="5" width="180" height="22"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <rect key="frame" x="77" y="5" width="180" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                     <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" allowsUndo="NO" borderStyle="bezel" placeholderString="" usesSingleLineMode="YES" bezelStyle="round" id="3QH-Xd-ctD">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -598,8 +598,8 @@ Adjust settings in Show menu</string>
                     </connections>
                 </searchField>
                 <button toolTip="Show or hide Snapshots" verticalHuggingPriority="750" id="yWu-L8-6Ms">
-                    <rect key="frame" x="3" y="3" width="25" height="25"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <rect key="frame" x="43" y="3" width="25" height="25"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="icon_nav_snapshot" imagePosition="only" alignment="center" alternateImage="icon_nav_snapshot_pressed" borderStyle="border" inset="2" id="rrq-JQ-Zyn">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -609,7 +609,7 @@ Adjust settings in Show menu</string>
                     </connections>
                 </button>
                 <button id="FEG-0e-0JW">
-                    <rect key="frame" x="206" y="9" width="12" height="15"/>
+                    <rect key="frame" x="246" y="9" width="12" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="bevel" bezelStyle="regularSquare" image="icon_nav_min" imagePosition="overlaps" alignment="center" alternateImage="icon_nav_min_pressed" inset="2" id="x0U-ct-UgO">
                         <behavior key="behavior" lightByContents="YES"/>
@@ -620,7 +620,7 @@ Adjust settings in Show menu</string>
                     </connections>
                 </button>
             </subviews>
-            <point key="canvasLocation" x="197.5" y="496"/>
+            <point key="canvasLocation" x="150" y="496"/>
         </customView>
         <customView id="ifo-84-dTf" userLabel="Reset View">
             <rect key="frame" x="0.0" y="0.0" width="300" height="19"/>

--- a/GitUp/GitUp.xcodeproj/project.pbxproj
+++ b/GitUp/GitUp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		165C32B61B95739700D2F894 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 165C32B51B95739700D2F894 /* QuartzCore.framework */; };
+		31CD50E3203E2E2800360B3A /* ToolbarItemWrapperView.m in Sources */ = {isa = PBXBuildFile; fileRef = 31CD50E2203E2E2800360B3A /* ToolbarItemWrapperView.m */; };
 		E212A6DE1B92100E00F62B18 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E212A6DD1B92100E00F62B18 /* libiconv.dylib */; };
 		E21739F71A5080DD00EC6777 /* DocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = E21739F61A5080DD00EC6777 /* DocumentController.m */; };
 		E21DCAEB1B253847006424E8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E21DCAEA1B253847006424E8 /* main.m */; };
@@ -106,6 +107,8 @@
 
 /* Begin PBXFileReference section */
 		165C32B51B95739700D2F894 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		31CD50E1203E2E2800360B3A /* ToolbarItemWrapperView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ToolbarItemWrapperView.h; sourceTree = "<group>"; };
+		31CD50E2203E2E2800360B3A /* ToolbarItemWrapperView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ToolbarItemWrapperView.m; sourceTree = "<group>"; };
 		E212A6DD1B92100E00F62B18 /* libiconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
 		E21739F51A5080DD00EC6777 /* DocumentController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DocumentController.h; sourceTree = "<group>"; };
 		E21739F61A5080DD00EC6777 /* DocumentController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DocumentController.m; sourceTree = "<group>"; };
@@ -268,6 +271,8 @@
 				E2C338BD19F8562F00063D95 /* MainMenu.xib */,
 				E2C5672B1A6D98BC00ECFE07 /* WindowController.h */,
 				E2C5672C1A6D98BC00ECFE07 /* WindowController.m */,
+				31CD50E1203E2E2800360B3A /* ToolbarItemWrapperView.h */,
+				31CD50E2203E2E2800360B3A /* ToolbarItemWrapperView.m */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -422,6 +427,7 @@
 				E2C5672D1A6D98BC00ECFE07 /* WindowController.m in Sources */,
 				E2C338B219F8562F00063D95 /* AppDelegate.m in Sources */,
 				E2C338B719F8562F00063D95 /* Document.m in Sources */,
+				31CD50E3203E2E2800360B3A /* ToolbarItemWrapperView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GitUpKit/Components/GISnapshotListViewController.m
+++ b/GitUpKit/Components/GISnapshotListViewController.m
@@ -150,7 +150,6 @@
                                        skipCheckoutOnUndo:NO
                                                     error:&error
                                                usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                                  BOOL didUpdateReferences;
                                                  if (![repository restoreSnapshot:snapshot
                                                                       withOptions:(kGCSnapshotOption_IncludeHEAD | kGCSnapshotOption_IncludeLocalBranches | kGCSnapshotOption_IncludeTags)
@@ -166,7 +165,6 @@
                                                    didUpdate = YES;
                                                  }
                                                  return YES;
-
                                                }];
   }
   if (success) {

--- a/GitUpKit/Components/GIUnifiedReflogViewController.m
+++ b/GitUpKit/Components/GIUnifiedReflogViewController.m
@@ -279,7 +279,6 @@ static NSString* _StringFromActions(GCReflogActions actions) {
   [alert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
   [self presentAlert:alert
       completionHandler:^(NSInteger returnCode) {
-
         if (returnCode == NSAlertFirstButtonReturn) {
           NSString* name = [_nameTextField.stringValue stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
           if (name.length) {
@@ -292,7 +291,6 @@ static NSString* _StringFromActions(GCReflogActions actions) {
                                                  skipCheckoutOnUndo:NO
                                                               error:&error
                                                          usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                                            GCLocalBranch* branch = [repository createLocalBranchFromCommit:entry.toCommit withName:name force:NO error:outError];
                                                            if (branch == nil) {
                                                              return NO;
@@ -302,7 +300,6 @@ static NSString* _StringFromActions(GCReflogActions actions) {
                                                              return NO;
                                                            }
                                                            return YES;
-
                                                          }];
             }
             if (success) {
@@ -316,7 +313,6 @@ static NSString* _StringFromActions(GCReflogActions actions) {
             NSBeep();
           }
         }
-
       }];
 }
 

--- a/GitUpKit/Core/GCBranch.m
+++ b/GitUpKit/Core/GCBranch.m
@@ -99,7 +99,6 @@
   BOOL success = [self enumerateReferencesWithOptions:kGCReferenceEnumerationOption_RetainReferences
                                                 error:error
                                            usingBlock:^BOOL(git_reference* reference) {
-
                                              if ((flags & GIT_BRANCH_LOCAL) && git_reference_is_branch(reference)) {
                                                GCLocalBranch* branch = [[GCLocalBranch alloc] initWithRepository:self reference:reference];
                                                [array addObject:branch];
@@ -110,7 +109,6 @@
                                                git_reference_free(reference);
                                              }
                                              return YES;
-
                                            }];
   return success ? array : nil;
 }

--- a/GitUpKit/Core/GCCommitDatabase.m
+++ b/GitUpKit/Core/GCCommitDatabase.m
@@ -1048,7 +1048,6 @@ cleanup:
   if (![_repository enumerateReferencesWithOptions:kGCReferenceEnumerationOption_IncludeHEAD
                                              error:error
                                         usingBlock:^BOOL(git_reference* reference) {
-
                                           if (git_reference_type(reference) == GIT_REF_OID) {  // We don't care about symbolic references as they eventually point to a direct one anyway
                                             const git_oid* oid = git_reference_target(reference);
                                             git_object* object = NULL;
@@ -1078,7 +1077,6 @@ cleanup:
                                             git_object_free(object);
                                           }
                                           return YES;
-
                                         }]) {
     goto cleanup;
   }

--- a/GitUpKit/Core/GCDiff.m
+++ b/GitUpKit/Core/GCDiff.m
@@ -534,7 +534,6 @@ cleanup:
                      maxContextLines:maxContextLines
                                error:error
                                block:^int(git_diff** outDiff, git_diff_options* diffOptions) {
-
                                  int status = git_diff_tree_to_index(outDiff, self.private, tree, index.private, diffOptions);
                                  if (status == GIT_OK) {
                                    git_diff* diff2;
@@ -554,7 +553,6 @@ cleanup:
                                    }
                                  }
                                  return status;
-
                                }];
   git_tree_free(tree);
   return diff;
@@ -579,14 +577,12 @@ cleanup:
              maxContextLines:maxContextLines
                        error:error
                        block:^int(git_diff** outDiff, git_diff_options* diffOptions) {
-
                          diffOptions->flags |= GIT_DIFF_UPDATE_INDEX;
                          int status = git_diff_index_to_workdir(outDiff, self.private, index.private, diffOptions);
                          if (status == GIT_ELOCKED) {
                            status = GIT_OK;  // Passing GIT_DIFF_UPDATE_INDEX means git_diff_index_to_workdir() will attempt to write the index even if there are no changes and this could fail if it is currently locked by another process
                          }
                          return status;
-
                        }];
 }
 
@@ -614,9 +610,7 @@ cleanup:
                      maxContextLines:maxContextLines
                                error:error
                                block:^int(git_diff** outDiff, git_diff_options* diffOptions) {
-
                                  return git_diff_tree_to_index(outDiff, self.private, tree, index.private, diffOptions);
-
                                }];
   git_tree_free(tree);
   return diff;
@@ -646,9 +640,7 @@ cleanup:
                      maxContextLines:maxContextLines
                                error:error
                                block:^int(git_diff** outDiff, git_diff_options* diffOptions) {
-
                                  return git_diff_tree_to_tree(outDiff, self.private, oldTree, newTree, diffOptions);
-
                                }];
   git_tree_free(newTree);
   git_tree_free(oldTree);
@@ -669,9 +661,7 @@ cleanup:
              maxContextLines:maxContextLines
                        error:error
                        block:^int(git_diff** outDiff, git_diff_options* diffOptions) {
-
                          return git_diff_index_to_index(outDiff, self.private, oldIndex.private, newIndex.private, diffOptions);
-
                        }];
 }
 

--- a/GitUpKit/Core/GCHistory.m
+++ b/GitUpKit/Core/GCHistory.m
@@ -337,7 +337,6 @@ static const void* _associatedObjectUpstreamNameKey = &_associatedObjectUpstream
     while (1) {
       NSUInteger oldCounter = counter;
       if (![walker iterateWithCommitBlock:^(GCHistoryCommit* commit, BOOL* stop) {
-
             if (!COMMIT_STATE(commit)) {
               BOOL skip = NO;
               CFArrayRef children = commit->_children;
@@ -354,7 +353,6 @@ static const void* _associatedObjectUpstreamNameKey = &_associatedObjectUpstream
                 ++counter;
               }
             }
-
           }] ||
           (counter == oldCounter)) {
         break;
@@ -781,7 +779,6 @@ static const void* _associatedObjectUpstreamNameKey = &_associatedObjectUpstream
   // Find all other tips
   BOOL (^enumerateBlock)
   (git_reference*) = ^(git_reference* reference) {
-
     GCReference* referenceObject = nil;
     if (git_reference_type(reference) != GIT_REF_SYMBOLIC) {  // Skip symbolic refs like "remote/origin/HEAD"
       git_commit* commit = NULL;
@@ -867,7 +864,6 @@ static const void* _associatedObjectUpstreamNameKey = &_associatedObjectUpstream
       git_reference_free(reference);
     }
     return YES;
-
   };
   if (snapshot) {
     for (GCSerializedReference* serializedReference in snapshot.serializedReferences) {
@@ -990,13 +986,11 @@ static const void* _associatedObjectUpstreamNameKey = &_associatedObjectUpstream
       XLOG_DEBUG_CHECK(tipCommit);
       [self _walkAncestorsFromCommit:tipCommit
                           usingBlock:^BOOL(GCHistoryCommit* commit, GCHistoryCommit* previousCommit) {
-
                             if (commit->generation == generation) {
                               return NO;
                             }
                             commit->generation = generation;
                             return YES;
-
                           }];
     }
 
@@ -1009,7 +1003,6 @@ static const void* _associatedObjectUpstreamNameKey = &_associatedObjectUpstream
       }
       [self _walkAncestorsFromCommit:tipCommit
                           usingBlock:^BOOL(GCHistoryCommit* commit, GCHistoryCommit* childCommit) {
-
                             if (commit->generation == generation) {
                               if (childCommit) {
                                 [childCommit removeParent:commit];
@@ -1029,7 +1022,6 @@ static const void* _associatedObjectUpstreamNameKey = &_associatedObjectUpstream
                               }
                             }
                             return YES;
-
                           }];
     }
   }

--- a/GitUpKit/Core/GCIndex.m
+++ b/GitUpKit/Core/GCIndex.m
@@ -355,7 +355,6 @@ cleanup:
   }
   [patch enumerateUsingBeginHunkHandler:NULL
                             lineHandler:^(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber, const char* contentBytes, NSUInteger contentLength) {
-
                               /* Comparing workdir to index:
      
      Change      | Filter     | Write?
@@ -383,7 +382,6 @@ cleanup:
                               if (shouldWrite) {
                                 [data appendBytes:contentBytes length:contentLength];
                               }
-
                             }
                          endHunkHandler:NULL];
 
@@ -453,7 +451,6 @@ cleanup:
   }
   [patch enumerateUsingBeginHunkHandler:NULL
                             lineHandler:^(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber, const char* contentBytes, NSUInteger contentLength) {
-
                               /* Comparing index to commit:
      
      Change      | Filter     | Write?
@@ -481,7 +478,6 @@ cleanup:
                               if (shouldWrite) {
                                 [data appendBytes:contentBytes length:contentLength];
                               }
-
                             }
                          endHunkHandler:NULL];
 
@@ -533,7 +529,6 @@ cleanup:
     __block BOOL failed = NO;
     [patch enumerateUsingBeginHunkHandler:NULL
                               lineHandler:^(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber, const char* contentBytes, NSUInteger contentLength) {
-
                                 /* Comparing workdir to index:
        
        Change      | Filter     | Write?
@@ -563,7 +558,6 @@ cleanup:
                                   failed = YES;
                                   XLOG_DEBUG_UNREACHABLE();
                                 }
-
                               }
                            endHunkHandler:NULL];
     if (failed) {
@@ -643,7 +637,6 @@ cleanup:
   }
   [patch enumerateUsingBeginHunkHandler:NULL
                             lineHandler:^(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber, const char* contentBytes, NSUInteger contentLength) {
-
                               /* Comparing other index to index:
      
      Change      | Filter     | Write?
@@ -671,7 +664,6 @@ cleanup:
                               if (shouldWrite) {
                                 [data appendBytes:contentBytes length:contentLength];
                               }
-
                             }
                          endHunkHandler:NULL];
 

--- a/GitUpKit/Core/GCLiveRepository.m
+++ b/GitUpKit/Core/GCLiveRepository.m
@@ -443,7 +443,6 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
   NSString* path = [self.privateAppDirectoryPath stringByAppendingPathComponent:kCommitDatabaseFileName];
   _updatingDatabase = YES;
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
-
     NSError* error;
     GCRepository* repository = [[GCRepository alloc] initWithExistingLocalRepository:self.repositoryPath error:&error];  // We cannot use self because we access the repo on a background thread
     GCCommitDatabase* database = repository ? [[GCCommitDatabase alloc] initWithRepository:repository
@@ -454,13 +453,10 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
     BOOL success = [database updateWithProgressHandler:handler error:&error];
     database = nil;  // Release and close immediately
     dispatch_async(dispatch_get_main_queue(), ^{
-
       XLOG_DEBUG_CHECK(_updatingDatabase);
       _updatingDatabase = NO;
       completion(success, error);
-
     });
-
   });
 }
 
@@ -471,7 +467,6 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
   } else {
     [self _updateDatabaseInBackgroundWithProgressHandler:NULL
                                               completion:^(BOOL success, NSError* error) {
-
                                                 if (success) {
                                                   if ([self.delegate respondsToSelector:@selector(repositoryDidUpdateSearch:)]) {
                                                     [self.delegate repositoryDidUpdateSearch:self];
@@ -487,7 +482,6 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
                                                     [self.delegate repository:self searchUpdateDidFailWithError:error];
                                                   }
                                                 }
-
                                               }];
   }
 }
@@ -859,12 +853,10 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
       [self.delegate repositoryBackgroundOperationInProgressDidChange:self];
     }
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-
       GCRepository* repository = [[GCRepository alloc] initWithExistingLocalRepository:self.repositoryPath error:&error];
       repository.delegate = self.delegate;
       __block BOOL success = repository && operationBlock(repository, &error);
       dispatch_async(dispatch_get_main_queue(), ^{
-
         if (success) {
           GCSnapshot* afterSnapshot = reason ? [self takeSnapshot:&error] : nil;
           if (!reason || afterSnapshot) {
@@ -881,15 +873,11 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
         }
         [[NSProcessInfo processInfo] enableSuddenTermination];
         completionBlock(success, error);
-
       });
-
     });
   } else {
     dispatch_async(dispatch_get_main_queue(), ^{
-
       completionBlock(NO, error);
-
     });
   }
 }
@@ -907,7 +895,6 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
                        skipCheckoutOnUndo:NO
                                     error:error
                                usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                  GCReferenceTransform* transform = block(repository, outError);
                                  if (!transform) {
                                    return NO;
@@ -927,7 +914,6 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
                                    return [self checkoutTreeForCommit:nil withBaseline:oldHeadCommit options:kGCCheckoutOption_UpdateSubmodulesRecursively error:outError];
                                  }
                                  return YES;
-
                                }];
 }
 
@@ -938,10 +924,8 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
                      skipCheckoutOnUndo:YES
                                   error:error
                              usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                newCommit = [repository createCommitFromHEADAndOtherParent:parent withMessage:message error:outError];
                                return newCommit ? YES : NO;
-
                              }]) {
     return nil;
   }
@@ -955,10 +939,8 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
                      skipCheckoutOnUndo:YES
                                   error:error
                              usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                newCommit = [repository createCommitByAmendingHEADWithMessage:message error:error];
                                return newCommit ? YES : NO;
-
                              }]) {
     return nil;
   }
@@ -976,7 +958,6 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
     _databaseIndexesDiffs = indexDiffs;
     [self _updateDatabaseInBackgroundWithProgressHandler:handler
                                               completion:^(BOOL success, NSError* error) {
-
                                                 if (success) {
                                                   NSString* path = [self.privateAppDirectoryPath stringByAppendingPathComponent:kCommitDatabaseFileName];
                                                   _database = [[GCCommitDatabase alloc] initWithRepository:self
@@ -993,7 +974,6 @@ static void _StreamCallback(ConstFSEventStreamRef streamRef, void* clientCallBac
                                                   }
                                                 }
                                                 completion(success, error);
-
                                               }];
   } else {
     XLOG_DEBUG_UNREACHABLE();

--- a/GitUpKit/Core/GCLiveRepository.m
+++ b/GitUpKit/Core/GCLiveRepository.m
@@ -992,9 +992,9 @@ static BOOL _MatchReference(NSString* match, NSString* name) {
   match = [match stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
   bool searchFileHistoryOnly = [match hasPrefix:@"/"];
   // Search file history directly
-  if(match.length >= kMinSearchLength && searchFileHistoryOnly) {
+  if(match.length >= (kMinSearchLength + 1) && searchFileHistoryOnly) {
     NSArray* fileCommits = [_history.repository lookupCommitsForFile:[match substringFromIndex:1] followRenames:YES error:NULL];
-    if([fileCommits count] > 0) {
+    if(fileCommits.count > 0) {
       [results addObjectsFromArray:fileCommits];
     }
   }
@@ -1015,7 +1015,7 @@ static BOOL _MatchReference(NSString* match, NSString* name) {
         }
       }
     }
-    
+
     // Search references
     for (GCHistoryLocalBranch* branch in _history.localBranches) {
       if (_MatchReference(match, branch.name)) {

--- a/GitUpKit/Core/GCLiveRepository.m
+++ b/GitUpKit/Core/GCLiveRepository.m
@@ -988,8 +988,18 @@ static BOOL _MatchReference(NSString* match, NSString* name) {
 - (NSArray*)findCommitsMatching:(NSString*)match {
   XLOG_DEBUG_CHECK(_database);
   NSMutableArray* results = [[NSMutableArray alloc] init];
+  
   match = [match stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-  if (match.length >= kMinSearchLength) {
+  bool searchFileHistoryOnly = [match hasPrefix:@"/"];
+  // Search file history directly
+  if(match.length >= kMinSearchLength && searchFileHistoryOnly) {
+    NSArray* fileCommits = [_history.repository lookupCommitsForFile:[match substringFromIndex:1] followRenames:YES error:NULL];
+    if([fileCommits count] > 0) {
+      [results addObjectsFromArray:fileCommits];
+    }
+  }
+  
+  if (match.length >= kMinSearchLength && !searchFileHistoryOnly) {
     // Search SHA1s directly
     NSArray* words = [match componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
     for (NSString* prefix in words) {
@@ -1005,7 +1015,7 @@ static BOOL _MatchReference(NSString* match, NSString* name) {
         }
       }
     }
-
+    
     // Search references
     for (GCHistoryLocalBranch* branch in _history.localBranches) {
       if (_MatchReference(match, branch.name)) {

--- a/GitUpKit/Core/GCRemote.m
+++ b/GitUpKit/Core/GCRemote.m
@@ -254,7 +254,6 @@ cleanup:
   if (![self enumerateReferencesWithOptions:0
                                       error:error
                                  usingBlock:^BOOL(git_reference* reference) {
-
                                    const char* name = git_reference_name(reference);
                                    if (((options & kGCRemoteCheckOption_IncludeBranches) && git_reference__is_remote(name)) ||
                                        ((options & kGCRemoteCheckOption_IncludeTags) && git_reference__is_tag(name))) {
@@ -269,7 +268,6 @@ cleanup:
                                      }
                                    }
                                    return YES;
-
                                  }]) {
     goto cleanup;
   }
@@ -515,14 +513,12 @@ static BOOL _SetBranchDefaultUpstream(git_repository* repository, git_remote* re
   BOOL success = [self enumerateReferencesWithOptions:0
                                                 error:error
                                            usingBlock:^BOOL(git_reference* reference) {
-
                                              if ((branches && git_reference_is_branch(reference)) || (tags && git_reference_is_tag(reference))) {
                                                char* buffer;
                                                asprintf(&buffer, "%s%s:%s", force ? "+" : "", git_reference_name(reference), git_reference_name(reference));
                                                GC_POINTER_LIST_APPEND(buffers, buffer);
                                              }
                                              return YES;
-
                                            }];
   if (success) {
     success = [self _pushToRemote:remote refspecs:(const char**)GC_POINTER_LIST_ROOT(buffers) count:GC_POINTER_LIST_COUNT(buffers) error:error];
@@ -542,12 +538,10 @@ static BOOL _SetBranchDefaultUpstream(git_repository* repository, git_remote* re
   if (setUpstream && ![self enumerateReferencesWithOptions:0
                                                      error:error
                                                 usingBlock:^BOOL(git_reference* reference) {
-
                                                   if (git_reference_is_branch(reference) && !_SetBranchDefaultUpstream(self.private, remote.private, reference, error)) {
                                                     return NO;
                                                   }
                                                   return YES;
-
                                                 }]) {
     return NO;
   }

--- a/GitUpKit/Core/GCRepository+Reflog.m
+++ b/GitUpKit/Core/GCRepository+Reflog.m
@@ -254,7 +254,6 @@ static CFHashCode _EntryHashCallBack(const void* value) {
   BOOL success = [self enumerateReferencesWithOptions:(kGCReferenceEnumerationOption_IncludeHEAD | kGCReferenceEnumerationOption_RetainReferences)
                                                 error:error
                                            usingBlock:^BOOL(git_reference* rawReference) {
-
                                              if (git_reference_has_log(self.private, git_reference_name(rawReference))) {
                                                git_reflog* reflog;
                                                CALL_LIBGIT2_FUNCTION_RETURN(NO, git_reflog_read, &reflog, self.private, git_reference_name(rawReference));
@@ -294,7 +293,6 @@ static CFHashCode _EntryHashCallBack(const void* value) {
                                                git_reference_free(rawReference);
                                              }
                                              return YES;
-
                                            }];
   CFRelease(cache);
   if (!success) {

--- a/GitUpKit/Core/GCSnapshot.m
+++ b/GitUpKit/Core/GCSnapshot.m
@@ -280,7 +280,6 @@ cleanup:
     BOOL success = [repository enumerateReferencesWithOptions:kGCReferenceEnumerationOption_IncludeHEAD
                                                         error:error
                                                    usingBlock:^BOOL(git_reference* reference) {
-
                                                      git_object* object = NULL;
                                                      git_oid oid;
                                                      if ([repository loadTargetOID:&oid fromReference:reference error:NULL]) {  // Ignore errors since repositories can have invalid references
@@ -298,7 +297,6 @@ cleanup:
 
                                                      git_object_free(object);
                                                      return YES;
-
                                                    }];
     if (!success) {
       return nil;
@@ -644,12 +642,10 @@ cleanup:
   BOOL result = [self enumerateReferencesWithOptions:kGCReferenceEnumerationOption_IncludeHEAD
                                                error:error
                                           usingBlock:^BOOL(git_reference* reference) {
-
                                             GCSerializedReference* serializedReference = [[GCSerializedReference alloc] initWithReference:reference resolvedObject:NULL];
                                             [references addObject:serializedReference];
                                             [serializedReference release];
                                             return YES;
-
                                           }];
   if (result) {
     result = [self _restoreFromReferences:references andConfig:config toSnapshot:snapshot withOptions:options reflogMessage:message didUpdateReferences:didUpdateReferences error:error];

--- a/GitUpKit/Core/GCStash.m
+++ b/GitUpKit/Core/GCStash.m
@@ -136,7 +136,6 @@ cleanup:
 - (NSArray*)listStashes:(NSError**)error {
   NSMutableArray* array = [[NSMutableArray alloc] init];
   CALL_LIBGIT2_FUNCTION_RETURN(nil, git_stash_foreach_block, self.private, ^int(size_t index, const char* message, const git_oid* stash_id) {
-
     XLOG_DEBUG_CHECK(array.count == index);
     GCStash* stash = [self _newStashFromOID:stash_id error:error];
     if (stash == nil) {
@@ -144,7 +143,6 @@ cleanup:
     }
     [array addObject:stash];
     return GIT_OK;
-
   });
   return array;
 }
@@ -153,13 +151,11 @@ cleanup:
   const git_oid* oid = git_commit_id(stash.private);
   __block NSUInteger stashIndex = NSNotFound;
   CALL_LIBGIT2_FUNCTION_RETURN(NSNotFound, git_stash_foreach_block, self.private, ^int(size_t index, const char* message, const git_oid* stash_id) {
-
     if (git_oid_equal(stash_id, oid)) {
       XLOG_DEBUG_CHECK(stashIndex == NSNotFound);
       stashIndex = index;
     }
     return GIT_OK;
-
   });
   if (stashIndex == NSNotFound) {
     GC_SET_GENERIC_ERROR(@"Stash does not exist");

--- a/GitUpKit/Core/GCTag.m
+++ b/GitUpKit/Core/GCTag.m
@@ -101,7 +101,6 @@
   BOOL success = [self enumerateReferencesWithOptions:kGCReferenceEnumerationOption_RetainReferences
                                                 error:error
                                            usingBlock:^BOOL(git_reference* reference) {
-
                                              if (git_reference_is_tag(reference)) {
                                                GCTag* tag = [[GCTag alloc] initWithRepository:self reference:reference];
                                                [array addObject:tag];
@@ -109,7 +108,6 @@
                                                git_reference_free(reference);
                                              }
                                              return YES;
-
                                            }];
   return success ? array : nil;
 }

--- a/GitUpKit/Extensions/GCHistory+Rewrite.m
+++ b/GitUpKit/Extensions/GCHistory+Rewrite.m
@@ -170,7 +170,6 @@ typedef NS_ENUM(NSUInteger, ReplayMode) {
   __block BOOL success = YES;
   [self walkDescendantsOfCommits:@[ fromCommit ]
                       usingBlock:^(GCHistoryCommit* commit, BOOL* stop) {
-
                         if ([self isCommitOnAnyLocalBranch:commit]) {
                           if (CFDictionaryContainsKey(mapping, (__bridge const void*)commit)) {
                             return;
@@ -222,7 +221,6 @@ typedef NS_ENUM(NSUInteger, ReplayMode) {
                         } else {
                           XLOG_DEBUG(@"Skipping replay of commit \"%@\" (%@) not on local branch", commit.summary, commit.shortSHA1);
                         }
-
                       }];
   CFRelease(mapping);
   return success;

--- a/GitUpKit/Extensions/GCRepository+Index-Tests.m
+++ b/GitUpKit/Extensions/GCRepository+Index-Tests.m
@@ -207,9 +207,7 @@
                                          toIndex:index2
                                            error:NULL
                                      usingFilter:^BOOL(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber) {
-
                                        return (newLineNumber % 2);
-
                                      }]);
   XCTAssertFalse(index2.empty);
   NSData* data2 = [self.repository exportBlobWithOID:[index2 OIDForFile:@"lines.txt"] error:NULL];
@@ -225,9 +223,7 @@
                                          toIndex:index2
                                            error:NULL
                                      usingFilter:^BOOL(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber) {
-
                                        return YES;
-
                                      }]);
   NSData* data3 = [self.repository exportBlobWithOID:[index2 OIDForFile:@"lines.txt"] error:NULL];
   XCTAssertNotNil(data3);

--- a/GitUpKit/Extensions/GCRepository+Utilities.m
+++ b/GitUpKit/Extensions/GCRepository+Utilities.m
@@ -80,7 +80,6 @@ NSString* GCNameFromHostingService(GCHostingService service) {
                     recursive:recursive
                         error:error
                         block:^BOOL(GCRepository* repository, NSArray* remotes, NSError** blockError) {
-
                           for (GCRemote* remote in remotes) {
                             NSUInteger count;
                             if (![repository fetchDefaultRemoteBranchesFromRemote:remote tagMode:mode prune:prune updatedTips:&count error:blockError]) {
@@ -89,7 +88,6 @@ NSString* GCNameFromHostingService(GCHostingService service) {
                             total += count;
                           }
                           return YES;
-
                         }]) {
     return NO;
   }
@@ -105,7 +103,6 @@ NSString* GCNameFromHostingService(GCHostingService service) {
                     recursive:recursive
                         error:error
                         block:^BOOL(GCRepository* repository, NSArray* remotes, NSError** blockError) {
-
                           NSMutableArray* remoteTags = prune ? [[NSMutableArray alloc] init] : nil;
                           for (GCRemote* remote in remotes) {
                             NSUInteger count;
@@ -131,7 +128,6 @@ NSString* GCNameFromHostingService(GCHostingService service) {
                             }
                           }
                           return YES;
-
                         }]) {
     return NO;
   }

--- a/GitUpKit/Interface/GISplitDiffView.m
+++ b/GitUpKit/Interface/GISplitDiffView.m
@@ -180,7 +180,6 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
       }
     };
     [self.patch enumerateUsingBeginHunkHandler:^(NSUInteger oldLineNumber, NSUInteger oldLineCount, NSUInteger newLineNumber, NSUInteger newLineCount) {
-
       NSString* string = [[NSString alloc] initWithFormat:@"@@ -%lu,%lu +%lu,%lu @@", oldLineNumber, oldLineCount, newLineNumber, newLineCount];
       CFAttributedStringRef attributedString = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)string, GIDiffViewAttributes);
       CTLineRef line = CTLineCreateWithAttributedString(attributedString);
@@ -194,10 +193,8 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
       addedCount = 0;
       deletedCount = 0;
       startIndex = NSNotFound;
-
     }
         lineHandler:^(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber, const char* contentBytes, NSUInteger contentLength) {
-
           NSString* string;
           if (contentBytes[contentLength - 1] != '\n') {
             size_t length = strlen(GIDiffViewMissingNewlinePlaceholder);
@@ -304,12 +301,9 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
           } while (offset < length);
           CFRelease(typeSetter);
           CFRelease(attributedString);
-
         }
         endHunkHandler:^{
-
           highlightBlock();
-
         }];
     _size = NSMakeSize(width, _lines.count * GIDiffViewLineHeight + kTextBottomPadding);
   }

--- a/GitUpKit/Interface/GIUnifiedDiffView.m
+++ b/GitUpKit/Interface/GIUnifiedDiffView.m
@@ -148,17 +148,14 @@ typedef struct {
       }
     };
     [self.patch enumerateUsingBeginHunkHandler:^(NSUInteger oldLineNumber, NSUInteger oldLineCount, NSUInteger newLineNumber, NSUInteger newLineCount) {
-
       CFStringRef string = CFStringCreateWithFormat(kCFAllocatorDefault, NULL, CFSTR("@@ -%lu,%lu +%lu,%lu @@\n"), oldLineNumber, oldLineCount, newLineNumber, newLineCount);
       [self _addLineWithString:string change:NSNotFound oldLineNumber:oldLineNumber newLineNumber:newLineNumber contentBytes:NULL contentLength:0];
       CFRelease(string);
 
       deletedIndex = NSNotFound;
       addedIndex = NSNotFound;
-
     }
         lineHandler:^(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber, const char* contentBytes, NSUInteger contentLength) {
-
           CFStringRef string;
           if (contentBytes[contentLength - 1] != '\n') {
             size_t length = strlen(GIDiffViewMissingNewlinePlaceholder);
@@ -189,12 +186,9 @@ typedef struct {
             deletedIndex = NSNotFound;
             addedIndex = NSNotFound;
           }
-
         }
         endHunkHandler:^{
-
           highlightBlock(_lineInfoCount);
-
         }];
   }
 }

--- a/GitUpKit/Utilities/GIModalView.m
+++ b/GitUpKit/Utilities/GIModalView.m
@@ -112,11 +112,9 @@
     [[NSAnimationContext currentContext] setDuration:kAnimationDuration];
     [[NSAnimationContext currentContext] setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseIn]];
     [[NSAnimationContext currentContext] setCompletionHandler:^{
-
       if (handler) {
         handler();
       }
-
     }];
     [self.animator addSubview:view];
     [NSAnimationContext endGrouping];
@@ -142,12 +140,10 @@
     [[NSAnimationContext currentContext] setDuration:kAnimationDuration];
     [[NSAnimationContext currentContext] setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut]];
     [[NSAnimationContext currentContext] setCompletionHandler:^{
-
       view.wantsLayer = NO;
       if (handler) {
         handler();
       }
-
     }];
     [view.animator removeFromSuperviewWithoutNeedingDisplay];
     [NSAnimationContext endGrouping];

--- a/GitUpKit/Utilities/GIViewController+Utilities.m
+++ b/GitUpKit/Utilities/GIViewController+Utilities.m
@@ -67,14 +67,12 @@ static NSString* _diffTemporaryDirectoryPath = nil;
                                 button:NSLocalizedString(@"Discard All", nil)
              suppressionUserDefaultKey:nil
                                  block:^{
-
                                    NSError* error;
                                    if ([self.repository syncWorkingDirectoryWithIndex:&error]) {
                                      [self.repository notifyWorkingDirectoryChanged];
                                    } else {
                                      [self presentError:error];
                                    }
-
                                  }];
 }
 
@@ -127,13 +125,11 @@ static NSString* _diffTemporaryDirectoryPath = nil;
                                 button:NSLocalizedString(@"Discard", nil)
              suppressionUserDefaultKey:nil
                                  block:^{
-
                                    NSError* error;
                                    if (![self discardSubmoduleAtPath:path resetIndex:resetIndex error:&error]) {
                                      [self presentError:error];
                                    }
                                    [self.repository notifyWorkingDirectoryChanged];
-
                                  }];
 }
 
@@ -152,7 +148,6 @@ static NSString* _diffTemporaryDirectoryPath = nil;
   if ([self.repository addLinesFromFileToIndex:path
                                          error:&error
                                    usingFilter:^BOOL(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber) {
-
                                      if (change == kGCLineDiffChange_Added) {
                                        return [newLines containsIndex:newLineNumber];
                                      }
@@ -160,7 +155,6 @@ static NSString* _diffTemporaryDirectoryPath = nil;
                                        return [oldLines containsIndex:oldLineNumber];
                                      }
                                      return YES;
-
                                    }]) {
     [self.repository notifyRepositoryChanged];
   } else {
@@ -182,7 +176,6 @@ static NSString* _diffTemporaryDirectoryPath = nil;
   if ([self.repository resetLinesFromFileInIndexToHEAD:path
                                                  error:&error
                                            usingFilter:^BOOL(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber) {
-
                                              if (change == kGCLineDiffChange_Added) {
                                                return [newLines containsIndex:newLineNumber];
                                              }
@@ -190,7 +183,6 @@ static NSString* _diffTemporaryDirectoryPath = nil;
                                                return [oldLines containsIndex:oldLineNumber];
                                              }
                                              return NO;
-
                                            }]) {
     [self.repository notifyWorkingDirectoryChanged];
   } else {
@@ -222,13 +214,11 @@ static NSString* _diffTemporaryDirectoryPath = nil;
                                 button:NSLocalizedString(@"Discard", nil)
              suppressionUserDefaultKey:nil
                                  block:^{
-
                                    NSError* error;
                                    if (![self discardAllChangesForFile:path resetIndex:resetIndex error:&error]) {
                                      [self presentError:error];
                                    }
                                    [self.repository notifyWorkingDirectoryChanged];
-
                                  }];
 }
 
@@ -239,7 +229,6 @@ static NSString* _diffTemporaryDirectoryPath = nil;
   return [self.repository checkoutLinesFromFileFromIndex:path
                                                    error:error
                                              usingFilter:^BOOL(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber) {
-
                                                if (change == kGCLineDiffChange_Added) {
                                                  return [newLines containsIndex:newLineNumber];
                                                }
@@ -247,7 +236,6 @@ static NSString* _diffTemporaryDirectoryPath = nil;
                                                  return [oldLines containsIndex:oldLineNumber];
                                                }
                                                return NO;
-
                                              }];
 }
 
@@ -258,13 +246,11 @@ static NSString* _diffTemporaryDirectoryPath = nil;
                                 button:NSLocalizedString(@"Discard", nil)
              suppressionUserDefaultKey:nil
                                  block:^{
-
                                    NSError* error;
                                    if (![self discardSelectedChangesForFile:path oldLines:oldLines newLines:newLines resetIndex:resetIndex error:&error]) {
                                      [self presentError:error];
                                    }
                                    [self.repository notifyWorkingDirectoryChanged];
-
                                  }];
 }
 
@@ -275,14 +261,12 @@ static NSString* _diffTemporaryDirectoryPath = nil;
                                 button:NSLocalizedString(@"Delete", nil)
              suppressionUserDefaultKey:nil
                                  block:^{
-
                                    NSError* error;
                                    if ([self.repository safeDeleteFile:path error:&error]) {
                                      [self.repository notifyWorkingDirectoryChanged];
                                    } else {
                                      [self presentError:error];
                                    }
-
                                  }];
 }
 
@@ -293,13 +277,11 @@ static NSString* _diffTemporaryDirectoryPath = nil;
                                 button:NSLocalizedString(@"Restore", nil)
              suppressionUserDefaultKey:nil
                                  block:^{
-
                                    NSError* error;
                                    if (![self.repository safeDeleteFileIfExists:path error:&error] || ![self.repository checkoutFileToWorkingDirectory:path fromCommit:commit skipIndex:YES error:&error]) {
                                      [self presentError:error];
                                    }
                                    [self.repository notifyWorkingDirectoryChanged];
-
                                  }];
 }
 
@@ -320,11 +302,9 @@ static NSString* _diffTemporaryDirectoryPath = nil;
       [[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:[NSURL fileURLWithPath:subrepo.workingDirectoryPath]
                                                                              display:YES
                                                                    completionHandler:^(NSDocument* document, BOOL documentWasAlreadyOpen, NSError* openError) {
-
                                                                      if (!document) {
                                                                        [[NSDocumentController sharedDocumentController] presentError:openError];
                                                                      }
-
                                                                    }];
     } else if ([error.domain isEqualToString:GCErrorDomain] && (error.code == kGCErrorCode_NotFound)) {
       [self.windowController showOverlayWithStyle:kGIOverlayStyle_Warning format:NSLocalizedString(@"Submodule \"%@\" is not initialized", nil), submodule.name];

--- a/GitUpKit/Utilities/GIViewController.m
+++ b/GitUpKit/Utilities/GIViewController.m
@@ -272,14 +272,12 @@
     [alert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
     [self presentAlert:alert
         completionHandler:^(NSInteger returnCode) {
-
           if (returnCode == NSAlertFirstButtonReturn) {
             block();
           }
           if (alert.suppressionButton.state) {
             [[NSUserDefaults standardUserDefaults] setBool:YES forKey:key];
           }
-
         }];
   }
 }

--- a/GitUpKit/Utilities/GIWindowController.m
+++ b/GitUpKit/Utilities/GIWindowController.m
@@ -247,14 +247,12 @@ static void _TimerCallBack(CFRunLoopTimerRef timer, void* info) {
     [[NSAnimationContext currentContext] setDuration:kOverlayAnimationInDuration];
     [[NSAnimationContext currentContext] setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseIn]];
     [[NSAnimationContext currentContext] setCompletionHandler:^{
-
       _overlayTextField.stringValue = message;
       [NSAnimationContext beginGrouping];
       [[NSAnimationContext currentContext] setDuration:kOverlayAnimationInDuration];
       [[NSAnimationContext currentContext] setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut]];
       [_overlayTextField.animator setAlphaValue:1.0];
       [NSAnimationContext endGrouping];
-
     }];
     [_overlayTextField.animator setAlphaValue:0.0];
     [NSAnimationContext endGrouping];
@@ -346,14 +344,12 @@ static void _TimerCallBack(CFRunLoopTimerRef timer, void* info) {
   _previousResponder = nil;
 
   [_modalView dismissContentViewWithCompletionHandler:^{
-
     [_modalView removeFromSuperview];
     [_delegate windowControllerDidChangeHasModalView:self];
 
     [self.window enableCursorRects];  // TODO: This hides the cursor until it moves again?!
 
     [[NSProcessInfo processInfo] enableSuddenTermination];
-
   }];
 
   if (_handler) {

--- a/GitUpKit/Views/GIAdvancedCommitViewController.m
+++ b/GitUpKit/Views/GIAdvancedCommitViewController.m
@@ -255,7 +255,6 @@
                                     button:NSLocalizedString(@"Discard", nil)
                  suppressionUserDefaultKey:nil
                                      block:^{
-
                                        for (GCDiffDelta* delta in deltas) {
                                          NSError* error;
                                          BOOL submodule = delta.submodule;
@@ -269,7 +268,6 @@
                                          _indexActive = YES;
                                          [self.view.window makeFirstResponder:_indexFilesViewController.preferredFirstResponder];
                                        }
-
                                      }];
     } else {
       NSBeep();
@@ -402,7 +400,6 @@
                                     button:NSLocalizedString(@"Discard", nil)
                  suppressionUserDefaultKey:nil
                                      block:^{
-
                                        for (GCDiffDelta* delta in _diffContentsViewController.deltas) {
                                          NSIndexSet* oldLines;
                                          NSIndexSet* newLines;
@@ -419,7 +416,6 @@
                                          _indexActive = !_indexActive;
                                        }
                                        [self.view.window makeFirstResponder:(_indexActive ? _indexFilesViewController.preferredFirstResponder : _workdirFilesViewController.preferredFirstResponder)];
-
                                      }];
     } else {
       NSBeep();

--- a/GitUpKit/Views/GICommitRewriterViewController.m
+++ b/GitUpKit/Views/GICommitRewriterViewController.m
@@ -205,17 +205,13 @@
                                                    argument:_targetCommit.SHA1
                                                       error:error
                                                  usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError1) {
-
                                                    return [repository.history rewriteCommit:_targetCommit
                                                                           withUpdatedCommit:newCommit
                                                                                   copyTrees:NO
                                                                             conflictHandler:^GCCommit*(GCIndex* index2, GCCommit* ourCommit, GCCommit* theirCommit, NSArray* parentCommits, NSString* message2, NSError** outError2) {
-
                                                                               return [self resolveConflictsWithResolver:self.delegate index:index2 ourCommit:ourCommit theirCommit:theirCommit parentCommits:parentCommits message:message2 error:outError2];
-
                                                                             }
                                                                                       error:outError1];
-
                                                  }]) {
     [self.repository resumeHistoryUpdates];
     goto cleanup;
@@ -312,7 +308,6 @@ cleanup:
   [self.windowController runModalView:self.messageView
             withInitialFirstResponder:self.messageTextView
                     completionHandler:^(BOOL success) {
-
                       if (success) {
                         NSString* message = [self.messageTextView.string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
                         if (message.length) {
@@ -321,7 +316,6 @@ cleanup:
                           [self presentAlertWithType:kGIAlertType_Stop title:NSLocalizedString(@"You must provide a non-empty commit message", nil) message:nil];
                         }
                       }
-
                     }];
 }
 

--- a/GitUpKit/Views/GICommitSplitterViewController.m
+++ b/GitUpKit/Views/GICommitSplitterViewController.m
@@ -195,12 +195,10 @@
                                        toCommit:_commit
                                           error:&error
                                     usingFilter:^BOOL(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber) {
-
                                       if (change == kGCLineDiffChange_Added) {
                                         return [oldLines containsIndex:newLineNumber];
                                       }
                                       return NO;
-
                                     }];
   } else {
     success = [self.repository copyLinesInFile:delta.canonicalPath
@@ -208,7 +206,6 @@
                                        toIndex:_indexOld
                                          error:&error
                                    usingFilter:^BOOL(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber) {
-
                                      if (change == kGCLineDiffChange_Added) {
                                        return [newLines containsIndex:newLineNumber];
                                      }
@@ -216,7 +213,6 @@
                                        return [oldLines containsIndex:oldLineNumber];
                                      }
                                      return NO;
-
                                    }];
   }
   if (success) {
@@ -266,7 +262,6 @@
                                toCommit:_parentCommit
                                   error:&error
                             usingFilter:^BOOL(GCLineDiffChange change, NSUInteger oldLineNumber, NSUInteger newLineNumber) {
-
                               if (change == kGCLineDiffChange_Added) {
                                 return [newLines containsIndex:newLineNumber];
                               }
@@ -274,7 +269,6 @@
                                 return [oldLines containsIndex:oldLineNumber];
                               }
                               return NO;
-
                             }]) {
     [self _reload];
     _disableFeedback = YES;
@@ -336,18 +330,14 @@
                                                   argument:_commit.SHA1
                                                      error:error
                                                 usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError1) {
-
                                                   return [repository.history rewriteCommit:_commit
                                                                          withUpdatedCommit:newCommit
                                                                                  copyTrees:YES
                                                                            conflictHandler:^GCCommit*(GCIndex* index, GCCommit* ourCommit, GCCommit* theirCommit, NSArray* parentCommits, NSString* message3, NSError** outError2) {
-
                                                                              XLOG_DEBUG_UNREACHABLE();  // Splitting a commit should not generate index conflicts when replaying descendants
                                                                              return [self resolveConflictsWithResolver:self.delegate index:index ourCommit:ourCommit theirCommit:theirCommit parentCommits:parentCommits message:message3 error:outError2];
-
                                                                            }
                                                                                      error:outError1];
-
                                                 }]) {
     success = YES;
   }
@@ -528,7 +518,6 @@ cleanup:
   [self.windowController runModalView:_messageView
             withInitialFirstResponder:self.messageTextView
                     completionHandler:^(BOOL success) {
-
                       if (success) {
                         NSString* message = [self.messageTextView.string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
                         NSString* otherMessage = [self.otherMessageTextView.string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
@@ -538,7 +527,6 @@ cleanup:
                           [self presentAlertWithType:kGIAlertType_Stop title:NSLocalizedString(@"You must provide non-empty commit messages", nil) message:nil];
                         }
                       }
-
                     }];
 }
 

--- a/GitUpKit/Views/GIConfigViewController.m
+++ b/GitUpKit/Views/GIConfigViewController.m
@@ -311,7 +311,6 @@ static NSMutableDictionary* _patternHelp = nil;
   [self.windowController runModalView:_editView
             withInitialFirstResponder:(option ? _valueTextField : _nameTextField)
             completionHandler:^(BOOL success) {
-
               if (success) {
                 NSString* name = option ? option.variable : [_nameTextField.stringValue stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
                 NSString* value = [_valueTextField.stringValue stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
@@ -333,7 +332,6 @@ static NSMutableDictionary* _patternHelp = nil;
                   NSBeep();
                 }
               }
-
             }];
 }
 

--- a/GitUpKit/Views/GIMapViewController+Operations.m
+++ b/GitUpKit/Views/GIMapViewController+Operations.m
@@ -116,9 +116,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 skipCheckoutOnUndo:NO
                                              error:&error
                                         usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                           return [repository checkoutCommit:commit options:kGCCheckoutOption_UpdateSubmodulesRecursively error:outError];
-
                                         }]) {
     [self presentError:error];
   }
@@ -133,9 +131,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 skipCheckoutOnUndo:NO
                                              error:&error
                                         usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                           return [repository checkoutLocalBranch:branch options:kGCCheckoutOption_UpdateSubmodulesRecursively error:outError];
-
                                         }]) {
     [self presentError:error];
   }
@@ -150,7 +146,6 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 skipCheckoutOnUndo:NO
                                              error:&error
                                         usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                           GCLocalBranch* localBranch = [repository createLocalBranchFromCommit:remoteBranch.tipCommit withName:remoteBranch.branchName force:NO error:outError];
                                           if (localBranch == nil) {
                                             return NO;
@@ -163,7 +158,6 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                             return NO;
                                           }
                                           return YES;
-
                                         }]) {
     [self presentError:error];
   }
@@ -181,17 +175,13 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                                                argument:commit.SHA1
                                                                   error:&error
                                                              usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError1) {
-
                                                                return [repository.history swapCommitWithItsParent:commit
                                                                                                   conflictHandler:^GCCommit*(GCIndex* index, GCCommit* ourCommit, GCCommit* theirCommit, NSArray* parentCommits, NSString* message, NSError** outError2) {
-
                                                                                                     return [self resolveConflictsWithResolver:self.delegate index:index ourCommit:ourCommit theirCommit:theirCommit parentCommits:parentCommits message:message error:outError2];
-
                                                                                                   }
                                                                                                    newChildCommit:NULL
                                                                                                   newParentCommit:&newCommit
                                                                                                             error:outError1];
-
                                                              }];
     [self.repository resumeHistoryUpdates];
     if (success) {
@@ -213,17 +203,13 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                                                argument:child.SHA1
                                                                   error:&error
                                                              usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError1) {
-
                                                                return [repository.history swapCommitWithItsParent:child
                                                                                                   conflictHandler:^GCCommit*(GCIndex* index, GCCommit* ourCommit, GCCommit* theirCommit, NSArray* parentCommits, NSString* message, NSError** outError2) {
-
                                                                                                     return [self resolveConflictsWithResolver:self.delegate index:index ourCommit:ourCommit theirCommit:theirCommit parentCommits:parentCommits message:message error:outError2];
-
                                                                                                   }
                                                                                                    newChildCommit:&newCommit
                                                                                                   newParentCommit:NULL
                                                                                                             error:outError1];
-
                                                              }];
     [self.repository resumeHistoryUpdates];
     if (success) {
@@ -242,7 +228,6 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                         withTitle:NSLocalizedString(@"Squashed commit message:", nil)
                            button:NSLocalizedString(@"Squash", nil)
                             block:^(NSString* message) {
-
                               NSError* error;
                               __block GCCommit* newCommit = nil;
                               [self.repository setUndoActionName:NSLocalizedString(@"Squash Commit", nil)];
@@ -250,15 +235,12 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                                                               argument:commit.SHA1
                                                                                  error:&error
                                                                             usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError) {
-
                                                                               return [repository.history squashCommit:commit withMessage:message newCommit:&newCommit error:outError];
-
                                                                             }]) {
                                 [self selectCommit:newCommit];
                               } else {
                                 [self presentError:error];
                               }
-
                             }];
   }
 }
@@ -272,9 +254,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                                     argument:commit.SHA1
                                                        error:&error
                                                   usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError) {
-
                                                     return [repository.history fixupCommit:commit newCommit:&newCommit error:outError];
-
                                                   }]) {
       [self selectCommit:newCommit];
     } else {
@@ -292,15 +272,11 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                                      argument:commit.SHA1
                                                         error:&error
                                                    usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError1) {
-
                                                      return [repository.history deleteCommit:commit
                                                                          withConflictHandler:^GCCommit*(GCIndex* index, GCCommit* ourCommit, GCCommit* theirCommit, NSArray* parentCommits, NSString* message, NSError** outError2) {
-
                                                                            return [self resolveConflictsWithResolver:self.delegate index:index ourCommit:ourCommit theirCommit:theirCommit parentCommits:parentCommits message:message error:outError2];
-
                                                                          }
                                                                                        error:outError1];
-
                                                    }]) {
       [self presentError:error];
     }
@@ -315,7 +291,6 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                         withTitle:NSLocalizedString(@"Cherry-picked commit message:", nil)
                            button:NSLocalizedString(@"Cherry-Pick", nil)
                             block:^(NSString* message) {
-
                               NSError* error;
                               __block GCCommit* newCommit = nil;
                               [self.repository setUndoActionName:NSLocalizedString(@"Cherry-Pick Commit", nil)];
@@ -323,24 +298,19 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                                                               argument:commit.SHA1
                                                                                  error:&error
                                                                             usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError1) {
-
                                                                               return [repository.history cherryPickCommit:commit
                                                                                                             againstBranch:branch
                                                                                                               withMessage:message
                                                                                                           conflictHandler:^GCCommit*(GCIndex* index, GCCommit* ourCommit, GCCommit* theirCommit, NSArray* parentCommits, NSString* message2, NSError** outError2) {
-
                                                                                                             return [self resolveConflictsWithResolver:self.delegate index:index ourCommit:ourCommit theirCommit:theirCommit parentCommits:parentCommits message:message2 error:outError2];
-
                                                                                                           }
                                                                                                                 newCommit:&newCommit
                                                                                                                     error:outError1];
-
                                                                             }]) {
                                 [self selectCommit:newCommit];
                               } else {
                                 [self presentError:error];
                               }
-
                             }];
   }
 }
@@ -367,7 +337,6 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                             withTitle:NSLocalizedString(@"Reverted commit message:", nil)
                                button:NSLocalizedString(@"Revert", nil)
                                 block:^(NSString* message) {
-
                                   NSError* error;
                                   __block GCCommit* newCommit = nil;
                                   [self.repository setUndoActionName:NSLocalizedString(@"Revert Commit", nil)];
@@ -375,24 +344,19 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                                                                   argument:commit.SHA1
                                                                                      error:&error
                                                                                 usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError1) {
-
                                                                                   return [repository.history revertCommit:commit
                                                                                                             againstBranch:branch
                                                                                                               withMessage:message
                                                                                                           conflictHandler:^GCCommit*(GCIndex* index, GCCommit* ourCommit, GCCommit* theirCommit, NSArray* parentCommits, NSString* message2, NSError** outError2) {
-
                                                                                                             return [self resolveConflictsWithResolver:self.delegate index:index ourCommit:ourCommit theirCommit:theirCommit parentCommits:parentCommits message:message2 error:outError2];
-
                                                                                                           }
                                                                                                                 newCommit:&newCommit
                                                                                                                     error:outError1];
-
                                                                                 }]) {
                                     [self selectCommit:newCommit];
                                   } else {
                                     [self presentError:error];
                                   }
-
                                 }];
       }
       break;
@@ -407,7 +371,6 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                       withTitle:NSLocalizedString(@"New commit message:", nil)
                          button:NSLocalizedString(@"Save", nil)
                           block:^(NSString* message) {
-
                             if (![message isEqualToString:originalMessage]) {
                               NSError* error;
                               __block GCCommit* newCommit = nil;
@@ -416,13 +379,11 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                                                               argument:commit.SHA1
                                                                                  error:&error
                                                                             usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError) {
-
                                                                               newCommit = [repository copyCommit:commit withUpdatedMessage:message updatedParents:nil updatedTreeFromIndex:nil updateCommitter:YES error:outError];
                                                                               if (newCommit == nil) {
                                                                                 return nil;
                                                                               }
                                                                               return [repository.history rewriteCommit:commit withUpdatedCommit:newCommit copyTrees:YES conflictHandler:NULL error:outError];  // No need for a conflict handler as editing a message should not result in conflicts
-
                                                                             }]) {
                                 [self selectCommit:newCommit];
                               } else {
@@ -431,7 +392,6 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                             } else {
                               NSBeep();
                             }
-
                           }];
 }
 
@@ -446,7 +406,6 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 skipCheckoutOnUndo:NO
                                              error:&error
                                         usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                           GCLocalBranch* branch = [repository createLocalBranchFromCommit:commit withName:name force:NO error:outError];
                                           if (branch == nil) {
                                             return NO;
@@ -456,7 +415,6 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                             return NO;
                                           }
                                           return YES;
-
                                         }]) {
     [self presentError:error];
   }
@@ -472,9 +430,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                skipCheckoutOnUndo:YES
                                             error:&error
                                        usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                          return [repository deleteLocalBranch:branch error:outError];
-
                                        }]) {
     if ([upstream isKindOfClass:[GCHistoryRemoteBranch class]]) {
       [self confirmUserActionWithAlertType:_AlertTypeForDangerousRemoteOperations()
@@ -483,9 +439,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                     button:NSLocalizedString(@"Delete Remote Branch", nil)
                  suppressionUserDefaultKey:nil
                                      block:^{
-
                                        [self _deleteRemoteBranchFromRemote:upstream];
-
                                      }];
     }
   } else {
@@ -502,9 +456,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 skipCheckoutOnUndo:YES
                                              error:&error
                                         usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                           return [repository setName:name forLocalBranch:branch force:NO error:outError];
-
                                         }]) {
     [self presentError:error];
   }
@@ -518,11 +470,9 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                                      argument:branch.name
                                                         error:&error
                                                    usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError) {
-
                                                      GCReferenceTransform* transform = [[GCReferenceTransform alloc] initWithRepository:repository reflogMessage:kGCReflogMessageFormat_GitUp_SetTip];
                                                      [transform setDirectTarget:commit forReference:branch];
                                                      return transform;
-
                                                    }]) {
       [self presentError:error];
     }
@@ -538,11 +488,9 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 skipCheckoutOnUndo:YES
                                              error:&error
                                         usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                           GCReferenceTransform* transform = [[GCReferenceTransform alloc] initWithRepository:repository reflogMessage:kGCReflogMessageFormat_GitUp_MoveTip];
                                           [transform setDirectTarget:commit forReference:branch];
                                           return [repository applyReferenceTransform:transform error:outError];
-
                                         }]) {
     [self presentError:error];
   }
@@ -558,9 +506,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                   skipCheckoutOnUndo:YES
                                                error:&error
                                           usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                             return [repository setUpstream:upstream forLocalBranch:branch error:outError];
-
                                           }]) {
       [self presentError:error];
     }
@@ -571,9 +517,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                   skipCheckoutOnUndo:YES
                                                error:&error
                                           usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                             return [self.repository unsetUpstreamForLocalBranch:branch error:outError];
-
                                           }]) {
       [self presentError:error];
     }
@@ -592,14 +536,12 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 skipCheckoutOnUndo:YES
                                              error:&error
                                         usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                           if (message.length) {
                                             tag = [repository createAnnotatedTagWithCommit:commit name:name message:message force:NO annotation:NULL error:outError];
                                           } else {
                                             tag = [repository createLightweightTagWithCommit:commit name:name force:NO error:outError];
                                           }
                                           return tag ? YES : NO;
-
                                         }]) {
     [self presentError:error];
   }
@@ -614,9 +556,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 skipCheckoutOnUndo:YES
                                              error:&error
                                         usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                           return [repository setName:name forTag:tag force:NO error:outError];
-
                                         }]) {
     [self presentError:error];
   }
@@ -631,9 +571,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 skipCheckoutOnUndo:YES
                                              error:&error
                                         usingBlock:^BOOL(GCLiveRepository* repository, NSError** outError) {
-
                                           return [repository deleteTag:tag error:outError];
-
                                         }]) {
     [self presentError:error];
   }
@@ -655,9 +593,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                          argument:(isBranch ? [commitOrBranch name] : [commitOrBranch SHA1])
                          error:&error
                                                   usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError) {
-
                                                     return [repository.history fastForwardBranch:branch toCommit:commit error:outError];
-
                                                   }]) {
       [self selectCommit:commit];
       if (userMessage) {
@@ -678,7 +614,6 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                         withTitle:NSLocalizedString(@"Merged commit message:", nil)
                            button:NSLocalizedString(@"Merge", nil)
                             block:^(NSString* message) {
-
                               NSError* error;
                               __block GCCommit* newCommit = nil;
                               if (isBranch) {
@@ -690,19 +625,15 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                                    argument:(isBranch ? [commitOrBranch name] : [commitOrBranch SHA1])
                                                    error:&error
                                                                             usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError1) {
-
                                                                               return [repository.history mergeCommit:commit
                                                                                                           intoBranch:branch
                                                                                                   withAncestorCommit:ancestorCommit
                                                                                                              message:message
                                                                                                      conflictHandler:^GCCommit*(GCIndex* index, GCCommit* ourCommit, GCCommit* theirCommit, NSArray* parentCommits, NSString* message2, NSError** outError2) {
-
                                                                                                        return [self resolveConflictsWithResolver:self.delegate index:index ourCommit:ourCommit theirCommit:theirCommit parentCommits:parentCommits message:message2 error:outError2];
-
                                                                                                      }
                                                                                                            newCommit:&newCommit
                                                                                                                error:outError1];
-
                                                                             }]) {
                                 [self selectCommit:newCommit];
                                 if (userMessage) {
@@ -711,7 +642,6 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                               } else {
                                 [self presentError:error];
                               }
-
                             }];
   }
 }
@@ -726,18 +656,14 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                                                argument:branch.name
                                                                   error:&error
                                                              usingBlock:^GCReferenceTransform*(GCLiveRepository* repository, NSError** outError1) {
-
                                                                return [repository.history rebaseBranch:branch
                                                                                             fromCommit:fromCommit
                                                                                             ontoCommit:commit
                                                                                        conflictHandler:^GCCommit*(GCIndex* index, GCCommit* ourCommit, GCCommit* theirCommit, NSArray* parentCommits, NSString* message, NSError** outError2) {
-
                                                                                          return [self resolveConflictsWithResolver:self.delegate index:index ourCommit:ourCommit theirCommit:theirCommit parentCommits:parentCommits message:message error:outError2];
-
                                                                                        }
                                                                                           newTipCommit:&newCommit
                                                                                                  error:outError1];
-
                                                              }];
     [self.repository resumeHistoryUpdates];
     if (success) {
@@ -780,13 +706,11 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
         alert.type = kGIAlertType_Note;
         [self presentAlert:alert
             completionHandler:^(NSInteger returnCode) {
-
               if (returnCode == NSAlertDefaultReturn) {
                 [self fastForwardLocalBranch:intoBranch toCommitOrBranch:commitOrBranch withUserMessage:userMessage];
               } else if (returnCode == NSAlertOtherReturn) {
                 [self mergeCommitOrBranch:commitOrBranch intoLocalBranch:intoBranch withAncestorCommit:ancestorCommit userMessage:userMessage];
               }
-
             }];
       }
       break;
@@ -836,16 +760,12 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 button:NSLocalizedString(@"Fetch Branch", nil)
              suppressionUserDefaultKey:kUserDefaultsKey_SkipFetchRemoteBranchWarning
                                  block:^{
-
                                    [self.repository performOperationInBackgroundWithReason:nil
                                        argument:nil
                                        usingOperationBlock:^BOOL(GCRepository* repository, NSError** error) {
-
                                          return [repository fetchRemoteBranch:branch tagMode:kGCFetchTagMode_None updatedTips:&updatedTips error:error];  // Don't fetch any tags to not mess up with undo
-
                                        }
                                        completionBlock:^(BOOL success, NSError* error) {
-
                                          if (success) {
                                            if (updatedTips) {
                                              [self.windowController showOverlayWithStyle:kGIOverlayStyle_Informational message:NSLocalizedString(@"Remote branch was updated", nil)];
@@ -855,9 +775,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                          } else {
                                            [self presentError:error];
                                          }
-
                                        }];
-
                                  }];
 }
 
@@ -868,17 +786,13 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 button:NSLocalizedString(@"Fetch Remote Branches", nil)
              suppressionUserDefaultKey:kUserDefaultsKey_SkipFetchRemoteBranchesWarning
                                  block:^{
-
                                    __block NSUInteger updatedTips;
                                    [self.repository performOperationInBackgroundWithReason:nil
                                        argument:nil
                                        usingOperationBlock:^BOOL(GCRepository* repository, NSError** error) {
-
                                          return [repository fetchDefaultRemoteBranchesFromAllRemotes:kGCFetchTagMode_None recursive:YES prune:YES updatedTips:&updatedTips error:error];  // Don't fetch any tags to avoid messing with undo (pruning is OK as it only affects remote branches)
-
                                        }
                                        completionBlock:^(BOOL success, NSError* error) {
-
                                          if (success) {
                                            if (updatedTips > 1) {
                                              [self.windowController showOverlayWithStyle:kGIOverlayStyle_Informational format:NSLocalizedString(@"%lu remote branches have been updated", nil), updatedTips];
@@ -890,9 +804,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                          } else {
                                            [self presentError:error];
                                          }
-
                                        }];
-
                                  }];
 }
 
@@ -902,12 +814,9 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
   [self.repository performOperationInBackgroundWithReason:@"fetch_remote_tags"
       argument:nil
       usingOperationBlock:^BOOL(GCRepository* repository, NSError** error) {
-
         return [repository fetchAllTagsFromAllRemotes:NO prune:prune updatedTips:&updatedTips error:error];  // Don't fetch recursively as we can't undo changes in submodules
-
       }
       completionBlock:^(BOOL success, NSError* error) {
-
         if (success) {
           if (updatedTips > 1) {
             [self.windowController showOverlayWithStyle:kGIOverlayStyle_Informational format:NSLocalizedString(@"%lu tags have been updated", nil), updatedTips];
@@ -919,7 +828,6 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
         } else {
           [self presentError:error];
         }
-
       }];
 }
 
@@ -930,16 +838,13 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
   [self.repository performOperationInBackgroundWithReason:nil
       argument:nil
       usingOperationBlock:^BOOL(GCRepository* repository, NSError** outError) {
-
         if (remote) {
           return [repository pushLocalBranch:branch toRemote:remote force:force setUpstream:NO error:outError];
         } else {
           return [repository pushLocalBranchToUpstream:branch force:force usedRemote:&upstreamRemote error:outError];
         }
-
       }
       completionBlock:^(BOOL success, NSError* error) {
-
         if (success) {
           if (remote) {
             NSError* localError;
@@ -953,9 +858,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                               button:NSLocalizedString(@"Set Upstream", nil)
                            suppressionUserDefaultKey:nil
                                                block:^{
-
                                                  [self setUpstream:remoteBranch forLocalBranch:branch];
-
                                                }];
               }
             } else {
@@ -972,14 +875,11 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                         button:NSLocalizedString(@"Force Push", nil)
                      suppressionUserDefaultKey:nil
                                          block:^{
-
                                            [self _pushLocalBranch:branch toRemote:remote force:YES];
-
                                          }];
         } else {
           [self presentError:error];
         }
-
       }];
 }
 
@@ -990,9 +890,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 button:NSLocalizedString(@"Push Branch", nil)
              suppressionUserDefaultKey:kUserDefaultsKey_SkipPushLocalBranchToRemoteWarning
                                  block:^{
-
                                    [self _pushLocalBranch:branch toRemote:remote force:NO];
-
                                  }];
 }
 
@@ -1004,9 +902,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 button:NSLocalizedString(@"Push Branch", nil)
              suppressionUserDefaultKey:kUserDefaultsKey_SkipPushBranchWarning
                                  block:^{
-
                                    [self _pushLocalBranch:branch toRemote:nil force:NO];
-
                                  }];
 }
 
@@ -1014,12 +910,9 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
   [self.repository performOperationInBackgroundWithReason:nil
       argument:nil
       usingOperationBlock:^BOOL(GCRepository* repository, NSError** error) {
-
         return [self.repository pushAllLocalBranchesToRemote:remote force:force setUpstream:NO error:error];
-
       }
       completionBlock:^(BOOL success, NSError* error) {
-
         if (success) {
           [self.windowController showOverlayWithStyle:kGIOverlayStyle_Informational format:NSLocalizedString(@"All branches were pushed to the remote \"%@\" successfully!", nil), remote.name];
         } else if ([error.domain isEqualToString:GCErrorDomain] && (error.code == kGCErrorCode_NonFastForward)) {
@@ -1029,14 +922,11 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                         button:NSLocalizedString(@"Force Push", nil)
                      suppressionUserDefaultKey:nil
                                          block:^{
-
                                            [self _pushAllLocalBranchesToRemote:remote force:YES];
-
                                          }];
         } else {
           [self presentError:error];
         }
-
       }];
 }
 
@@ -1051,9 +941,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                   button:NSLocalizedString(@"Push All Branches", nil)
                suppressionUserDefaultKey:nil
                                    block:^{
-
                                      [self _pushAllLocalBranchesToRemote:remote force:NO];
-
                                    }];
   } else if (remotes == nil) {
     [self presentError:localError];
@@ -1069,18 +957,14 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
   [self.repository performOperationInBackgroundWithReason:nil
       argument:nil
       usingOperationBlock:^BOOL(GCRepository* repository, NSError** error) {
-
         return [repository pushTag:tag toRemote:remote force:YES error:error];
-
       }
       completionBlock:^(BOOL success, NSError* error) {
-
         if (success) {
           [self.windowController showOverlayWithStyle:kGIOverlayStyle_Informational format:NSLocalizedString(@"The tag \"%@\" was pushed to the remote \"%@\" successfully!", nil), tag.name, remote.name];
         } else {
           [self presentError:error];
         }
-
       }];
 }
 
@@ -1092,9 +976,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 button:NSLocalizedString(@"Push Tag", nil)
              suppressionUserDefaultKey:kUserDefaultsKey_SkipPushTagWarning
                                  block:^{
-
                                    [self _pushTag:tag toRemote:remote];
-
                                  }];
 }
 
@@ -1110,24 +992,18 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                   button:NSLocalizedString(@"Push All Tags", nil)
                suppressionUserDefaultKey:nil
                                    block:^{
-
                                      [self.repository performOperationInBackgroundWithReason:nil
                                          argument:nil
                                          usingOperationBlock:^BOOL(GCRepository* repository, NSError** error) {
-
                                            return [self.repository pushAllTagsToRemote:remote force:YES error:error];
-
                                          }
                                          completionBlock:^(BOOL success, NSError* error) {
-
                                            if (success) {
                                              [self.windowController showOverlayWithStyle:kGIOverlayStyle_Informational format:NSLocalizedString(@"All tags were pushed to the remote \"%@\" successfully!", nil), remote.name];
                                            } else {
                                              [self presentError:error];
                                            }
-
                                          }];
-
                                    }];
   } else if (remotes == nil) {
     [self presentError:localError];
@@ -1142,16 +1018,12 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
   [self.repository performOperationInBackgroundWithReason:nil
       argument:nil
       usingOperationBlock:^BOOL(GCRepository* repository, NSError** error) {
-
         return [repository deleteRemoteBranchFromRemote:branch error:error];
-
       }
       completionBlock:^(BOOL success, NSError* error) {
-
         if (!success) {
           [self presentError:error];
         }
-
       }];
 }
 
@@ -1163,9 +1035,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 button:NSLocalizedString(@"Delete Branch", nil)
              suppressionUserDefaultKey:nil
                                  block:^{
-
                                    [self _deleteRemoteBranchFromRemote:branch];
-
                                  }];
 }
 
@@ -1176,7 +1046,6 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 button:NSLocalizedString(@"Delete Tag", nil)
              suppressionUserDefaultKey:nil
                                  block:^{
-
                                    NSError* localError;
                                    NSArray* remotes = [self.repository listRemotes:&localError];
                                    if (remotes == nil) {
@@ -1187,24 +1056,19 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                      [self.repository performOperationInBackgroundWithReason:nil
                                          argument:nil
                                          usingOperationBlock:^BOOL(GCRepository* repository, NSError** error) {
-
                                            for (GCRemote* remote in remotes) {
                                              if (![repository deleteTag:tag fromRemote:remote error:error]) {
                                                return NO;
                                              }
                                            }
                                            return YES;
-
                                          }
                                          completionBlock:^(BOOL success, NSError* error) {
-
                                            if (!success) {
                                              [self presentError:error];
                                            }
-
                                          }];
                                    }
-
                                  }];
 }
 
@@ -1218,16 +1082,12 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                 button:NSLocalizedString(@"Pull Branch", nil)
              suppressionUserDefaultKey:kUserDefaultsKey_SkipPullBranchWarning
                                  block:^{
-
                                    [self.repository performOperationInBackgroundWithReason:nil
                                        argument:nil
                                        usingOperationBlock:^BOOL(GCRepository* repository, NSError** error) {
-
                                          return [repository fetchRemoteBranch:upstream tagMode:kGCFetchTagMode_None updatedTips:NULL error:error];  // Don't fetch any tags to not mess up with undo
-
                                        }
                                        completionBlock:^(BOOL success, NSError* error) {
-
                                          if (success) {
                                            GCHistoryCommit* branchCommit = branch.tipCommit;
                                            upstream = [self.repository.history historyRemoteBranchForRemoteBranch:upstream];  // We must refetch the branch from history as it has changed
@@ -1256,13 +1116,11 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                                alert.type = kGIAlertType_Note;
                                                [self presentAlert:alert
                                                    completionHandler:^(NSInteger returnCode) {
-
                                                      if (returnCode == NSAlertDefaultReturn) {
                                                        [self rebaseLocalBranch:branch fromCommit:ancestorCommit ontoCommit:upstream.tipCommit withUserMessage:nil];
                                                      } else if (returnCode == NSAlertOtherReturn) {
                                                        [self mergeCommitOrBranch:upstream intoLocalBranch:branch withAncestorCommit:ancestorCommit userMessage:nil];
                                                      }
-
                                                    }];
                                                break;
                                              }
@@ -1270,9 +1128,7 @@ static inline GIAlertType _AlertTypeForDangerousRemoteOperations() {
                                          } else {
                                            [self presentError:error];
                                          }
-
                                        }];
-
                                  }];
 }
 

--- a/GitUpKit/Views/GIMapViewController.m
+++ b/GitUpKit/Views/GIMapViewController.m
@@ -591,7 +591,6 @@ static NSColor* _patternColor = nil;
   [self.windowController runModalView:_messageView
             withInitialFirstResponder:_messageTextView
                     completionHandler:^(BOOL success) {
-
                       if (success) {
                         NSString* editedMessage = [_messageTextView.string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
                         if (editedMessage.length) {
@@ -602,7 +601,6 @@ static NSColor* _patternColor = nil;
                       }
                       _messageTextView.string = @"";
                       [_messageTextView.undoManager removeAllActions];
-
                     }];
 }
 
@@ -881,13 +879,11 @@ static NSColor* _patternColor = nil;
       alert.type = kGIAlertType_Note;
       [self presentAlert:alert
           completionHandler:^(NSInteger returnCode) {
-
             if (returnCode == NSAlertDefaultReturn) {
               [self checkoutRemoteBranch:branch];
             } else if (returnCode == NSAlertOtherReturn) {
               [self checkoutCommit:target];
             }
-
           }];
     } else {
       [self checkoutCommit:target];
@@ -902,7 +898,6 @@ static NSColor* _patternColor = nil;
   [self.windowController runModalView:_tagView
             withInitialFirstResponder:_tagNameTextField
                     completionHandler:^(BOOL success) {
-
                       if (success) {
                         NSString* name = _tagNameTextField.stringValue;
                         NSString* message = [_tagMessageTextView.string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
@@ -914,7 +909,6 @@ static NSColor* _patternColor = nil;
                       }
                       _tagMessageTextView.string = @"";
                       [_tagMessageTextView.undoManager removeAllActions];
-
                     }];
 }
 
@@ -954,13 +948,11 @@ static NSColor* _patternColor = nil;
     alert.type = kGIAlertType_Note;
     [self presentAlert:alert
         completionHandler:^(NSInteger returnCode) {
-
           if (returnCode == NSAlertDefaultReturn) {
             [self deleteLocalBranch:localBranch];
           } else if (returnCode == NSAlertOtherReturn) {
             [self deleteCommit:commit];
           }
-
         }];
   } else {
     GCHistoryRemoteBranch* remoteBranch = commit.remoteBranches.firstObject;
@@ -1028,7 +1020,6 @@ static NSColor* _patternColor = nil;
   [self.windowController runModalView:_createBranchView
             withInitialFirstResponder:_createBranchTextField
                     completionHandler:^(BOOL success) {
-
                       if (success) {
                         NSString* name = _createBranchTextField.stringValue;
                         if (name.length) {
@@ -1037,7 +1028,6 @@ static NSColor* _patternColor = nil;
                           NSBeep();
                         }
                       }
-
                     }];
 }
 
@@ -1049,7 +1039,6 @@ static NSColor* _patternColor = nil;
   [self.windowController runModalView:_renameTagView
             withInitialFirstResponder:_renameTagTextField
                     completionHandler:^(BOOL success) {
-
                       if (success) {
                         NSString* name = _renameTagTextField.stringValue;
                         if (name.length && ![name isEqualToString:tag.name]) {
@@ -1058,7 +1047,6 @@ static NSColor* _patternColor = nil;
                           NSBeep();
                         }
                       }
-
                     }];
 }
 
@@ -1125,7 +1113,6 @@ static NSColor* _patternColor = nil;
   [self.windowController runModalView:_renameBranchView
             withInitialFirstResponder:_renameBranchTextField
                     completionHandler:^(BOOL success) {
-
                       if (success) {
                         NSString* name = _renameBranchTextField.stringValue;
                         if (name.length && ![name isEqualToString:branch.name]) {
@@ -1134,7 +1121,6 @@ static NSColor* _patternColor = nil;
                           NSBeep();
                         }
                       }
-
                     }];
 }
 

--- a/GitUpKit/Views/GIStashListViewController.m
+++ b/GitUpKit/Views/GIStashListViewController.m
@@ -234,7 +234,6 @@
   [self.windowController runModalView:_saveView
             withInitialFirstResponder:_messageTextField
                     completionHandler:^(BOOL success) {
-
                       if (success) {
                         NSString* message = [_messageTextField.stringValue stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
                         NSError* error;
@@ -251,7 +250,6 @@
                           [self presentError:error];
                         }
                       }
-
                     }];
 }
 
@@ -265,7 +263,6 @@
                                   button:NSLocalizedString(@"Apply Stash", nil)
                suppressionUserDefaultKey:kUserDefaultsKey_SkipApplyWarning
                                    block:^{
-
                                      NSError* error;
                                      if ([self.repository applyStash:stash restoreIndex:NO error:&error]) {
                                        [self.repository notifyRepositoryChanged];
@@ -273,7 +270,6 @@
                                      } else {
                                        [self presentError:error];
                                      }
-
                                    }];
   } else {
     NSBeep();

--- a/format-source.sh
+++ b/format-source.sh
@@ -3,7 +3,7 @@
 # brew install clang-format
 
 CLANG_FORMAT_VERSION=`clang-format -version | awk '{ print $3 }'`
-if [[ "$CLANG_FORMAT_VERSION" != "6.0.0" ]]; then
+if [[ "$CLANG_FORMAT_VERSION" != "7.0.0" ]]; then
   echo "Unsupported clang-format version"
   exit 1
 fi


### PR DESCRIPTION
## What is this PR trying to solve

Refer to #76 

This PR enables a user to search a single file's commit history. The equivalent git command would be `git log --follow path/to/filename`. The difference between the git command and a gitUp single file search is we're using prefix `/` to indicate that we only want the file history.

e.g.

If you want to search any changes for file `package.json`, you'd use `/package.json` in search.

If you want to search for the keyword `package.json` in commit messages, you'd use `package.json` instead.

## What it looks like
[
<img width="1333" alt="screen shot 2018-02-25 at 1 54 22 pm" src="https://user-images.githubusercontent.com/635858/36645962-51ec8674-1a36-11e8-95a1-50a6f0c2e7b6.png">
](https://user-images.githubusercontent.com/635858/36645962-51ec8674-1a36-11e8-95a1-50a6f0c2e7b6.png)

## Known issue

When searching in a large repo, it is slow

## Contribution Agreement

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT