### PR TITLE
Text size setting

### DIFF
--- a/GitUp/Application/AppDelegate.m
+++ b/GitUp/Application/AppDelegate.m
@@ -93,6 +93,7 @@
     GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters : @(YES),
     GICommitMessageViewUserDefaultKey_ShowMargins : @(YES),
     GICommitMessageViewUserDefaultKey_EnableSpellChecking : @(YES),
+    GIUserDefaultKey_FontSize : @(GIDefaultFontSize),
     kUserDefaultsKey_ReleaseChannel : kReleaseChannel_Stable,
     kUserDefaultsKey_CheckInterval : @(15 * 60),
     kUserDefaultsKey_FirstLaunch : @(YES),

--- a/GitUp/Application/Base.lproj/MainMenu.xib
+++ b/GitUp/Application/Base.lproj/MainMenu.xib
@@ -15,10 +15,10 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window title="GitUp Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="preferences" animationBehavior="default" id="3qV-q4-a6k">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
-            <rect key="contentRect" x="940" y="240" width="500" height="410"/>
+            <rect key="contentRect" x="940" y="240" width="500" height="504"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1440"/>
             <view key="contentView" id="uEJ-lO-PMl">
-                <rect key="frame" x="0.0" y="0.0" width="500" height="410"/>
+                <rect key="frame" x="0.0" y="0.0" width="500" height="504"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <userGuides>
                     <userLayoutGuide location="138" affinity="minX"/>
@@ -26,17 +26,17 @@
                 </userGuides>
                 <subviews>
                     <tabView fixedFrame="YES" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="anN-jw-l7x">
-                        <rect key="frame" x="0.0" y="0.0" width="500" height="410"/>
+                        <rect key="frame" x="0.0" y="0.0" width="500" height="504"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <font key="font" metaFont="system"/>
                         <tabViewItems>
-                            <tabViewItem label="{500, 410}" identifier="general" id="M8N-WY-xpP">
+                            <tabViewItem label="{500, 445}" identifier="general" id="M8N-WY-xpP">
                                 <view key="view" ambiguous="YES" id="ZJf-t1-iGB">
-                                    <rect key="frame" x="0.0" y="0.0" width="500" height="410"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="500" height="504"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EBQ-WH-0CZ">
-                                            <rect key="frame" x="12" y="373" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="467" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Appearance:" id="KoF-W9-skh">
                                                 <font key="font" metaFont="system"/>
@@ -45,7 +45,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2WQ-hK-j2t">
-                                            <rect key="frame" x="137" y="372" width="162" height="18"/>
+                                            <rect key="frame" x="137" y="466" width="162" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Show welcome window" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="x90-KD-anh">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -62,7 +62,7 @@
                                             </connections>
                                         </button>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lyZ-cf-MT6">
-                                            <rect key="frame" x="12" y="203" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="297" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Commits:" id="6J8-35-XZI">
                                                 <font key="font" metaFont="system"/>
@@ -71,7 +71,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CQY-oC-oQ8">
-                                            <rect key="frame" x="137" y="202" width="146" height="18"/>
+                                            <rect key="frame" x="137" y="296" width="146" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Use Simple mode" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="rMb-zc-NF1">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -88,7 +88,7 @@
                                             </connections>
                                         </button>
                                         <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="T1B-3i-hRB">
-                                            <rect key="frame" x="137" y="112" width="191" height="18"/>
+                                            <rect key="frame" x="137" y="206" width="191" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Show invisible characters" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="omy-Qf-vg9">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -105,7 +105,7 @@
                                             </connections>
                                         </button>
                                         <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SyF-mN-F3q">
-                                            <rect key="frame" x="137" y="92" width="270" height="18"/>
+                                            <rect key="frame" x="137" y="186" width="270" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Show margins at 50 and 72 characters" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="AMR-Ne-0QY">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -122,7 +122,7 @@
                                             </connections>
                                         </button>
                                         <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ag6-rb-zPH">
-                                            <rect key="frame" x="137" y="72" width="176" height="18"/>
+                                            <rect key="frame" x="137" y="166" width="176" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Enable spell checking" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="G82-Jf-2sb">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -139,10 +139,10 @@
                                             </connections>
                                         </button>
                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jee-vl-BUt">
-                                            <rect key="frame" x="137" y="140" width="345" height="56"/>
+                                            <rect key="frame" x="137" y="234" width="345" height="56"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="v99-tx-ohB">
-                                                <font key="font" metaFont="menu" size="11"/>
+                                                <font key="font" metaFont="label" size="11"/>
                                                 <string key="title">In "Simple" commit mode, GitUp unifies the working directory and index i.e. there is no staging area.
 You must close and reopen any opened repositories in GitUp after changing this setting.</string>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -150,7 +150,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YZU-dx-gjr">
-                                            <rect key="frame" x="12" y="274" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="368" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Diffs Layout:" id="B0V-bN-usw">
                                                 <font key="font" metaFont="system"/>
@@ -159,7 +159,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <matrix verticalHuggingPriority="750" fixedFrame="YES" allowsEmptySelection="NO" autorecalculatesCellSize="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pP3-w2-KOs">
-                                            <rect key="frame" x="139" y="234" width="341" height="58"/>
+                                            <rect key="frame" x="139" y="328" width="341" height="58"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             <size key="cellSize" width="276" height="18"/>
@@ -195,7 +195,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </connections>
                                         </matrix>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mC1-sE-MTH">
-                                            <rect key="frame" x="12" y="113" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="207" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Message Editor:" id="5Hr-DF-QKw">
                                                 <font key="font" metaFont="system"/>
@@ -204,7 +204,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IO8-Wx-DRo">
-                                            <rect key="frame" x="12" y="348" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="442" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Diff Generation:" id="cxW-C3-fIQ">
                                                 <font key="font" metaFont="system"/>
@@ -213,7 +213,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <matrix verticalHuggingPriority="750" fixedFrame="YES" allowsEmptySelection="NO" autorecalculatesCellSize="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zwg-99-t9E">
-                                            <rect key="frame" x="139" y="308" width="341" height="58"/>
+                                            <rect key="frame" x="139" y="402" width="341" height="58"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             <size key="cellSize" width="268" height="18"/>
@@ -249,7 +249,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </connections>
                                         </matrix>
                                         <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aYx-qQ-zM6" userLabel="Theme">
-                                            <rect key="frame" x="137" y="34" width="251" height="25"/>
+                                            <rect key="frame" x="137" y="128" width="251" height="25"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <popUpButtonCell key="cell" type="push" title="&lt;THEME&gt;" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="Sc6-iK-E7E" id="VKw-op-BDT">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -267,7 +267,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </connections>
                                         </popUpButton>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1hO-bG-lcd">
-                                            <rect key="frame" x="82" y="39" width="50" height="17"/>
+                                            <rect key="frame" x="82" y="133" width="50" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Theme:" id="JLz-xa-wP4">
                                                 <font key="font" usesAppearanceFont="YES"/>
@@ -275,16 +275,58 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
+                                        <slider verticalHuggingPriority="750" ambiguous="YES" id="rhi-3l-Hqe">
+                                            <rect key="frame" x="161" y="89" width="220" height="24"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <sliderCell key="cell" continuous="YES" state="on" alignment="left" maxValue="7" doubleValue="1" tickMarkPosition="below" numberOfTickMarks="8" allowsTickMarkValuesOnly="YES" sliderType="linear" id="l2k-ze-Mef"/>
+                                            <connections>
+                                                <binding destination="AR1-cq-KNa" name="value" keyPath="values.GIUserDefaultKey_FontSize" id="Qvl-2n-Mm7">
+                                                    <dictionary key="options">
+                                                        <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                        <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                        <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                                        <string key="NSValueTransformerName">FontSizeTransformer</string>
+                                                    </dictionary>
+                                                </binding>
+                                            </connections>
+                                        </slider>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" id="5aY-1Q-fPN">
+                                            <rect key="frame" x="137" y="93" width="20" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Aa" id="KQN-gV-qvd">
+                                                <font key="font" metaFont="system" size="10"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" id="Gtc-me-VZe">
+                                            <rect key="frame" x="385" y="95" width="29" height="24"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Aa" id="4Va-3A-rhV">
+                                                <font key="font" metaFont="system" size="20"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" id="USF-fw-I4Y">
+                                            <rect key="frame" x="12" y="98" width="120" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Text Size:" id="i4L-0T-dLo">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                     </subviews>
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="{500, 310}" identifier="advanced" id="Qdl-lQ-O4q">
                                 <view key="view" id="8CG-H0-Xhk">
-                                    <rect key="frame" x="0.0" y="0.0" width="500" height="410"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="500" height="612"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7N4-S9-iWL">
-                                            <rect key="frame" x="136" y="168" width="200" height="26"/>
+                                            <rect key="frame" x="136" y="370" width="200" height="26"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <popUpButtonCell key="cell" type="push" title="&lt;RELEASE CHANNEL&gt;" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" autoenablesItems="NO" selectedItem="xdx-IX-FK6" id="Sdr-Ep-kPW">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -302,7 +344,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </connections>
                                         </popUpButton>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mi3-Eg-51i">
-                                            <rect key="frame" x="12" y="174" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="376" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Release Channel:" id="M0A-b6-dhN">
                                                 <font key="font" metaFont="system"/>
@@ -311,7 +353,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="b9G-MU-MDn">
-                                            <rect key="frame" x="12" y="271" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="473" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Remotes:" id="LAp-ea-WLX">
                                                 <font key="font" metaFont="system"/>
@@ -320,16 +362,16 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PtA-hG-Qmn">
-                                            <rect key="frame" x="137" y="130" width="345" height="34"/>
+                                            <rect key="frame" x="137" y="332" width="345" height="34"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="The &quot;Continuous&quot; release channel installs builds directly from GitUp Continuous Integration. Use at your own risk!" id="qB2-E4-Yuu">
-                                                <font key="font" metaFont="menu" size="11"/>
+                                                <font key="font" metaFont="label" size="11"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="w2N-io-xkS">
-                                            <rect key="frame" x="137" y="271" width="130" height="17"/>
+                                            <rect key="frame" x="137" y="473" width="130" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Automatically check" id="X1v-BK-dAQ">
                                                 <font key="font" metaFont="system"/>
@@ -338,7 +380,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZYX-Yt-1fl">
-                                            <rect key="frame" x="271" y="265" width="145" height="26"/>
+                                            <rect key="frame" x="271" y="467" width="145" height="26"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <popUpButtonCell key="cell" type="push" title="Never" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" autoenablesItems="NO" altersStateOfSelectedItem="NO" selectedItem="KgR-3b-gT5" id="Pdg-S3-YXJ">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -363,7 +405,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </connections>
                                         </popUpButton>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vpU-gW-P72">
-                                            <rect key="frame" x="12" y="379" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="581" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="External Diff:" id="WZ7-h0-Fpb">
                                                 <font key="font" metaFont="system"/>
@@ -372,7 +414,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mZX-yf-dtK">
-                                            <rect key="frame" x="136" y="373" width="165" height="26"/>
+                                            <rect key="frame" x="136" y="575" width="165" height="26"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <popUpButtonCell key="cell" type="push" title="FileMerge" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" autoenablesItems="NO" altersStateOfSelectedItem="NO" selectedItem="szc-39-qmN" id="yfJ-9J-pbb">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -400,7 +442,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </connections>
                                         </popUpButton>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2WJ-iR-f3R">
-                                            <rect key="frame" x="12" y="343" width="120" height="17"/>
+                                            <rect key="frame" x="12" y="545" width="120" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="External Merge:" id="2DT-l7-dgY">
                                                 <font key="font" metaFont="system"/>
@@ -409,7 +451,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ud9-w0-9vK">
-                                            <rect key="frame" x="136" y="337" width="165" height="26"/>
+                                            <rect key="frame" x="136" y="539" width="165" height="26"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <popUpButtonCell key="cell" type="push" title="FileMerge" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" autoenablesItems="NO" altersStateOfSelectedItem="NO" selectedItem="Zln-Lm-NeH" id="NHJ-tA-W14">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -437,7 +479,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </connections>
                                         </popUpButton>
                                         <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xxa-CO-ELY">
-                                            <rect key="frame" x="136" y="245" width="346" height="18"/>
+                                            <rect key="frame" x="136" y="447" width="346" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Allow quick confirmation of dangerous operations" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="uJq-iS-sPr">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -448,16 +490,16 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </connections>
                                         </button>
                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ad9-ef-Jqv">
-                                            <rect key="frame" x="137" y="213" width="345" height="28"/>
+                                            <rect key="frame" x="137" y="415" width="345" height="28"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="This allows dangerous operations on remotes, like force push, to be confirmed by pressing the Return key in dialogs." id="LQY-Xb-bQ5">
-                                                <font key="font" metaFont="menu" size="11"/>
+                                                <font key="font" metaFont="label" size="11"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yk0-pw-L66">
-                                            <rect key="frame" x="16" y="309" width="116" height="17"/>
+                                            <rect key="frame" x="16" y="511" width="116" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="External Terminal:" id="2fJ-Wk-1yE">
                                                 <font key="font" metaFont="system"/>
@@ -466,7 +508,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             </textFieldCell>
                                         </textField>
                                         <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="t3W-1A-hzN">
-                                            <rect key="frame" x="136" y="305" width="166" height="22"/>
+                                            <rect key="frame" x="136" y="507" width="166" height="22"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <popUpButtonCell key="cell" type="push" title="Terminal" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" autoenablesItems="NO" altersStateOfSelectedItem="NO" selectedItem="UlY-xH-pGx" id="5eq-0P-7Rr">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -517,7 +559,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                     <toolbarItem reference="doU-9n-plE"/>
                 </defaultToolbarItems>
             </toolbar>
-            <point key="canvasLocation" x="-8" y="1138"/>
+            <point key="canvasLocation" x="-8" y="1185"/>
         </window>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate">
             <connections>

--- a/GitUp/Application/Base.lproj/MainMenu.xib
+++ b/GitUp/Application/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,7 +16,7 @@
         <window title="GitUp Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="preferences" animationBehavior="default" id="3qV-q4-a6k">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <rect key="contentRect" x="940" y="240" width="500" height="410"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="900"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1440"/>
             <view key="contentView" id="uEJ-lO-PMl">
                 <rect key="frame" x="0.0" y="0.0" width="500" height="410"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -142,7 +142,7 @@
                                             <rect key="frame" x="137" y="140" width="345" height="56"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="v99-tx-ohB">
-                                                <font key="font" metaFont="controlContent" size="11"/>
+                                                <font key="font" metaFont="menu" size="11"/>
                                                 <string key="title">In "Simple" commit mode, GitUp unifies the working directory and index i.e. there is no staging area.
 You must close and reopen any opened repositories in GitUp after changing this setting.</string>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -323,7 +323,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             <rect key="frame" x="137" y="130" width="345" height="34"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="The &quot;Continuous&quot; release channel installs builds directly from GitUp Continuous Integration. Use at your own risk!" id="qB2-E4-Yuu">
-                                                <font key="font" metaFont="controlContent" size="11"/>
+                                                <font key="font" metaFont="menu" size="11"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
@@ -451,7 +451,7 @@ You must close and reopen any opened repositories in GitUp after changing this s
                                             <rect key="frame" x="137" y="213" width="345" height="28"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="This allows dangerous operations on remotes, like force push, to be confirmed by pressing the Return key in dialogs." id="LQY-Xb-bQ5">
-                                                <font key="font" metaFont="controlContent" size="11"/>
+                                                <font key="font" metaFont="menu" size="11"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>

--- a/GitUp/Application/FontSizeTransformer.h
+++ b/GitUp/Application/FontSizeTransformer.h
@@ -1,0 +1,21 @@
+//  Copyright (C) 2015-2019 Pierre-Olivier Latour <info@pol-online.net>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import <Foundation/Foundation.h>
+
+/// Transforms between the linear slider in Preferences to a non-linear list of font sizes matching the system font picker.
+@interface FontSizeTransformer : NSValueTransformer
+
+@end

--- a/GitUp/Application/FontSizeTransformer.m
+++ b/GitUp/Application/FontSizeTransformer.m
@@ -1,0 +1,55 @@
+//  Copyright (C) 2015-2019 Pierre-Olivier Latour <info@pol-online.net>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import "FontSizeTransformer.h"
+#import <GitUpKit/GIAppKit.h>
+
+static NSArray* sizes;
+
+@implementation FontSizeTransformer
+
++ (void)initialize {
+  // Match the system font picker
+  sizes = @[ @9, @10, @11, @12, @13, @14, @18, @24 ];
+}
+
++ (Class)transformedValueClass {
+  return [NSNumber class];
+}
+
++ (BOOL)allowsReverseTransformation {
+  return YES;
+}
+
+- (id)transformedValue:(id)fontSizeValue {
+  NSUInteger idx = [sizes indexOfObject:fontSizeValue];
+  if (idx == NSNotFound) {
+    // If the user default is set externally, fallback to the default index.
+    return @1;
+  }
+
+  return @(idx);
+}
+
+- (id)reverseTransformedValue:(id)indexValue {
+  NSUInteger idx = [indexValue unsignedIntegerValue];
+  if (idx >= sizes.count) {
+    return @(GIDefaultFontSize);
+  }
+
+  return sizes[idx];
+}
+
+@end

--- a/GitUp/GitUp.xcodeproj/project.pbxproj
+++ b/GitUp/GitUp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		0AE7F5F12312C1B000B06050 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0AE7F5ED2312C1B000B06050 /* InfoPlist.strings */; };
 		165C32B61B95739700D2F894 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 165C32B51B95739700D2F894 /* QuartzCore.framework */; };
 		31CD50E3203E2E2800360B3A /* ToolbarItemWrapperView.m in Sources */ = {isa = PBXBuildFile; fileRef = 31CD50E2203E2E2800360B3A /* ToolbarItemWrapperView.m */; };
+		A53C6D0C1E61A9CF0070387E /* FontSizeTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = A53C6D0B1E61A9CF0070387E /* FontSizeTransformer.m */; };
 		E212A6DE1B92100E00F62B18 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E212A6DD1B92100E00F62B18 /* libiconv.dylib */; };
 		E21739F71A5080DD00EC6777 /* DocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = E21739F61A5080DD00EC6777 /* DocumentController.m */; };
 		E21DCAEB1B253847006424E8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E21DCAEA1B253847006424E8 /* main.m */; };
@@ -134,6 +135,8 @@
 		165C32B51B95739700D2F894 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		31CD50E1203E2E2800360B3A /* ToolbarItemWrapperView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ToolbarItemWrapperView.h; sourceTree = "<group>"; };
 		31CD50E2203E2E2800360B3A /* ToolbarItemWrapperView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ToolbarItemWrapperView.m; sourceTree = "<group>"; };
+		A53C6D0A1E61A9CF0070387E /* FontSizeTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FontSizeTransformer.h; sourceTree = "<group>"; };
+		A53C6D0B1E61A9CF0070387E /* FontSizeTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FontSizeTransformer.m; sourceTree = "<group>"; };
 		E212A6DD1B92100E00F62B18 /* libiconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
 		E21739F51A5080DD00EC6777 /* DocumentController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DocumentController.h; sourceTree = "<group>"; };
 		E21739F61A5080DD00EC6777 /* DocumentController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DocumentController.m; sourceTree = "<group>"; };
@@ -295,6 +298,8 @@
 				0AE7F5ED2312C1B000B06050 /* InfoPlist.strings */,
 				E2C338B319F8562F00063D95 /* main.m */,
 				E2C338BD19F8562F00063D95 /* MainMenu.xib */,
+				A53C6D0A1E61A9CF0070387E /* FontSizeTransformer.h */,
+				A53C6D0B1E61A9CF0070387E /* FontSizeTransformer.m */,
 				E2C5672B1A6D98BC00ECFE07 /* WindowController.h */,
 				E2C5672C1A6D98BC00ECFE07 /* WindowController.m */,
 				31CD50E1203E2E2800360B3A /* ToolbarItemWrapperView.h */,
@@ -471,6 +476,7 @@
 				E2E3C9A01D771E7600AA9A62 /* GARawTracker.m in Sources */,
 				E2C338B419F8562F00063D95 /* main.m in Sources */,
 				E2C5672D1A6D98BC00ECFE07 /* WindowController.m in Sources */,
+				A53C6D0C1E61A9CF0070387E /* FontSizeTransformer.m in Sources */,
 				E2C338B219F8562F00063D95 /* AppDelegate.m in Sources */,
 				0A58CD77237B4F4B00C2BDD0 /* CloneWindowController.m in Sources */,
 				E2C338B719F8562F00063D95 /* Document.m in Sources */,

--- a/GitUpKit/Components/GIDiffContentsViewController.m
+++ b/GitUpKit/Components/GIDiffContentsViewController.m
@@ -24,7 +24,8 @@
 #import "GCRepository+Index.h"
 #import "XLFacilityMacros.h"
 
-#define kMinSplitDiffViewWidth 1000
+// Units ems: a multiple of the font point size, so the width threshold is 100 * 10 = 1000 for a 10 point font.
+#define kMinSplitDiffViewWidthEms 100
 
 #define kContextualMenuOffsetX 0
 #define kContextualMenuOffsetY -6
@@ -189,6 +190,7 @@ static NSImage* _untrackedImage = nil;
 - (instancetype)initWithRepository:(GCLiveRepository*)repository {
   if ((self = [super initWithRepository:repository])) {
     [[NSUserDefaults standardUserDefaults] addObserver:self forKeyPath:GIDiffContentsViewControllerUserDefaultKey_DiffViewMode options:0 context:(__bridge void*)[GIDiffContentsViewController class]];
+    [[NSUserDefaults standardUserDefaults] addObserver:self forKeyPath:GIUserDefaultKey_FontSize options:0 context:(__bridge void*)[GIDiffContentsViewController class]];
   }
   return self;
 }
@@ -196,6 +198,7 @@ static NSImage* _untrackedImage = nil;
 - (void)dealloc {
   [[NSNotificationCenter defaultCenter] removeObserver:self name:NSViewBoundsDidChangeNotification object:_tableView.superview];
 
+  [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:GIUserDefaultKey_FontSize context:(__bridge void*)[GIDiffContentsViewController class]];
   [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:GIDiffContentsViewControllerUserDefaultKey_DiffViewMode context:(__bridge void*)[GIDiffContentsViewController class]];
 }
 
@@ -227,13 +230,13 @@ static NSImage* _untrackedImage = nil;
     if ((change == kGCFileDiffChange_Untracked) || (change == kGCFileDiffChange_Added) || (change == kGCFileDiffChange_Deleted)) {
       return [GIUnifiedDiffView class];
     }
-    return self.view.bounds.size.width < kMinSplitDiffViewWidth ? [GIUnifiedDiffView class] : [GISplitDiffView class];
+    return self.view.bounds.size.width < kMinSplitDiffViewWidthEms * GIFontSize() ? [GIUnifiedDiffView class] : [GISplitDiffView class];
   }
   return mode > 0 ? [GISplitDiffView class] : [GIUnifiedDiffView class];
 }
 
-- (void)_updateDiffViews {
-  BOOL reload = NO;
+- (void)_updateDiffViewsForcingReload:(BOOL)forceReload {
+  BOOL reload = forceReload;
   for (GIDiffContentData* data in _data) {
     if (!data.diffView) {
       continue;
@@ -256,7 +259,7 @@ static NSImage* _untrackedImage = nil;
 
 - (void)viewDidResize {
   if (self.viewVisible && !self.liveResizing) {
-    [self _updateDiffViews];
+    [self _updateDiffViewsForcingReload:NO];
     [NSAnimationContext beginGrouping];
     [[NSAnimationContext currentContext] setDuration:0.0];  // Prevent animations in case the view is actually not on screen yet (e.g. in a hidden tab)
     [_tableView noteHeightOfRowsWithIndexesChanged:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, [self numberOfRowsInTableView:_tableView])]];
@@ -265,15 +268,16 @@ static NSImage* _untrackedImage = nil;
 }
 
 - (void)viewDidFinishLiveResize {
-  [self _updateDiffViews];
+  [self _updateDiffViewsForcingReload:NO];
   [_tableView noteHeightOfRowsWithIndexesChanged:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, [self numberOfRowsInTableView:_tableView])]];
 }
 
 // WARNING: This is called *several* times when the default has been changed
 - (void)observeValueForKeyPath:(NSString*)keyPath ofObject:(id)object change:(NSDictionary*)change context:(void*)context {
   if (context == (__bridge void*)[GIDiffContentsViewController class]) {
-    if (self.viewVisible) {
-      [self _updateDiffViews];  // This is idempotent
+    BOOL isFontSizeChange = [keyPath isEqualToString:GIUserDefaultKey_FontSize];
+    if (self.viewVisible || isFontSizeChange) {
+      [self _updateDiffViewsForcingReload:isFontSizeChange];  // This is idempotent
     }
   } else {
     [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];

--- a/GitUpKit/Interface/GIDiffView.h
+++ b/GitUpKit/Interface/GIDiffView.h
@@ -32,6 +32,12 @@
 @property(nonatomic, readonly, getter=isEmpty) BOOL empty;
 - (CGFloat)updateLayoutForWidth:(CGFloat)width;
 
+@property(nonatomic, readonly) CFDictionaryRef textAttributes;
+@property(nonatomic, readonly) CTLineRef addedLine;
+@property(nonatomic, readonly) CTLineRef deletedLine;
+@property(nonatomic, readonly) CGFloat lineHeight;
+@property(nonatomic, readonly) CGFloat lineDescent;
+
 @property(nonatomic, readonly) BOOL hasSelection;
 @property(nonatomic, readonly) BOOL hasSelectedText;
 @property(nonatomic, readonly) BOOL hasSelectedLines;

--- a/GitUpKit/Interface/GIPrivate.h
+++ b/GitUpKit/Interface/GIPrivate.h
@@ -20,14 +20,6 @@
 
 #if __GI_HAS_APPKIT__
 
-extern CFDictionaryRef GIDiffViewAttributes;
-
-extern CTLineRef GIDiffViewAddedLine;
-extern CTLineRef GIDiffViewDeletedLine;
-
-extern CGFloat GIDiffViewLineHeight;
-extern CGFloat GIDiffViewLineDescent;
-
 extern const char* GIDiffViewMissingNewlinePlaceholder;
 
 #endif

--- a/GitUpKit/Interface/GIUnifiedDiffView.m
+++ b/GitUpKit/Interface/GIUnifiedDiffView.m
@@ -18,11 +18,25 @@
 #endif
 
 #import "GIPrivate.h"
+#import "GIAppKit.h"
 
-#define kTextLineNumberMargin (5 * 8)
-#define kTextInsetLeft 15
-#define kTextInsetRight 5
 #define kTextBottomPadding 0
+
+static CGFloat textLineNumberMargin(void) {
+  return round(4 * GIFontSize());
+}
+
+static CGFloat textInsetLeft(void) {
+  return round(1.5 * GIFontSize());
+}
+
+static CGFloat textInsetRight(void) {
+  return round(0.5 * GIFontSize());
+}
+
+static CGFloat textLineStartX(void) {
+  return 2 * textLineNumberMargin() + textInsetLeft();
+}
 
 typedef NS_ENUM(NSUInteger, SelectionMode) {
   kSelectionMode_None = 0,
@@ -195,20 +209,22 @@ typedef struct {
 }
 
 - (CGFloat)updateLayoutForWidth:(CGFloat)width {
-  if (_string && (NSInteger)width != (NSInteger)_size.width) {
+  if (_string &&
+      ((NSInteger)width != (NSInteger)_size.width ||
+       (CFAttributedStringGetLength(_string) > 0 && !CFEqual(CFAttributedStringGetAttributes(_string, 0, NULL), self.textAttributes)))) {
     if (_frame) {
       CFRelease(_frame);
     }
     if (_framesetter) {
       CFRelease(_framesetter);
     }
-    CFAttributedStringSetAttributes(_string, CFRangeMake(0, CFAttributedStringGetLength(_string)), GIDiffViewAttributes, false);
+    CFAttributedStringSetAttributes(_string, CFRangeMake(0, CFAttributedStringGetLength(_string)), self.textAttributes, false);
     _framesetter = CTFramesetterCreateWithAttributedString(_string);
-    CGFloat textWidth = width - 2 * kTextLineNumberMargin - kTextInsetLeft - kTextInsetRight;
+    CGFloat textWidth = width - 2 * textLineNumberMargin() - textInsetLeft() - textInsetRight();
     CGPathRef path = CGPathCreateWithRect(CGRectMake(0, 0, textWidth, CGFLOAT_MAX), NULL);
     _frame = CTFramesetterCreateFrame(_framesetter, CFRangeMake(0, CFAttributedStringGetLength(_string)), path, NULL);
     CGPathRelease(path);
-    _size = NSMakeSize(width, CFArrayGetCount(CTFrameGetLines(_frame)) * GIDiffViewLineHeight + kTextBottomPadding);
+    _size = NSMakeSize(width, CFArrayGetCount(CTFrameGetLines(_frame)) * self.lineHeight + kTextBottomPadding);
   }
   return _size.height;
 }
@@ -240,11 +256,14 @@ typedef struct {
   [self.backgroundColor setFill];
   CGContextFillRect(context, dirtyRect);
 
+  CGFloat lineNumberMargin = textLineNumberMargin();
+  CGFloat lineStartX = textLineStartX();
+
   void (^drawHorizontalSeparator)(CGFloat) = ^(CGFloat y) {
     CGContextSaveGState(context);
     CGContextSetStrokeColorWithColor(context, NSColor.gridColor.CGColor);
 
-    CGFloat pattern[] = {kTextLineNumberMargin - 1, 1, kTextLineNumberMargin - 1, 1, CGFLOAT_MAX};
+    CGFloat pattern[] = {lineNumberMargin - 1, 1, lineNumberMargin - 1, 1, CGFLOAT_MAX};
     size_t count = sizeof(pattern) / sizeof(*pattern);
     CGContextSetLineDash(context, 0, pattern, count);
 
@@ -262,14 +281,14 @@ typedef struct {
     CGContextSetTextMatrix(context, CGAffineTransformIdentity);
     CFArrayRef lines = CTFrameGetLines(_frame);
     CFIndex count = CFArrayGetCount(lines);
-    CFIndex start = MIN(MAX(count - (dirtyRect.origin.y + dirtyRect.size.height - kTextBottomPadding) / GIDiffViewLineHeight, 0), count);
-    CFIndex end = MIN(MAX(count - (dirtyRect.origin.y - kTextBottomPadding) / GIDiffViewLineHeight + 1, 0), count);
+    CFIndex start = MIN(MAX(count - (dirtyRect.origin.y + dirtyRect.size.height - kTextBottomPadding) / self.lineHeight, 0), count);
+    CFIndex end = MIN(MAX(count - (dirtyRect.origin.y - kTextBottomPadding) / self.lineHeight + 1, 0), count);
     const LineInfo* info = NULL;
     for (CFIndex i = start; i < end; ++i) {
       CTLineRef line = CFArrayGetValueAtIndex(lines, i);
       CFRange lineRange = CTLineGetStringRange(line);
-      CGFloat linePosition = (count - 1 - i) * GIDiffViewLineHeight + kTextBottomPadding;
-      CGFloat textPosition = linePosition + GIDiffViewLineDescent;
+      CGFloat linePosition = (count - 1 - i) * self.lineHeight + kTextBottomPadding;
+      CGFloat textPosition = linePosition + self.lineDescent;
 
       if (info) {
         while (lineRange.location >= info->range.location + info->range.length) {
@@ -283,17 +302,19 @@ typedef struct {
       if (!info) break;
 #endif
 
+      CGFloat lineTextInset = 2 * lineNumberMargin + round(0.4 * GIFontSize());
+
       if ((NSUInteger)info->change != NSNotFound) {
         if ([_selectedLines containsIndex:info->index]) {
           [selectedColor setFill];
-          CGContextFillRect(context, CGRectMake(0, linePosition, bounds.size.width, GIDiffViewLineHeight));
+          CGContextFillRect(context, CGRectMake(0, linePosition, bounds.size.width, self.lineHeight));
         } else if (info->change != kGCLineDiffChange_Unmodified) {
           if (info->change == kGCLineDiffChange_Deleted) {
             [NSColor.gitUpDiffDeletedTextBackgroundColor setFill];
           } else {
             [NSColor.gitUpDiffAddedTextBackgroundColor setFill];
           }
-          CGContextFillRect(context, CGRectMake(0, linePosition, bounds.size.width, GIDiffViewLineHeight));
+          CGContextFillRect(context, CGRectMake(0, linePosition, bounds.size.width, self.lineHeight));
 
           if (info->highlighted.length) {
             if (info->change == kGCLineDiffChange_Deleted) {
@@ -304,77 +325,80 @@ typedef struct {
             CGFloat startX = CTLineGetOffsetForStringIndex(line, info->range.location + info->highlighted.location, NULL);
             CGFloat endX = CTLineGetOffsetForStringIndex(line, info->range.location + info->highlighted.location + info->highlighted.length, NULL);
             if (endX > startX) {
-              startX = 2 * kTextLineNumberMargin + kTextInsetLeft + round(startX);
-              endX = 2 * kTextLineNumberMargin + kTextInsetLeft + round(endX);
-              CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, GIDiffViewLineHeight));
+              startX = lineStartX + round(startX);
+              endX = lineStartX + round(endX);
+              CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, self.lineHeight));
             }
           }
         }
 
+        CGFloat lineNumberTextInset = round(0.5 * GIFontSize());
+
         [NSColor.tertiaryLabelColor setFill];
         if ((lineRange.location == info->range.location) && (info->oldLineNumber != NSNotFound)) {
-          CFAttributedStringRef string = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)(info->oldLineNumber >= 100000 ? @"9999…" : [NSString stringWithFormat:@"%5lu", info->oldLineNumber]), GIDiffViewAttributes);
+          CFAttributedStringRef string = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)(info->oldLineNumber >= 100000 ? @"9999…" : [NSString stringWithFormat:@"%5lu", info->oldLineNumber]), self.textAttributes);
           CTLineRef prefix = CTLineCreateWithAttributedString(string);
-          CGContextSetTextPosition(context, 5, textPosition);
+          CGContextSetTextPosition(context, lineNumberTextInset, textPosition);
           CTLineDraw(prefix, context);
           CFRelease(prefix);
           CFRelease(string);
 
           if (info->change == kGCLineDiffChange_Deleted) {
-            CGContextSetTextPosition(context, 2 * kTextLineNumberMargin + 4, textPosition);
-            CTLineDraw(GIDiffViewDeletedLine, context);
+            CGContextSetTextPosition(context, lineTextInset, textPosition);
+            CTLineDraw(self.deletedLine, context);
           }
         }
         if ((lineRange.location == info->range.location) && (info->newLineNumber != NSNotFound)) {
-          CFAttributedStringRef string = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)(info->newLineNumber >= 100000 ? @"9999…" : [NSString stringWithFormat:@"%5lu", info->newLineNumber]), GIDiffViewAttributes);
+          CFAttributedStringRef string = CFAttributedStringCreate(kCFAllocatorDefault, (CFStringRef)(info->newLineNumber >= 100000 ? @"9999…" : [NSString stringWithFormat:@"%5lu", info->newLineNumber]), self.textAttributes);
           CTLineRef prefix = CTLineCreateWithAttributedString(string);
-          CGContextSetTextPosition(context, kTextLineNumberMargin + 5, textPosition);
+          CGContextSetTextPosition(context, lineNumberMargin + lineNumberTextInset, textPosition);
           CTLineDraw(prefix, context);
           CFRelease(prefix);
           CFRelease(string);
 
           if (info->change == kGCLineDiffChange_Added) {
-            CGContextSetTextPosition(context, 2 * kTextLineNumberMargin + 4, textPosition);
-            CTLineDraw(GIDiffViewAddedLine, context);
+            CGContextSetTextPosition(context, lineTextInset, textPosition);
+            CTLineDraw(self.addedLine, context);
           }
         }
 
         if (_selectedText.length && (_selectedText.location < lineRange.location + lineRange.length) && (_selectedText.location + _selectedText.length > lineRange.location)) {
           [selectedColor setFill];
-          CGFloat startX = 2 * kTextLineNumberMargin + kTextInsetLeft;
+          CGFloat startX = lineStartX;
           CGFloat endX = bounds.size.width;
           if (_selectedText.location > lineRange.location) {
-            startX = 2 * kTextLineNumberMargin + kTextInsetLeft + round(CTLineGetOffsetForStringIndex(line, _selectedText.location, NULL));
+            startX = lineStartX + round(CTLineGetOffsetForStringIndex(line, _selectedText.location, NULL));
           }
           if (_selectedText.location + _selectedText.length < lineRange.location + lineRange.length) {
-            endX = 2 * kTextLineNumberMargin + kTextInsetLeft + round(CTLineGetOffsetForStringIndex(line, _selectedText.location + _selectedText.length, NULL));
+            endX = lineStartX + round(CTLineGetOffsetForStringIndex(line, _selectedText.location + _selectedText.length, NULL));
           }
-          CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, GIDiffViewLineHeight));
+          CGContextFillRect(context, CGRectMake(startX, linePosition, endX - startX, self.lineHeight));
         }
 
         [NSColor.labelColor set];
-        CGContextSetTextPosition(context, 2 * kTextLineNumberMargin + kTextInsetLeft, textPosition);
+        CGContextSetTextPosition(context, lineStartX, textPosition);
         CTLineDraw(line, context);
       } else {
         [NSColor.gitUpDiffSeparatorBackgroundColor setFill];
-        CGContextFillRect(context, CGRectMake(0, linePosition + 1, bounds.size.width, GIDiffViewLineHeight - 2));
+        CGContextFillRect(context, CGRectMake(0, linePosition + 1, bounds.size.width, self.lineHeight - 2));
 
         drawHorizontalSeparator(linePosition + 0.5);
-        drawHorizontalSeparator(linePosition + GIDiffViewLineHeight - 0.5);
+        drawHorizontalSeparator(linePosition + self.lineHeight - 0.5);
 
         [NSColor.tertiaryLabelColor setFill];
-        CGContextSetTextPosition(context, 2 * kTextLineNumberMargin + 4, textPosition);
+        CGContextSetTextPosition(context, lineTextInset, textPosition);
         CTLineDraw(line, context);
       }
     }
   }
 
   [NSColor.gridColor setStroke];
-  CGContextMoveToPoint(context, kTextLineNumberMargin - 0.5, 0);
-  CGContextAddLineToPoint(context, kTextLineNumberMargin - 0.5, bounds.size.height);
+  CGFloat lineHorizontalPosition = lineNumberMargin - 0.5;
+  CGContextMoveToPoint(context, lineHorizontalPosition, 0);
+  CGContextAddLineToPoint(context, lineHorizontalPosition, bounds.size.height);
   CGContextStrokePath(context);
-  CGContextMoveToPoint(context, 2 * kTextLineNumberMargin - 0.5, 0);
-  CGContextAddLineToPoint(context, 2 * kTextLineNumberMargin - 0.5, bounds.size.height);
+  CGContextMoveToPoint(context, 2 * lineHorizontalPosition, 0);
+  CGContextAddLineToPoint(context, 2 * lineHorizontalPosition, bounds.size.height);
   CGContextStrokePath(context);
 
   CGContextRestoreGState(context);
@@ -382,7 +406,8 @@ typedef struct {
 
 - (void)resetCursorRects {
   NSRect bounds = self.bounds;
-  [self addCursorRect:NSMakeRect(2 * kTextLineNumberMargin + kTextInsetLeft, 0, bounds.size.width - 2 * kTextLineNumberMargin - kTextInsetLeft, bounds.size.height)
+  CGFloat lineNumberMargin = textLineNumberMargin();
+  [self addCursorRect:NSMakeRect(textLineStartX(), 0, bounds.size.width - 2 * lineNumberMargin - textInsetLeft(), bounds.size.height)
                cursor:[NSCursor IBeamCursor]];
 }
 
@@ -459,7 +484,7 @@ typedef struct {
 
   // Check if mouse is in the content area
   CFArrayRef lines = CTFrameGetLines(_frame);
-  CFIndex index = CFArrayGetCount(lines) - (location.y - kTextBottomPadding) / GIDiffViewLineHeight;
+  CFIndex index = CFArrayGetCount(lines) - (location.y - kTextBottomPadding) / self.lineHeight;
   if ((index >= 0) && (index < CFArrayGetCount(lines))) {
     CTLineRef line = CFArrayGetValueAtIndex(lines, index);
 
@@ -472,8 +497,10 @@ typedef struct {
       _selectionMode = kSelectionMode_Replace;
     }
 
+    CGFloat lineNumberMargin = textLineNumberMargin();
+
     // Check if mouse is in the margin area
-    if (location.x < 2 * kTextLineNumberMargin) {
+    if (location.x < 2 * lineNumberMargin) {
       // Reset selection
       _selectedText.length = 0;
       if (_selectionMode == kSelectionMode_Replace) {
@@ -523,13 +550,13 @@ typedef struct {
 
     }
     // Otherwise check if mouse is is in the diff area
-    else if (location.x >= 2 * kTextLineNumberMargin + kTextInsetLeft) {
+    else if (location.x >= textLineStartX()) {
       // Reset selection
       _selectedText.length = 0;
       [_selectedLines removeAllIndexes];
 
       // Update selected text
-      index = CTLineGetStringIndexForPosition(line, CGPointMake(location.x - (2 * kTextLineNumberMargin + kTextInsetLeft), GIDiffViewLineHeight / 2));
+      index = CTLineGetStringIndexForPosition(line, CGPointMake(location.x - (textLineStartX()), self.lineHeight / 2));
       if (index != kCFNotFound) {
         _deletedIndex = index;
         if (event.clickCount > 1) {
@@ -569,7 +596,7 @@ typedef struct {
 
   // Check if mouse is in the content area
   CFArrayRef lines = CTFrameGetLines(_frame);
-  CFIndex index = CFArrayGetCount(lines) - (location.y - kTextBottomPadding) / GIDiffViewLineHeight;
+  CFIndex index = CFArrayGetCount(lines) - (location.y - kTextBottomPadding) / self.lineHeight;
   if ((index >= 0) && (index < CFArrayGetCount(lines))) {
     CTLineRef line = CFArrayGetValueAtIndex(lines, index);
 
@@ -614,7 +641,7 @@ typedef struct {
     }
     // Otherwise we are in text-selection mode
     else {
-      index = CTLineGetStringIndexForPosition(line, CGPointMake(location.x - (2 * kTextLineNumberMargin + kTextInsetLeft), GIDiffViewLineHeight / 2));
+      index = CTLineGetStringIndexForPosition(line, CGPointMake(location.x - (textLineStartX()), self.lineHeight / 2));
       if (index != kCFNotFound) {
         // Update selected text
         if (index > (CFIndex)_deletedIndex) {

--- a/GitUpKit/Utilities/GIAppKit.h
+++ b/GitUpKit/Utilities/GIAppKit.h
@@ -25,6 +25,11 @@ typedef NS_ENUM(NSUInteger, GIAlertType) {
 extern NSString* const GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters;
 extern NSString* const GICommitMessageViewUserDefaultKey_ShowMargins;
 extern NSString* const GICommitMessageViewUserDefaultKey_EnableSpellChecking;
+extern NSString* const GIUserDefaultKey_FontSize;  // NSNumber. Base font size for user interface text. Read this with GIFontSize() to always get a valid value.
+
+extern CGFloat const GIDefaultFontSize;
+
+FOUNDATION_EXPORT CGFloat GIFontSize(void);  // Reads GIUserDefaultKey_FontSize, falling back to GIDefaultFontSize if the user defaults value is not usable.
 
 @interface NSMutableAttributedString (GIAppKit)
 - (void)appendString:(NSString*)string withAttributes:(NSDictionary*)attributes;

--- a/GitUpKit/Utilities/GIAppKit.m
+++ b/GitUpKit/Utilities/GIAppKit.m
@@ -34,6 +34,14 @@
 NSString* const GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters = @"GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters";
 NSString* const GICommitMessageViewUserDefaultKey_ShowMargins = @"GICommitMessageViewUserDefaultKey_ShowMargins";
 NSString* const GICommitMessageViewUserDefaultKey_EnableSpellChecking = @"GICommitMessageViewUserDefaultKey_EnableSpellChecking";
+NSString* const GIUserDefaultKey_FontSize = @"GIUserDefaultKey_FontSize";
+
+CGFloat const GIDefaultFontSize = 10;
+
+CGFloat GIFontSize(void) {
+  CGFloat size = [[NSUserDefaults standardUserDefaults] floatForKey:GIUserDefaultKey_FontSize];
+  return size > 0 ? size : GIDefaultFontSize;
+}
 
 static const void* _associatedObjectCommitKey = &_associatedObjectCommitKey;
 

--- a/GitUpKit/Utilities/GIAppKit.m
+++ b/GitUpKit/Utilities/GIAppKit.m
@@ -149,6 +149,7 @@ static const void* _associatedObjectCommitKey = &_associatedObjectCommitKey;
 @implementation GICommitMessageView
 
 - (void)dealloc {
+  [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:GIUserDefaultKey_FontSize context:(__bridge void*)[GICommitMessageView class]];
   [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:GICommitMessageViewUserDefaultKey_EnableSpellChecking context:(__bridge void*)[GICommitMessageView class]];
   [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:GICommitMessageViewUserDefaultKey_ShowMargins context:(__bridge void*)[GICommitMessageView class]];
   [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters context:(__bridge void*)[GICommitMessageView class]];
@@ -157,7 +158,7 @@ static const void* _associatedObjectCommitKey = &_associatedObjectCommitKey;
 - (void)awakeFromNib {
   [super awakeFromNib];
 
-  self.font = [NSFont userFixedPitchFontOfSize:11];
+  [self updateFont];
   self.continuousSpellCheckingEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:GICommitMessageViewUserDefaultKey_EnableSpellChecking];
   self.automaticSpellingCorrectionEnabled = NO;  // Don't trust IB
   self.grammarCheckingEnabled = NO;  // Don't trust IB
@@ -174,6 +175,13 @@ static const void* _associatedObjectCommitKey = &_associatedObjectCommitKey;
   [[NSUserDefaults standardUserDefaults] addObserver:self forKeyPath:GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters options:0 context:(__bridge void*)[GICommitMessageView class]];
   [[NSUserDefaults standardUserDefaults] addObserver:self forKeyPath:GICommitMessageViewUserDefaultKey_ShowMargins options:0 context:(__bridge void*)[GICommitMessageView class]];
   [[NSUserDefaults standardUserDefaults] addObserver:self forKeyPath:GICommitMessageViewUserDefaultKey_EnableSpellChecking options:0 context:(__bridge void*)[GICommitMessageView class]];
+  [[NSUserDefaults standardUserDefaults] addObserver:self forKeyPath:GIUserDefaultKey_FontSize options:0 context:(__bridge void*)[GICommitMessageView class]];
+}
+
+- (void)updateFont {
+  // To match the original design, the commit message font should be 10% larger than the diff view font.
+  self.font = [NSFont userFixedPitchFontOfSize:round(1.1 * GIFontSize())];
+  [self setNeedsDisplay:YES];
 }
 
 - (void)drawRect:(NSRect)dirtyRect {
@@ -226,6 +234,8 @@ static const void* _associatedObjectCommitKey = &_associatedObjectCommitKey;
         self.continuousSpellCheckingEnabled = flag;
         [self setNeedsDisplay:YES];  // TODO: Why is this needed to refresh?
       }
+    } else if ([keyPath isEqualToString:GIUserDefaultKey_FontSize]) {
+      [self updateFont];
     } else {
       XLOG_DEBUG_UNREACHABLE();
     }


### PR DESCRIPTION
I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT

This is a resurrection of https://github.com/git-up/GitUp/pull/283 rebased onto master. The functionality is the same.

Things not addressed, and I have no immediate plans to do anything about:

- Zooming the map. That’s mostly unrelated to the font size. This seems like it could be a lot of work.
- Changing the text size in the map view’s floating selected commit info view. Since this is independent from the rest of the map layout it seems it should be fairly easy to make it respect `GIFontSize`.
- Changing the text size of the quick view’s commit message. Again, should be straightforward to make it respect and observe the font size setting.

Because of the first two points, I think this does not fix https://github.com/git-up/GitUp/issues/615 since that is specifically asking about the map view. Doesn’t really fix https://github.com/git-up/GitUp/issues/87 either but I don’t think giving the user a full font picker is the right design and sizing the text is the most useful part of picking a custom font.

Original PR text below. Everything I wrote back then is still valid so I’ve just included it verbatim expect for updating the Preferences window screenshot.

---

This branch adds a slider to let users change the font size of the diff and commit message views.

<img width="612" alt="Screenshot 2019-12-14 at 18 36 29" src="https://user-images.githubusercontent.com/2149061/70855408-464a8900-1ec2-11ea-8ded-0b8e48adc50f.png">

![size changes](https://cloud.githubusercontent.com/assets/2149061/23335703/21407fc0-fbbb-11e6-8555-9de7f9d51569.gif)

This addresses the font size requests in the comments of https://github.com/git-up/GitUp/issues/87 — but not changing the typeface itself which is what the original comment is about. See also the alternative PR https://github.com/git-up/GitUp/pull/265 while adds very similar functionality, including changing the typeface. I’m making this pull request because I think my branch has some advantages over other the other PR.

## Design goals

Users should be able to control how large text on computers because software authors can’t know in advance what size would be most comfortable for the user to read due to factors such as visual impairments, screen pixel density and the distance between the screen and the user.

This branch aims to lay a flexible foundation for allowing any part of GitUp to be scalable, and implements scalability in the diff and commit edit views, because I think these are the two views where readability is most important. Using the same scaling in other views is open as possible future work.

Letting the user specify a scale but the application specify the typefaces and relative sizes seems like the best trade-off between allowing the user to see the app comfortably without asking them to be the designer. Also different views have use different fonts and relative sizes. Therefore, the user does not set an explicit typeface name or numerical size and instead a slider without value labels has been added to General Preferences to set the scale. This (deliberately) results in the exact size used being hard to find.

The scale factor is stored in user defaults and this value happens to match the font size of the diff view. Users with unusual requirements for especially large (or small) text can set this to any value using the `defaults` tool.

## Implementation notes

One limitation of storing the font size in the standard user defaults is that this is global state so an app using GitUpKit that wants to show two diff views at the same time would not be able to make them use different font sizes. I don’t think this use case is particularly important.

As a framework, GitUpKit should not register default values in user defaults, and it can’t guarantee that the app using GitUpKit registers a sensible default for this key. Therefore I made GitUpKit always read the font size from user defaults wrapped in a `GIFontSize()` function which ensures the value is greater than zero.

I put the `GIFontSize` function in `GIAppKit.h/m` because that’s where other GitUpKit user defaults keys are defined. I didn’t think this fits in in `GIFunctions` because it’s only available in the Mac version of GitUpKit. Putting it in `GIFunctions` wrapped in `#if __GI_HAS_APPKIT__` would work too but makes less sense to me.

I thought it would be messy to do the `#ifdef __cplusplus` like in `GIFunctions` for this one function, so I used `FOUNDATION_EXPORT`. (My preferred way to do this would be to drop the `#ifdef __cplusplus` from `GIFunctions` and define a `GIEXPORT` used for every public function.)

Naming of the user defaults key: I mirrored `GICommitMessageViewUserDefaultKey_ShowMargins` but removed the `CommitMessageView` part because this one is more general.

I decided to store the most obvious thing in user defaults: the font size used in the diff view in points. This simplicity comes at the cost of making the slider in preferences more complicated as a linear slider would not be very good: the difference between 10 and 11 points is much more important than the difference between 18 and 19 points. A value transformer is used to map between the discrete slider value and a non-linear array of font sizes that match the preset sizes in the Mac system font picker.