### PR TITLE
Fixes interaction with toolbar mode picker on Mojave

### DIFF
--- a/GitUp/Application/Info.plist
+++ b/GitUp/Application/Info.plist
@@ -50,5 +50,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<true/>
 </dict>
 </plist>

--- a/GitUp/Application/ToolbarItemWrapperView.m
+++ b/GitUp/Application/ToolbarItemWrapperView.m
@@ -19,22 +19,30 @@
 
 - (NSView*)hitTest:(NSPoint)point {
   // Normally, a double-click in a window title bar zooms the window on the second mouse-up. In a unified title/toolbar window, if a mouse-up hit-tests into a subview of a toolbar item, the mouse-up cannot zoom the window. This subclass selectively suppresses hits to allow a double-click to zoom its window.
-  id hit = [super hitTest:point];
+  NSView* hit = [super hitTest:point];
 
-  if ([hit isKindOfClass:[NSTextField class]]) {
-    NSTextField* field = hit;
-    return field.selectable ? field : nil;
-  }
+  for (NSView* child = hit; child != nil && child != self; child = [child superview]) {
+    if ([child isKindOfClass:[NSTextField class]]) {
+      NSTextField* field = (NSTextField*)child;
+      if (field.enabled && field.selectable) {
+        return hit;
+      }
+    }
 
-  if ([hit isKindOfClass:[NSControl class]]) {
-    NSControl* control = hit;
-    return control.isEnabled ? control : nil;
-  }
+    if ([child isKindOfClass:[NSControl class]]) {
+      NSControl* control = (NSControl*)child;
+      if (control.enabled) {
+        return hit;
+      }
+    }
 
-  if ([hit isKindOfClass:[NSTextView class]]) {
-    // The search field adds the field editor, an NSTextView, as a subview when it's being edited.
-    NSTextView* textView = hit;
-    return textView.selectable ? textView : nil;
+    if ([child isKindOfClass:[NSTextView class]]) {
+      // The search field adds the field editor, an NSTextView, as a subview when it's being edited.
+      NSTextView* textView = (NSTextView*)child;
+      if (textView.selectable) {
+        return hit;
+      }
+    }
   }
 
   return nil;

--- a/GitUp/GitUp.xcodeproj/project.pbxproj
+++ b/GitUp/GitUp.xcodeproj/project.pbxproj
@@ -333,7 +333,7 @@
 		E2C338A319F8562F00063D95 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					E21DCAE71B253847006424E8 = {

--- a/GitUp/GitUp.xcodeproj/xcshareddata/xcschemes/Application.xcscheme
+++ b/GitUp/GitUp.xcodeproj/xcshareddata/xcschemes/Application.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "1000"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
       </Testables>
@@ -50,7 +49,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableAddressSanitizer = "YES"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/GitUp/GitUp.xcodeproj/xcshareddata/xcschemes/Tool.xcscheme
+++ b/GitUp/GitUp.xcodeproj/xcshareddata/xcschemes/Tool.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -46,7 +45,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/GitUpKit/GitUpKit.xcodeproj/project.pbxproj
+++ b/GitUpKit/GitUpKit.xcodeproj/project.pbxproj
@@ -1249,7 +1249,7 @@
 		E2C338A319F8562F00063D95 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					E217531A1B91613300BE234A = {

--- a/GitUpKit/GitUpKit.xcodeproj/xcshareddata/xcschemes/GitUpKit (OSX).xcscheme
+++ b/GitUpKit/GitUpKit.xcodeproj/xcshareddata/xcschemes/GitUpKit (OSX).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,7 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableAddressSanitizer = "YES"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
@@ -53,7 +52,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/GitUpKit/GitUpKit.xcodeproj/xcshareddata/xcschemes/GitUpKit (iOS).xcscheme
+++ b/GitUpKit/GitUpKit.xcodeproj/xcshareddata/xcschemes/GitUpKit (iOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -37,7 +36,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/GitUpKit/Third-Party/libgit2.xcodeproj/project.pbxproj
+++ b/GitUpKit/Third-Party/libgit2.xcodeproj/project.pbxproj
@@ -1134,7 +1134,7 @@
 		E217485D1B911B5200BE234A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					E2174BD41B91240400BE234A = {

--- a/GitUpKit/Third-Party/libgit2.xcodeproj/xcshareddata/xcschemes/libgit2 (OSX).xcscheme
+++ b/GitUpKit/Third-Party/libgit2.xcodeproj/xcshareddata/xcschemes/libgit2 (OSX).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -37,7 +36,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/GitUpKit/Third-Party/libgit2.xcodeproj/xcshareddata/xcschemes/libgit2 (iOS).xcscheme
+++ b/GitUpKit/Third-Party/libgit2.xcodeproj/xcshareddata/xcschemes/libgit2 (iOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -37,7 +36,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
Mojave moves several controls to paint using subviews instead of cells, causing the double-click hit test checking to fail. This addresses that, and allows building on the 10.14 SDK unmodified.

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT
