### PR TITLE
Improve char width computation

### DIFF
--- a/GitUpKit/Utilities/GIAppKit.m
+++ b/GitUpKit/Utilities/GIAppKit.m
@@ -174,7 +174,10 @@ static const void* _associatedObjectCommitKey = &_associatedObjectCommitKey;
   if ([[NSUserDefaults standardUserDefaults] boolForKey:GICommitMessageViewUserDefaultKey_ShowMargins]) {
     NSRect bounds = self.bounds;
     CGFloat offset = self.textContainerOrigin.x + self.textContainerInset.width + self.textContainer.lineFragmentPadding;
-    CGFloat charWidth = self.font.maximumAdvancement.width;  // TODO: Is this the most reliable way to get the character width of a fixed-width font?
+    CGFloat charWidth = [@"x" sizeWithAttributes:@{
+                           NSFontAttributeName : self.font
+                         }]
+                             .width;
     CGContextRef context = [[NSGraphicsContext currentContext] graphicsPort];
 
     CGContextSaveGState(context);


### PR DESCRIPTION
Char width computation didn't work as expected when the first character of the NSTextView was an emoji. The `maximumAdvancement` returned the length of the emoji, placing the margins at unexpected position.

This commit improves the computation by using a fixed character (`x` has been chosen, arbitrarily). The margin will thus be placed at 50 non-emoji characters.

This is a workaround for the issue https://github.com/git-up/GitUp/issues/419.

This is not perfect though. I believe an actual fix would be to count the number of characters per line and display a warning if the the count is greater than an expected number (by default, this would be 50 for the first line, 72 for the other lines I guess).

**Before the fix**
<img width="1049" alt="Capture d’écran 2019-10-03 à 14 17 09" src="https://user-images.githubusercontent.com/13909/66125945-851db200-e5e8-11e9-957b-a7c42b61d259.png">

**After the fix**
<img width="726" alt="Capture d’écran 2019-10-03 à 14 18 32" src="https://user-images.githubusercontent.com/13909/66126026-b8604100-e5e8-11e9-8b29-ffa4cfa904ab.png">


