### PR TITLE
Allow searching single file history with prefix "/"

### DIFF
--- a/GitUpKit/Core/GCLiveRepository.m
+++ b/GitUpKit/Core/GCLiveRepository.m
@@ -988,17 +988,17 @@ static BOOL _MatchReference(NSString* match, NSString* name) {
 - (NSArray*)findCommitsMatching:(NSString*)match {
   XLOG_DEBUG_CHECK(_database);
   NSMutableArray* results = [[NSMutableArray alloc] init];
-  
+
   match = [match stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
   bool searchFileHistoryOnly = [match hasPrefix:@"/"];
   // Search file history directly
-  if(match.length >= (kMinSearchLength + 1) && searchFileHistoryOnly) {
+  if (match.length >= (kMinSearchLength + 1) && searchFileHistoryOnly) {
     NSArray* fileCommits = [_history.repository lookupCommitsForFile:[match substringFromIndex:1] followRenames:YES error:NULL];
-    if(fileCommits.count > 0) {
+    if (fileCommits.count > 0) {
       [results addObjectsFromArray:fileCommits];
     }
   }
-  
+
   if (match.length >= kMinSearchLength && !searchFileHistoryOnly) {
     // Search SHA1s directly
     NSArray* words = [match componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];

--- a/GitUpKit/Core/GCLiveRepository.m
+++ b/GitUpKit/Core/GCLiveRepository.m
@@ -992,9 +992,9 @@ static BOOL _MatchReference(NSString* match, NSString* name) {
   match = [match stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
   bool searchFileHistoryOnly = [match hasPrefix:@"/"];
   // Search file history directly
-  if(match.length >= kMinSearchLength && searchFileHistoryOnly) {
+  if(match.length >= (kMinSearchLength + 1) && searchFileHistoryOnly) {
     NSArray* fileCommits = [_history.repository lookupCommitsForFile:[match substringFromIndex:1] followRenames:YES error:NULL];
-    if([fileCommits count] > 0) {
+    if(fileCommits.count > 0) {
       [results addObjectsFromArray:fileCommits];
     }
   }
@@ -1015,7 +1015,7 @@ static BOOL _MatchReference(NSString* match, NSString* name) {
         }
       }
     }
-    
+
     // Search references
     for (GCHistoryLocalBranch* branch in _history.localBranches) {
       if (_MatchReference(match, branch.name)) {

--- a/GitUpKit/Core/GCLiveRepository.m
+++ b/GitUpKit/Core/GCLiveRepository.m
@@ -988,8 +988,18 @@ static BOOL _MatchReference(NSString* match, NSString* name) {
 - (NSArray*)findCommitsMatching:(NSString*)match {
   XLOG_DEBUG_CHECK(_database);
   NSMutableArray* results = [[NSMutableArray alloc] init];
+  
   match = [match stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-  if (match.length >= kMinSearchLength) {
+  bool searchFileHistoryOnly = [match hasPrefix:@"/"];
+  // Search file history directly
+  if(match.length >= kMinSearchLength && searchFileHistoryOnly) {
+    NSArray* fileCommits = [_history.repository lookupCommitsForFile:[match substringFromIndex:1] followRenames:YES error:NULL];
+    if([fileCommits count] > 0) {
+      [results addObjectsFromArray:fileCommits];
+    }
+  }
+  
+  if (match.length >= kMinSearchLength && !searchFileHistoryOnly) {
     // Search SHA1s directly
     NSArray* words = [match componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
     for (NSString* prefix in words) {
@@ -1005,7 +1015,7 @@ static BOOL _MatchReference(NSString* match, NSString* name) {
         }
       }
     }
-
+    
     // Search references
     for (GCHistoryLocalBranch* branch in _history.localBranches) {
       if (_MatchReference(match, branch.name)) {


### PR DESCRIPTION
## What is this PR trying to solve

Refer to #76 

This PR enables a user to search a single file's commit history. The equivalent git command would be `git log --follow path/to/filename`. The difference between the git command and a gitUp single file search is we're using prefix `/` to indicate that we only want the file history.

e.g.

If you want to search any changes for file `package.json`, you'd use `/package.json` in search.

If you want to search for the keyword `package.json` in commit messages, you'd use `package.json` instead.

## What it looks like
[
<img width="1333" alt="screen shot 2018-02-25 at 1 54 22 pm" src="https://user-images.githubusercontent.com/635858/36645962-51ec8674-1a36-11e8-95a1-50a6f0c2e7b6.png">
](https://user-images.githubusercontent.com/635858/36645962-51ec8674-1a36-11e8-95a1-50a6f0c2e7b6.png)

## Known issue

When searching in a large repo, it is slow

## Contribution Agreement

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT