### PR TITLE
Optimize rounding of the welcome window

### DIFF
--- a/GitUp/Application/AppDelegate.m
+++ b/GitUp/Application/AppDelegate.m
@@ -35,8 +35,6 @@
 
 #define kPreferencePaneIdentifier_General @"general"
 
-#define kWelcomeWindowCornerRadius 10
-
 #define kInstallerName @"install.sh"
 #define kToolName @"gitup"
 #define kToolInstallPath @"/usr/local/bin/" kToolName
@@ -45,32 +43,20 @@
 - (void)setShowsTagField:(BOOL)flag;
 @end
 
-@interface WelcomeView : NSView
-@end
-
 @interface AppDelegate () <NSUserNotificationCenterDelegate, SUUpdaterDelegate>
 - (IBAction)closeWelcomeWindow:(id)sender;
-@end
-
-@implementation WelcomeView
-
-- (void)drawRect:(NSRect)dirtyRect {
-  NSRect bounds = self.bounds;
-  CGContextRef context = [[NSGraphicsContext currentContext] graphicsPort];
-
-  CGContextClearRect(context, dirtyRect);
-
-  CGContextSetRGBFillColor(context, 0.9, 0.9, 0.9, 1.0);
-  GICGContextAddRoundedRect(context, bounds, kWelcomeWindowCornerRadius);
-  CGContextFillPath(context);
-}
-
 @end
 
 @interface WelcomeWindow : NSWindow
 @end
 
 @implementation WelcomeWindow
+
+- (void)awakeFromNib {
+  self.opaque = NO;
+  self.backgroundColor = [NSColor clearColor];
+  self.movableByWindowBackground = YES;
+}
 
 - (BOOL)validateMenuItem:(NSMenuItem*)menuItem {
   return menuItem.action == @selector(performClose:) ? YES : [super validateMenuItem:menuItem];
@@ -266,10 +252,6 @@
   _welcomeMaxHeight = _welcomeWindow.frame.size.height;
 
   _allowWelcome = -1;
-
-  _welcomeWindow.alphaValue = 1.0;
-  _welcomeWindow.opaque = NO;
-  _welcomeWindow.movableByWindowBackground = YES;
 
   _twitterButton.textAlignment = NSLeftTextAlignment;
   _twitterButton.textFont = [NSFont boldSystemFontOfSize:11];

--- a/GitUp/Application/en.lproj/MainMenu.xib
+++ b/GitUp/Application/en.lproj/MainMenu.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14269.12" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14269.12"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="GitUp Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="preferences" animationBehavior="default" id="3qV-q4-a6k">
+        <window title="GitUp Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="preferences" animationBehavior="default" id="3qV-q4-a6k">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <rect key="contentRect" x="940" y="240" width="500" height="400"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
@@ -853,7 +852,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                 </menuItem>
             </items>
         </menu>
-        <window title="Clone Repository" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="6SP-eN-0Kv">
+        <window title="Clone Repository" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="6SP-eN-0Kv">
             <windowStyleMask key="styleMask" titled="YES"/>
             <rect key="contentRect" x="131" y="158" width="502" height="167"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
@@ -866,7 +865,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" id="QXH-ou-KWa">
                             <font key="font" metaFont="system"/>
-                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
@@ -928,12 +927,12 @@ Gw
             </view>
             <point key="canvasLocation" x="-716" y="966.5"/>
         </window>
-        <window title="Authentication Required" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="mcM-YD-UN9">
+        <window title="Authentication Required" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="mcM-YD-UN9">
             <windowStyleMask key="styleMask" titled="YES"/>
             <rect key="contentRect" x="131" y="158" width="428" height="217"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
             <view key="contentView" id="kmS-EA-B5p">
-                <rect key="frame" x="0.0" y="5" width="428" height="217"/>
+                <rect key="frame" x="0.0" y="0.0" width="428" height="217"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="ThD-Fn-TeP">
@@ -970,7 +969,7 @@ Gw
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="y3C-g4-ftz">
                             <font key="font" metaFont="system"/>
-                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
@@ -988,7 +987,7 @@ Gw
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="LyY-DF-jhs">
                             <font key="font" metaFont="system"/>
-                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             <allowedInputSourceLocales>
                                 <string>NSAllRomanInputSourcesLocaleIdentifier</string>
@@ -1037,7 +1036,7 @@ Gw
             </view>
             <point key="canvasLocation" x="-709" y="619.5"/>
         </window>
-        <window title="About GitUp" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="about" animationBehavior="default" id="sHg-NM-pfN" userLabel="About" customClass="NSPanel">
+        <window title="About GitUp" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="about" animationBehavior="default" id="sHg-NM-pfN" userLabel="About" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <rect key="contentRect" x="612" y="242" width="276" height="363"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
@@ -1101,52 +1100,117 @@ UI design by Wayne Fan</string>
             </view>
             <point key="canvasLocation" x="114" y="441.5"/>
         </window>
-        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="mjY-As-hbN" userLabel="Welcome" customClass="WelcomeWindow">
+        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="mjY-As-hbN" userLabel="Welcome" customClass="WelcomeWindow">
             <rect key="contentRect" x="131" y="158" width="280" height="349"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
-            <view key="contentView" id="36m-6r-JT2" customClass="WelcomeView">
+            <view key="contentView" id="36m-6r-JT2">
                 <rect key="frame" x="0.0" y="0.0" width="280" height="349"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <button id="Fwx-IU-wXQ">
-                        <rect key="frame" x="9" y="327" width="12" height="15"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="bevel" bezelStyle="regularSquare" image="icon_nav_closetip_dark" imagePosition="overlaps" alignment="center" alternateImage="icon_nav_closetip_dark_pressed" inset="2" id="9ia-bK-Ohr">
-                            <behavior key="behavior" lightByContents="YES"/>
-                            <font key="font" metaFont="system"/>
-                        </buttonCell>
-                        <connections>
-                            <action selector="closeWelcomeWindow:" target="Voe-Tx-rLC" id="xWF-ok-YMZ"/>
-                        </connections>
-                    </button>
-                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="Apd-kA-Fr2">
-                        <rect key="frame" x="76" y="180" width="128" height="128"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSApplicationIcon" id="hqR-yy-x5J"/>
-                    </imageView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="jwH-EW-hhE">
-                        <rect key="frame" x="58" y="145" width="164" height="17"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="Welcome to GitUp" id="mWe-61-l7s">
-                            <font key="font" metaFont="systemBold"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                    <box verticalHuggingPriority="750" boxType="separator" id="zd1-ko-kkJ">
-                        <rect key="frame" x="0.0" y="121" width="280" height="5"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    </box>
-                    <box autoresizesSubviews="NO" boxType="custom" borderType="none" title="Box" titlePosition="noTitle" id="Yk1-Lc-GjF">
-                        <rect key="frame" x="0.0" y="88" width="280" height="35"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <view key="contentView" id="e59-at-kYh">
-                            <rect key="frame" x="0.0" y="0.0" width="280" height="35"/>
+                    <box misplaced="YES" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="10" title="Box" titlePosition="noTitle" id="UoN-n1-xSr">
+                        <rect key="frame" x="0.0" y="0.0" width="280" height="349"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <view key="contentView" appearanceType="aqua" id="UVs-2r-EAT">
+                            <rect key="frame" x="0.0" y="0.0" width="280" height="349"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <customView id="edN-Xy-LJd" customClass="GILinkButton">
-                                    <rect key="frame" x="50" y="7" width="180" height="20"/>
+                                <button misplaced="YES" id="Fwx-IU-wXQ">
+                                    <rect key="frame" x="9" y="327" width="12" height="15"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="bevel" bezelStyle="regularSquare" image="icon_nav_closetip_dark" imagePosition="overlaps" alignment="center" alternateImage="icon_nav_closetip_dark_pressed" inset="2" id="9ia-bK-Ohr">
+                                        <behavior key="behavior" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="closeWelcomeWindow:" target="Voe-Tx-rLC" id="xWF-ok-YMZ"/>
+                                    </connections>
+                                </button>
+                                <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" id="Apd-kA-Fr2">
+                                    <rect key="frame" x="76" y="180" width="128" height="128"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSApplicationIcon" id="hqR-yy-x5J"/>
+                                </imageView>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" id="jwH-EW-hhE">
+                                    <rect key="frame" x="58" y="145" width="164" height="17"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="Welcome to GitUp" id="mWe-61-l7s">
+                                        <font key="font" metaFont="systemBold"/>
+                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                                <box verticalHuggingPriority="750" misplaced="YES" boxType="separator" id="zd1-ko-kkJ">
+                                    <rect key="frame" x="0.0" y="121" width="280" height="5"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                </box>
+                                <box autoresizesSubviews="NO" misplaced="YES" boxType="custom" borderType="none" title="Box" titlePosition="noTitle" id="Yk1-Lc-GjF">
+                                    <rect key="frame" x="0.0" y="88" width="280" height="35"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <view key="contentView" id="e59-at-kYh">
+                                        <rect key="frame" x="0.0" y="0.0" width="280" height="35"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <subviews>
+                                            <customView id="edN-Xy-LJd" customClass="GILinkButton">
+                                                <rect key="frame" x="50" y="7" width="180" height="20"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="linkColor">
+                                                        <color key="value" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="alternateLinkColor">
+                                                        <color key="value" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="calibratedRGB"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="link" value="Open a Git Repository…"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="openDocument:" target="-1" id="PnG-74-JXS"/>
+                                                </connections>
+                                            </customView>
+                                        </subviews>
+                                    </view>
+                                    <color key="fillColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                </box>
+                                <box verticalHuggingPriority="750" misplaced="YES" boxType="separator" id="FXE-km-lcD">
+                                    <rect key="frame" x="0.0" y="85" width="280" height="5"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                </box>
+                                <box autoresizesSubviews="NO" misplaced="YES" boxType="custom" borderType="none" title="Box" titlePosition="noTitle" id="ll1-UT-nBS">
+                                    <rect key="frame" x="0.0" y="52" width="280" height="35"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <view key="contentView" id="qq4-a6-dvv">
+                                        <rect key="frame" x="0.0" y="0.0" width="280" height="35"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <subviews>
+                                            <popUpButton id="rck-lm-gsz">
+                                                <rect key="frame" x="65" y="7" width="150" height="21"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                <popUpButtonCell key="cell" type="bevel" title="Recently Opened…" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" pullsDown="YES" autoenablesItems="NO" altersStateOfSelectedItem="NO" selectedItem="BnD-OX-t50" id="TkZ-yA-jfp">
+                                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                    <font key="font" metaFont="menu"/>
+                                                    <string key="keyEquivalent"></string>
+                                                    <menu key="menu" autoenablesItems="NO" id="SuZ-b2-YNW">
+                                                        <items>
+                                                            <menuItem title="Recently Opened…" state="on" hidden="YES" id="BnD-OX-t50"/>
+                                                        </items>
+                                                    </menu>
+                                                </popUpButtonCell>
+                                            </popUpButton>
+                                        </subviews>
+                                    </view>
+                                    <color key="fillColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                </box>
+                                <box verticalHuggingPriority="750" misplaced="YES" boxType="separator" id="3Ya-QW-NlZ">
+                                    <rect key="frame" x="0.0" y="49" width="280" height="5"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                </box>
+                                <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" id="TgX-Ty-AUa">
+                                    <rect key="frame" x="45" y="20" width="12" height="12"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_twitter" id="4p0-VD-kVJ"/>
+                                </imageView>
+                                <customView misplaced="YES" id="5ht-7L-7AO" customClass="GILinkButton">
+                                    <rect key="frame" x="60" y="13" width="75" height="20"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="color" keyPath="linkColor">
                                             <color key="value" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -1154,91 +1218,37 @@ UI design by Wayne Fan</string>
                                         <userDefinedRuntimeAttribute type="color" keyPath="alternateLinkColor">
                                             <color key="value" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="calibratedRGB"/>
                                         </userDefinedRuntimeAttribute>
-                                        <userDefinedRuntimeAttribute type="string" keyPath="link" value="Open a Git Repository…"/>
+                                        <userDefinedRuntimeAttribute type="string" keyPath="link" value="@gitupapp"/>
                                     </userDefinedRuntimeAttributes>
                                     <connections>
-                                        <action selector="openDocument:" target="-1" id="PnG-74-JXS"/>
+                                        <action selector="openTwitter:" target="Voe-Tx-rLC" id="CcB-Tp-tMx"/>
+                                    </connections>
+                                </customView>
+                                <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" id="3gN-gU-6Rk">
+                                    <rect key="frame" x="154" y="20" width="12" height="12"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_forum" id="3Om-2j-ETN"/>
+                                </imageView>
+                                <customView misplaced="YES" id="ozw-os-Nc4" customClass="GILinkButton">
+                                    <rect key="frame" x="169" y="13" width="75" height="20"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="color" keyPath="linkColor">
+                                            <color key="value" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        </userDefinedRuntimeAttribute>
+                                        <userDefinedRuntimeAttribute type="color" keyPath="alternateLinkColor">
+                                            <color key="value" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="calibratedRGB"/>
+                                        </userDefinedRuntimeAttribute>
+                                        <userDefinedRuntimeAttribute type="string" keyPath="link" value="Feedback"/>
+                                    </userDefinedRuntimeAttributes>
+                                    <connections>
+                                        <action selector="viewIssues:" target="Voe-Tx-rLC" id="C7T-gw-NmH"/>
                                     </connections>
                                 </customView>
                             </subviews>
                         </view>
-                        <color key="fillColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="fillColor" red="0.90000000000000002" green="0.90000000000000002" blue="0.90000000000000002" alpha="1" colorSpace="calibratedRGB"/>
                     </box>
-                    <box verticalHuggingPriority="750" boxType="separator" id="FXE-km-lcD">
-                        <rect key="frame" x="0.0" y="85" width="280" height="5"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    </box>
-                    <box autoresizesSubviews="NO" boxType="custom" borderType="none" title="Box" titlePosition="noTitle" id="ll1-UT-nBS">
-                        <rect key="frame" x="0.0" y="52" width="280" height="35"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <view key="contentView" id="qq4-a6-dvv">
-                            <rect key="frame" x="0.0" y="0.0" width="280" height="35"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                            <subviews>
-                                <popUpButton id="rck-lm-gsz">
-                                    <rect key="frame" x="65" y="7" width="150" height="21"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="bevel" title="Recently Opened…" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" pullsDown="YES" autoenablesItems="NO" altersStateOfSelectedItem="NO" selectedItem="BnD-OX-t50" id="TkZ-yA-jfp">
-                                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="menu"/>
-                                        <string key="keyEquivalent"></string>
-                                        <menu key="menu" autoenablesItems="NO" id="SuZ-b2-YNW">
-                                            <items>
-                                                <menuItem title="Recently Opened…" state="on" hidden="YES" id="BnD-OX-t50"/>
-                                            </items>
-                                        </menu>
-                                    </popUpButtonCell>
-                                </popUpButton>
-                            </subviews>
-                        </view>
-                        <color key="fillColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                    </box>
-                    <box verticalHuggingPriority="750" boxType="separator" id="3Ya-QW-NlZ">
-                        <rect key="frame" x="0.0" y="49" width="280" height="5"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    </box>
-                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="TgX-Ty-AUa">
-                        <rect key="frame" x="45" y="20" width="12" height="12"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_twitter" id="4p0-VD-kVJ"/>
-                    </imageView>
-                    <customView id="5ht-7L-7AO" customClass="GILinkButton">
-                        <rect key="frame" x="60" y="13" width="75" height="20"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="color" keyPath="linkColor">
-                                <color key="value" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                            </userDefinedRuntimeAttribute>
-                            <userDefinedRuntimeAttribute type="color" keyPath="alternateLinkColor">
-                                <color key="value" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="calibratedRGB"/>
-                            </userDefinedRuntimeAttribute>
-                            <userDefinedRuntimeAttribute type="string" keyPath="link" value="@gitupapp"/>
-                        </userDefinedRuntimeAttributes>
-                        <connections>
-                            <action selector="openTwitter:" target="Voe-Tx-rLC" id="CcB-Tp-tMx"/>
-                        </connections>
-                    </customView>
-                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="3gN-gU-6Rk">
-                        <rect key="frame" x="154" y="20" width="12" height="12"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_forum" id="3Om-2j-ETN"/>
-                    </imageView>
-                    <customView id="ozw-os-Nc4" customClass="GILinkButton">
-                        <rect key="frame" x="169" y="13" width="75" height="20"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="color" keyPath="linkColor">
-                                <color key="value" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                            </userDefinedRuntimeAttribute>
-                            <userDefinedRuntimeAttribute type="color" keyPath="alternateLinkColor">
-                                <color key="value" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="calibratedRGB"/>
-                            </userDefinedRuntimeAttribute>
-                            <userDefinedRuntimeAttribute type="string" keyPath="link" value="Feedback"/>
-                        </userDefinedRuntimeAttributes>
-                        <connections>
-                            <action selector="viewIssues:" target="Voe-Tx-rLC" id="C7T-gw-NmH"/>
-                        </connections>
-                    </customView>
                 </subviews>
             </view>
             <point key="canvasLocation" x="-252" y="578.5"/>


### PR DESCRIPTION
Mojave uses a (non-changeable) window backing that breaks how the welcome window is rounded off. This changes follows the pattern of Xcode's own welcome window by making the window clear and drawing the custom background with a box. This has the upshot of automatically using optimized drawing (layer backing) on OS' where that's available.

Before and after screenshots:

<img width="686" alt="screen shot 2018-06-11 at 11 02 37" src="https://user-images.githubusercontent.com/170812/41250809-fef54fe8-6d85-11e8-8225-c671251a5dba.png">

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT