### PR TITLE
Graph View: Make performance livable for a large number of branches

### DIFF
--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -867,13 +867,7 @@ static inline CGFloat _SquareDistanceFromPointToLine(CGFloat x0, CGFloat y0, CGF
     visible = YES;
   }
 
-  BOOL shouldDraw = visible && ^BOOL {
-    CGRect boundingBox = CGContextGetPathBoundingBox(context);
-    boundingBox.size.width = fmax(boundingBox.size.width, 1);
-    boundingBox.size.height = fmax(boundingBox.size.height, 1);
-    return [self needsToDrawRect:boundingBox];
-  }();
-
+  BOOL shouldDraw = visible && [self needsToDrawRect:CGRectInset(CGContextGetPathBoundingBox(context), -kMainLineWidth, -kMainLineWidth)];
   if (shouldDraw) {
     XLOG_DEBUG_CHECK(!line.virtual || [[(GINode*)line.nodes[0] layer] index] == 0);
     CGContextSaveGState(context);


### PR DESCRIPTION
For a large (>400) number of branches with "Remote Branch Tips" on, looking at the graph hangs will hang for a few seconds, as well as whenever the graph reloads.

The `minY` and `maxY` passed to the graph's `drawRect:` are used to clamp which layers get drawn, ostensibly to improve performance. However, lines do not get similarly clamped between the `minX` and `maxY`, likely because branch lines can cross great distances to connect nodes, and thus wouldn't be included by a sample. At least,

This means that for 400 lines, the same vertical subset of all 400 lines get drawn repeatedly for every tile the OS asks for in the horizontal direction. That's a bunch of repeated work.

This PR adds a very small occlusion check just before actually drawing the given line using the path that it generates. The resulting performance isn't as fast as I'd hope for, but it does make using the app livable for me again while I have "Remote Branch Tips" on (i.e., 5-10s vs. 0s with dropped frames).

**I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT**