### PR TITLE
Welcome window shows when all tabs are closed.

### DIFF
--- a/GitUp/Application/DocumentController.m
+++ b/GitUp/Application/DocumentController.m
@@ -49,6 +49,12 @@
   [[AppDelegate sharedDelegate] handleDocumentCountChanged];
 }
 
+- (void)removeDocument:(NSDocument*)document {
+  [super removeDocument:document];
+
+  [[AppDelegate sharedDelegate] handleDocumentCountChanged];
+}
+
 - (void)newWindowForTab:(id)sender {
   [self openDocument:sender];
 }


### PR DESCRIPTION
In https://github.com/git-up/GitUp/pull/528 it's a bad idea to hide welcome window when all tabs are closed. This MR fix that and https://github.com/git-up/GitUp/issues/566.