### PR TITLE
Fix alignment of main window search field

### DIFF
--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -292,6 +292,16 @@ static void _CheckTimerCallBack(CFRunLoopTimerRef timer, void* info) {
   _titleView.wantsLayer = YES;
   _rightView.wantsLayer = YES;
 
+  if (@available(macOS 10.11, *)) {
+    // Fields have different alignment rects from their bounds starting in 10.11
+    // and will appear slightly small when laid out just by autoresizing.
+    // Manually make it its preferred height to align with the snapshots button.
+    CGRect searchFieldFrame = _searchField.frame;
+    searchFieldFrame.size.height = [_searchField sizeThatFits:searchFieldFrame.size].height;
+    searchFieldFrame.origin.y = floor(NSMidY(_snapshotsButton.frame) - (searchFieldFrame.size.height / 2));
+    _searchField.frame = searchFieldFrame;
+  }
+
   // Text fields must be drawn on an opaque background to avoid subpixel antialiasing issues during animation.
   for (NSTextField* field in @[ _infoTextField1, _infoTextField2, _progressTextField ]) {
     field.drawsBackground = YES;


### PR DESCRIPTION
On 10.11 and up, the search field doesn't align with the rest of the toolbar items. Fixes that.

This is a minor quality-of-life split from #532 since it's not technically related to dark mode.

### Before

<img width="293" alt="Screen Shot 2019-07-01 at 2 58 45 PM" src="https://user-images.githubusercontent.com/170812/60460157-fe37f280-9c10-11e9-8042-4d7685b02297.png">

### After

<img width="299" alt="Screen Shot 2019-07-01 at 2 59 24 PM" src="https://user-images.githubusercontent.com/170812/60460165-009a4c80-9c11-11e9-9fe3-16e1d0927839.png">
