### PR TITLE
Increase the contrast in commit view prompts

### DIFF
--- a/GitUpKit/Views/Base.lproj/GICommitRewriterViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GICommitRewriterViewController.xib
@@ -24,10 +24,14 @@
             <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="GrA-cS-Ts1" customClass="GIColorView">
+                <customView id="GrA-cS-Ts1">
                     <rect key="frame" x="0.0" y="470" width="1000" height="30"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <subviews>
+                        <box verticalHuggingPriority="750" boxType="separator" id="e23-jK-FRM">
+                            <rect key="frame" x="0.0" y="-2" width="1000" height="5"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                        </box>
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="r86-wZ-wly">
                             <rect key="frame" x="13" y="8" width="122" height="16"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -47,11 +51,6 @@
                             </textFieldCell>
                         </textField>
                     </subviews>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                            <color key="value" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
                 </customView>
                 <splitView dividerStyle="thin" vertical="YES" id="ggX-gG-WJV" customClass="GIDualSplitView">
                     <rect key="frame" x="0.0" y="0.0" width="1000" height="470"/>

--- a/GitUpKit/Views/Base.lproj/GICommitSplitterViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GICommitSplitterViewController.xib
@@ -25,10 +25,14 @@
             <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="eJw-Ro-RO2" customClass="GIColorView">
+                <customView id="eJw-Ro-RO2">
                     <rect key="frame" x="0.0" y="470" width="1000" height="30"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <subviews>
+                        <box verticalHuggingPriority="750" boxType="separator" id="9kw-yf-Rw7">
+                            <rect key="frame" x="0.0" y="-2" width="1000" height="5"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                        </box>
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="ZXE-Q8-0tE">
                             <rect key="frame" x="13" y="8" width="114" height="16"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -48,11 +52,6 @@
                             </textFieldCell>
                         </textField>
                     </subviews>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                            <color key="value" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
                 </customView>
                 <splitView dividerStyle="thin" vertical="YES" id="GbO-qM-CQw" customClass="GIDualSplitView">
                     <rect key="frame" x="0.0" y="0.0" width="1000" height="470"/>

--- a/GitUpKit/Views/Base.lproj/GIConflictResolverViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GIConflictResolverViewController.xib
@@ -22,10 +22,14 @@
             <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="xtX-wF-ETB" customClass="GIColorView">
+                <customView id="xtX-wF-ETB">
                     <rect key="frame" x="0.0" y="450" width="1000" height="50"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <subviews>
+                        <box verticalHuggingPriority="750" boxType="separator" id="JPb-MQ-Lkt">
+                            <rect key="frame" x="0.0" y="-2" width="1000" height="5"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                        </box>
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="ZFh-UY-NQJ">
                             <rect key="frame" x="3" y="29" width="117" height="16"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -63,11 +67,6 @@
                             </textFieldCell>
                         </textField>
                     </subviews>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                            <color key="value" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
                 </customView>
                 <splitView dividerStyle="thin" vertical="YES" id="GFw-7l-pVF" customClass="GIDualSplitView">
                     <rect key="frame" x="0.0" y="0.0" width="1000" height="450"/>

--- a/GitUpKit/Views/Base.lproj/GIDiffViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GIDiffViewController.xib
@@ -21,10 +21,14 @@
             <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="epl-1T-nOb" customClass="GIColorView">
+                <customView id="epl-1T-nOb">
                     <rect key="frame" x="0.0" y="450" width="1000" height="50"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <subviews>
+                        <box verticalHuggingPriority="750" boxType="separator" id="gNx-IO-rt1">
+                            <rect key="frame" x="0.0" y="-2" width="1000" height="5"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                        </box>
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="6Rg-tf-kE6">
                             <rect key="frame" x="115" y="8" width="867" height="16"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
@@ -62,11 +66,6 @@
                             </textFieldCell>
                         </textField>
                     </subviews>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                            <color key="value" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
                 </customView>
                 <splitView autosaveName="" dividerStyle="thin" vertical="YES" id="E0I-P5-wti" customClass="GIDualSplitView">
                     <rect key="frame" x="0.0" y="0.0" width="1000" height="450"/>


### PR DESCRIPTION
Trivial aesthetic change to the top of the window when rewriting, merging, splitting, etc. The prompt now follows the window background (like the footer with Cancel / Commit), instead of having a dark background like an editable text view.

### Before

<img width="842" alt="before-dark" src="https://user-images.githubusercontent.com/170812/60748208-79730e80-9f59-11e9-99e0-a94ca828ad27.png">
<img width="854" alt="before-light" src="https://user-images.githubusercontent.com/170812/60748209-79730e80-9f59-11e9-966d-a3721f266f6f.png">

### After

<img width="862" alt="after-light" src="https://user-images.githubusercontent.com/170812/60748211-7d9f2c00-9f59-11e9-987e-c0834b5ee80f.png">
<img width="864" alt="after-dark" src="https://user-images.githubusercontent.com/170812/60748212-7d9f2c00-9f59-11e9-8fb8-adaa8635827f.png">
