### PR TITLE
Safely reopen repository when it is renamed instead of crashing

### DIFF
--- a/GitUp/Application/DocumentController.m
+++ b/GitUp/Application/DocumentController.m
@@ -49,12 +49,6 @@
   [[AppDelegate sharedDelegate] handleDocumentCountChanged];
 }
 
-- (void)removeDocument:(NSDocument*)document {
-  [super removeDocument:document];
-
-  [[AppDelegate sharedDelegate] handleDocumentCountChanged];
-}
-
 - (void)newWindowForTab:(id)sender {
   [self openDocument:sender];
 }

--- a/GitUpKit/Core/GCPrivate.h
+++ b/GitUpKit/Core/GCPrivate.h
@@ -247,7 +247,6 @@ extern int git_submodule_foreach_block(git_repository* repo, int (^block)(git_su
 @property(nonatomic, readonly) git_repository* private NS_RETURNS_INNER_POINTER;
 @property(nonatomic, readonly) NSUInteger lastUpdatedTips;  // Reset before fetching and updated during fetching
 - (instancetype)initWithRepository:(git_repository*)repository error:(NSError**)error;
-- (void)updateRepository:(git_repository*)repository;
 - (NSString*)privateTemporaryFilePath;
 #if DEBUG
 - (GCDiff*)checkUnifiedStatus:(NSError**)error;

--- a/GitUpKit/Core/GCRepository.m
+++ b/GitUpKit/Core/GCRepository.m
@@ -135,21 +135,15 @@ static int _GitLFSApply(git_filter* self, void** payload, git_buf* to, const git
 
 - (instancetype)initWithRepository:(git_repository*)repository error:(NSError**)error {
   if ((self = [super init])) {
-    [self updateRepository:repository];
+    _private = repository;
+    _repositoryPath = _MakeDirectoryPath(git_repository_path(_private));
+    _workingDirectoryPath = _MakeDirectoryPath(git_repository_workdir(_private));
   }
   return self;
 }
 
 - (void)dealloc {
   git_repository_free(_private);
-}
-
-// TODO: Should we really have this method? There might still be a bunch of libgit2 objects around that refer to the old git_repository*
-- (void)updateRepository:(git_repository*)repository {
-  git_repository_free(_private);
-  _private = repository;
-  _repositoryPath = _MakeDirectoryPath(git_repository_path(_private));
-  _workingDirectoryPath = _MakeDirectoryPath(git_repository_workdir(_private));
 }
 
 - (NSString*)description {


### PR DESCRIPTION
Closes #526.

The existing support for handling a renamed repository causes crashes because it invalidates the associated `git_repository *` instance, and thus every object associated with it. This left a dangling pointer in all the commit, history, etc. objects, as well as making is possible those objects to be used across repositories, which is not supported.

The issue manifests as a crash on macOS Catalina because it vends a `RootChange` event a) in some unexpected contexts and b) often, thus triggering the issue much more readily. The original code could be modified with a `strcmp` as a workaround, but I'm confident in the alternative presented herein.

This PR avoids re-initializing any of the repository objects in place and instead closes and re-opens the associated document. While not ideal from the approach of modal views or in-progress work, renaming directories is an edge case; to boot, one that isn't very well handled in any other Git GUI I can find.

This is the smallest and most expedient version of this fix. I originally started down the road of making it possible to update the `repository` on all the associated `GCViewController`, but that would've taken multiple days to audit.

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT

- [x] Needs some backwards deployment testing (I'm creating VMs right now)