### PR TITLE
Fix crash by adding a check for the `standardOutput` that it is not nil.

### DIFF
--- a/GitUpKit/Core/GCRepository.m
+++ b/GitUpKit/Core/GCRepository.m
@@ -354,6 +354,9 @@ static int _ReferenceForEachCallback(const char* refname, void* payload) {
       }
       return NO;
     }
+    if (standardOutput) {
+      *standardOutput = [[NSString alloc] initWithData:stdoutData encoding:NSUTF8StringEncoding];
+    }
   }
   return YES;
 }


### PR DESCRIPTION
As for example during the `pre-commit` hook.