### PR TITLE
Update dark mode branch colors

### DIFF
--- a/GitUpKit/Interface/Interface.xcassets/branch/1.colorset/Contents.json
+++ b/GitUpKit/Interface/Interface.xcassets/branch/1.colorset/Contents.json
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "1.000",
+          "red" : "0.851",
           "alpha" : "1.000",
-          "blue" : "0.461",
-          "green" : "0.461"
+          "blue" : "0.392",
+          "green" : "0.392"
         }
       }
     }

--- a/GitUpKit/Interface/Interface.xcassets/branch/2.colorset/Contents.json
+++ b/GitUpKit/Interface/Interface.xcassets/branch/2.colorset/Contents.json
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "1.000",
+          "red" : "0.800",
           "alpha" : "1.000",
-          "blue" : "0.328",
-          "green" : "0.691"
+          "blue" : "0.263",
+          "green" : "0.533"
         }
       }
     }

--- a/GitUpKit/Interface/Interface.xcassets/branch/3.colorset/Contents.json
+++ b/GitUpKit/Interface/Interface.xcassets/branch/3.colorset/Contents.json
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.900",
+          "red" : "0.820",
           "alpha" : "1.000",
-          "blue" : "0.295",
-          "green" : "0.803"
+          "blue" : "0.204",
+          "green" : "0.647"
         }
       }
     }

--- a/GitUpKit/Interface/Interface.xcassets/branch/4.colorset/Contents.json
+++ b/GitUpKit/Interface/Interface.xcassets/branch/4.colorset/Contents.json
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.423",
+          "red" : "0.333",
           "alpha" : "1.000",
-          "blue" : "0.387",
-          "green" : "0.840"
+          "blue" : "0.302",
+          "green" : "0.702"
         }
       }
     }

--- a/GitUpKit/Interface/Interface.xcassets/branch/5.colorset/Contents.json
+++ b/GitUpKit/Interface/Interface.xcassets/branch/5.colorset/Contents.json
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.349",
+          "red" : "0.282",
           "alpha" : "1.000",
-          "blue" : "0.820",
-          "green" : "0.820"
+          "blue" : "0.741",
+          "green" : "0.741"
         }
       }
     }

--- a/GitUpKit/Interface/Interface.xcassets/branch/6.colorset/Contents.json
+++ b/GitUpKit/Interface/Interface.xcassets/branch/6.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.495",
+          "red" : "0.494",
           "alpha" : "1.000",
-          "blue" : "0.900",
-          "green" : "0.681"
+          "blue" : "0.898",
+          "green" : "0.678"
         }
       }
     },
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.328",
+          "red" : "0.329",
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "0.677"
+          "blue" : "0.780",
+          "green" : "0.537"
         }
       }
     }

--- a/GitUpKit/Interface/Interface.xcassets/branch/7.colorset/Contents.json
+++ b/GitUpKit/Interface/Interface.xcassets/branch/7.colorset/Contents.json
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.816",
+          "red" : "0.600",
           "alpha" : "1.000",
-          "blue" : "0.950",
-          "green" : "0.531"
+          "blue" : "0.722",
+          "green" : "0.380"
         }
       }
     }

--- a/GitUpKit/Interface/Interface.xcassets/branch/8.colorset/Contents.json
+++ b/GitUpKit/Interface/Interface.xcassets/branch/8.colorset/Contents.json
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "1.000",
+          "red" : "0.812",
           "alpha" : "1.000",
-          "blue" : "0.749",
-          "green" : "0.454"
+          "blue" : "0.612",
+          "green" : "0.388"
         }
       }
     }


### PR DESCRIPTION
I’ve been using the awesome dark mode by @zwaldowski for a while. As he notes in #532, branch  colors are on the neon side of things. I found them difficult to look at for a long time. This pull request adjusts branch colors to values that are, in my opinion, better adaptations of the original colors for dark mode. I’d be happy to adjust the colors further if you think they should be improved.

## Screenshots

### Dark Before
<img width="912" alt="Dark-Before" src="https://user-images.githubusercontent.com/129705/60965303-32e92f80-a31e-11e9-9189-ff6cdf8b1c48.png">

### Light
<img width="912" alt="Light" src="https://user-images.githubusercontent.com/129705/60965302-32e92f80-a31e-11e9-9d53-a222ffd8a6d2.png">

### Dark After
<img width="912" alt="Dark-After" src="https://user-images.githubusercontent.com/129705/60965304-32e92f80-a31e-11e9-8493-2702ece3c9bc.png">

## License

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT