### PR TITLE
Allow files in diff views to be dragged outside of the app

### DIFF
--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -284,7 +284,7 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
       field.backgroundColor = _mainWindow.backgroundColor;
     }
   }
-  
+
   if (@available(macOS 10.11, *)) {
     // Fields have different alignment rects from their bounds starting in 10.11
     // and will appear slightly small when laid out just by autoresizing.

--- a/GitUpKit/Components/GIDiffFilesViewController.m
+++ b/GitUpKit/Components/GIDiffFilesViewController.m
@@ -23,6 +23,7 @@
 #import "XLFacilityMacros.h"
 
 static const NSPasteboardType GIPasteboardTypeFileRowIndex = @"co.gitup.mac.file-row-index";
+static const NSPasteboardType GIPasteboardTypeFileURL = @"public.file-url";
 
 @interface GIFileCellView : NSTableCellView
 @end
@@ -86,6 +87,7 @@ static NSImage* _untrackedImage = nil;
   _tableView.doubleAction = @selector(doubleClick:);
   [_tableView registerForDraggedTypes:@[ GIPasteboardTypeFileRowIndex ]];
   [_tableView setDraggingSourceOperationMask:NSDragOperationMove forLocal:YES];
+  [_tableView setDraggingSourceOperationMask:NSDragOperationGeneric forLocal:NO];
 
   _emptyTextField.stringValue = @"";
 
@@ -197,6 +199,10 @@ static NSImage* _untrackedImage = nil;
   NSPasteboardItem* pasteboardItem = [[NSPasteboardItem alloc] init];
   [pasteboardItem setPropertyList:@(row) forType:GIPasteboardTypeFileRowIndex];
   [pasteboardItem setString:delta.canonicalPath forType:NSPasteboardTypeString];
+
+  NSString* path = [delta.diff.repository absolutePathForFile:delta.canonicalPath];
+  NSURL* url = [NSURL fileURLWithPath:path isDirectory:NO];
+  [pasteboardItem setString:url.absoluteString forType:GIPasteboardTypeFileURL];
 
   return pasteboardItem;
 }

--- a/GitUpKit/Components/GIDiffFilesViewController.m
+++ b/GitUpKit/Components/GIDiffFilesViewController.m
@@ -167,16 +167,16 @@ static NSImage* _untrackedImage = nil;
 }
 
 - (IBAction)copy:(id)sender {
-  NSMutableString* string = [[NSMutableString alloc] init];
+  NSMutableArray* objects = [NSMutableArray array];
   [_tableView.selectedRowIndexes enumerateIndexesUsingBlock:^(NSUInteger index, BOOL* stop) {
-    GCDiffDelta* delta = self.items[index];
-    if (string.length) {
-      [string appendString:@"\n"];
+    id<NSPasteboardWriting> pasteboardWriter = [self tableView:_tableView pasteboardWriterForRow:index];
+    if (!pasteboardWriter) {
+      return;
     }
-    [string appendString:delta.canonicalPath];
+    [objects addObject:pasteboardWriter];
   }];
-  [[NSPasteboard generalPasteboard] declareTypes:@[ NSPasteboardTypeString ] owner:nil];
-  [[NSPasteboard generalPasteboard] setString:string forType:NSPasteboardTypeString];
+  [[NSPasteboard generalPasteboard] clearContents];
+  [[NSPasteboard generalPasteboard] writeObjects:objects];
 }
 
 - (IBAction)doubleClick:(id)sender {

--- a/GitUpKit/Components/GIDiffFilesViewController.m
+++ b/GitUpKit/Components/GIDiffFilesViewController.m
@@ -192,8 +192,12 @@ static NSImage* _untrackedImage = nil;
 }
 
 - (id<NSPasteboardWriting>)tableView:(NSTableView*)tableView pasteboardWriterForRow:(NSInteger)row {
+  GCDiffDelta* delta = self.items[row];
+
   NSPasteboardItem* pasteboardItem = [[NSPasteboardItem alloc] init];
   [pasteboardItem setPropertyList:@(row) forType:GIPasteboardTypeFileRowIndex];
+  [pasteboardItem setString:delta.canonicalPath forType:NSPasteboardTypeString];
+
   return pasteboardItem;
 }
 


### PR DESCRIPTION
Modernizes the table drag/drop in diff file views so it can pass file names, URLs, and promises to drags that finish outside the app.

I often find myself in the situation, particularly when resolving conflicts, that I want to open a file in an editor that would not be opened by clicking “Open with Default Editor”. This supports that use case and many more.

| Dragging a file or files from… | …to… | …will… |
|--------------------------------|:----------------------------------:|-------------------------------------:|
| any diff file list | another file list in the same view | stage/unstage/split/etc. |
| any diff file list | any other file list | do nothing. |
| the working copy | an icon in the macOS Dock | try to open them in the app. |
| the history | an icon in the macOS Dock | open a copy of the blobs in the app. |
| any diff file list | Terminal | paste relative paths to the files. |
| and diff file list | Terminal, with ⌥ held | paste absolute paths to the files. |

![Screen Recording 2019-06-25 at 12 18 58 PM](https://user-images.githubusercontent.com/170812/60143679-56906f80-978d-11e9-8803-53df1da0a589.gif)

⚠️ Note, the screen recording shows Dark Mode but this PR does not include #532, it was just recorded from a combined branch.