### PR TITLE
Faster multiple file staging

### DIFF
--- a/GitUpKit/Core/GCDiff-Tests.m
+++ b/GitUpKit/Core/GCDiff-Tests.m
@@ -165,16 +165,16 @@
   XCTAssertTrue([self.repository addFileToIndex:@"renamed1.txt" error:NULL]);
   [self updateFileAtPath:@"type-changed.txt" withString:@""];
   XCTAssertTrue([self.repository addFileToIndex:@"type-changed.txt" error:NULL]);
-  
-  NSArray *files = @[@".gitignore", @"modified.txt", @"deleted.txt", @"renamed1.txt", @"type-changed.txt"];
-  
+
+  NSArray* files = @[ @".gitignore", @"modified.txt", @"deleted.txt", @"renamed1.txt", @"type-changed.txt" ];
+
   // Test adding and removing multiple files
   XCTAssertTrue([self.repository removeFilesFromIndex:files error:NULL]);
   XCTAssertEqual([self.repository checkIndexStatus:NULL].deltas.count, 0);
-  
+
   XCTAssertTrue([self.repository addFilesToIndex:files error:NULL]);
   XCTAssertEqual([self.repository checkIndexStatus:NULL].deltas.count, 5);
-  
+
   XCTAssertNotNil([self.repository createCommitFromHEADWithMessage:@"Update" error:NULL]);
 
   // Touch files
@@ -189,7 +189,7 @@
 
   // Stage some files
   XCTAssertTrue([self.repository addFileToIndex:@"modified.txt" error:NULL]);
-  files = @[@"deleted.txt", @"renamed1.txt"];
+  files = @[ @"deleted.txt", @"renamed1.txt" ];
   XCTAssertTrue([self.repository removeFilesFromIndex:files error:NULL]);
   XCTAssertTrue([self.repository addFileToIndex:@"renamed2.txt" error:NULL]);
   XCTAssertTrue([self.repository addFileToIndex:@"added.txt" error:NULL]);

--- a/GitUpKit/Core/GCDiff-Tests.m
+++ b/GitUpKit/Core/GCDiff-Tests.m
@@ -165,6 +165,16 @@
   XCTAssertTrue([self.repository addFileToIndex:@"renamed1.txt" error:NULL]);
   [self updateFileAtPath:@"type-changed.txt" withString:@""];
   XCTAssertTrue([self.repository addFileToIndex:@"type-changed.txt" error:NULL]);
+  
+  NSArray *files = @[@".gitignore", @"modified.txt", @"deleted.txt", @"renamed1.txt", @"type-changed.txt"];
+  
+  // Test adding and removing multiple files
+  XCTAssertTrue([self.repository removeFilesFromIndex:files error:NULL]);
+  XCTAssertEqual([self.repository checkIndexStatus:NULL].deltas.count, 0);
+  
+  XCTAssertTrue([self.repository addFilesToIndex:files error:NULL]);
+  XCTAssertEqual([self.repository checkIndexStatus:NULL].deltas.count, 5);
+  
   XCTAssertNotNil([self.repository createCommitFromHEADWithMessage:@"Update" error:NULL]);
 
   // Touch files
@@ -179,8 +189,8 @@
 
   // Stage some files
   XCTAssertTrue([self.repository addFileToIndex:@"modified.txt" error:NULL]);
-  XCTAssertTrue([self.repository removeFileFromIndex:@"deleted.txt" error:NULL]);
-  XCTAssertTrue([self.repository removeFileFromIndex:@"renamed1.txt" error:NULL]);
+  files = @[@"deleted.txt", @"renamed1.txt"];
+  XCTAssertTrue([self.repository removeFilesFromIndex:files error:NULL]);
   XCTAssertTrue([self.repository addFileToIndex:@"renamed2.txt" error:NULL]);
   XCTAssertTrue([self.repository addFileToIndex:@"added.txt" error:NULL]);
 

--- a/GitUpKit/Core/GCIndex.h
+++ b/GitUpKit/Core/GCIndex.h
@@ -66,6 +66,7 @@ typedef BOOL (^GCIndexLineFilter)(GCLineDiffChange change, NSUInteger oldLineNum
 - (BOOL)resetLinesInFile:(NSString*)path index:(GCIndex*)index toCommit:(GCCommit*)commit error:(NSError**)error usingFilter:(GCIndexLineFilter)filter;
 
 - (BOOL)checkoutFileToWorkingDirectory:(NSString*)path fromIndex:(GCIndex*)index error:(NSError**)error;
+- (BOOL)checkoutFilesToWorkingDirectory:(NSArray<NSString*>*)paths fromIndex:(GCIndex*)index error:(NSError**)error;
 - (BOOL)checkoutLinesInFileToWorkingDirectory:(NSString*)path fromIndex:(GCIndex*)index error:(NSError**)error usingFilter:(GCIndexLineFilter)filter;
 
 - (BOOL)clearConflictForFile:(NSString*)path inIndex:(GCIndex*)index error:(NSError**)error;

--- a/GitUpKit/Core/GCIndex.m
+++ b/GitUpKit/Core/GCIndex.m
@@ -485,11 +485,21 @@ cleanup:
 }
 
 - (BOOL)checkoutFileToWorkingDirectory:(NSString*)path fromIndex:(GCIndex*)index error:(NSError**)error {
+  return [self checkoutFilesToWorkingDirectory:@[path]
+                                     fromIndex:index
+                                         error:error];
+}
+
+- (BOOL)checkoutFilesToWorkingDirectory:(NSArray<NSString*>*)paths fromIndex:(GCIndex*)index error:(NSError**)error {
   git_checkout_options options = GIT_CHECKOUT_OPTIONS_INIT;
   options.checkout_strategy = GIT_CHECKOUT_FORCE | GIT_CHECKOUT_DONT_UPDATE_INDEX | GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;  // There's no reason to update the index
-  options.paths.count = 1;
-  const char* filePath = GCGitPathFromFileSystemPath(path);
-  options.paths.strings = (char**)&filePath;
+  options.paths.count = paths.count;
+  options.paths.strings = (char **)malloc((paths.count + 1) * sizeof(char*));
+  for (NSUInteger i = 0; i < paths.count; i++) {
+    const char* filePath = GCGitPathFromFileSystemPath(paths[i]);
+    options.paths.strings[i] = (char*)filePath;
+  }
+  
   CALL_LIBGIT2_FUNCTION_RETURN(NO, git_checkout_index, self.private, index.private, &options);
   return YES;
 }

--- a/GitUpKit/Core/GCIndex.m
+++ b/GitUpKit/Core/GCIndex.m
@@ -485,7 +485,7 @@ cleanup:
 }
 
 - (BOOL)checkoutFileToWorkingDirectory:(NSString*)path fromIndex:(GCIndex*)index error:(NSError**)error {
-  return [self checkoutFilesToWorkingDirectory:@[path]
+  return [self checkoutFilesToWorkingDirectory:@[ path ]
                                      fromIndex:index
                                          error:error];
 }
@@ -494,12 +494,12 @@ cleanup:
   git_checkout_options options = GIT_CHECKOUT_OPTIONS_INIT;
   options.checkout_strategy = GIT_CHECKOUT_FORCE | GIT_CHECKOUT_DONT_UPDATE_INDEX | GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;  // There's no reason to update the index
   options.paths.count = paths.count;
-  options.paths.strings = (char **)malloc((paths.count + 1) * sizeof(char*));
+  options.paths.strings = (char**)malloc((paths.count + 1) * sizeof(char*));
   for (NSUInteger i = 0; i < paths.count; i++) {
     const char* filePath = GCGitPathFromFileSystemPath(paths[i]);
     options.paths.strings[i] = (char*)filePath;
   }
-  
+
   CALL_LIBGIT2_FUNCTION_RETURN(NO, git_checkout_index, self.private, index.private, &options);
   return YES;
 }

--- a/GitUpKit/Core/GCIndex.m
+++ b/GitUpKit/Core/GCIndex.m
@@ -494,13 +494,15 @@ cleanup:
   git_checkout_options options = GIT_CHECKOUT_OPTIONS_INIT;
   options.checkout_strategy = GIT_CHECKOUT_FORCE | GIT_CHECKOUT_DONT_UPDATE_INDEX | GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;  // There's no reason to update the index
   options.paths.count = paths.count;
-  options.paths.strings = (char**)malloc((paths.count + 1) * sizeof(char*));
+  char** pathStrings = malloc(paths.count * sizeof(char*));
+  options.paths.strings = pathStrings;
   for (NSUInteger i = 0; i < paths.count; i++) {
     const char* filePath = GCGitPathFromFileSystemPath(paths[i]);
     options.paths.strings[i] = (char*)filePath;
   }
 
   CALL_LIBGIT2_FUNCTION_RETURN(NO, git_checkout_index, self.private, index.private, &options);
+  free(pathStrings);
   return YES;
 }
 

--- a/GitUpKit/Extensions/GCRepository+Index-Tests.m
+++ b/GitUpKit/Extensions/GCRepository+Index-Tests.m
@@ -68,22 +68,22 @@
   // Re-add file to index
   XCTAssertTrue([self.repository addFileToIndex:@"test.txt" error:NULL]);
   [self assertGitCLTOutputEqualsString:@"A  test.txt\n" withRepository:self.repository command:@"status", @"--ignored", @"--porcelain", nil];
-  
+
   // Add multiple files to working directory
-  NSMutableArray *filePaths = [[NSMutableArray alloc] init];
-  NSString *expectedGitCLTOutput = [[NSString alloc] init];
+  NSMutableArray* filePaths = [[NSMutableArray alloc] init];
+  NSString* expectedGitCLTOutput = [[NSString alloc] init];
   for (int i = 0; i < 50; i++) {
-    NSString *filePath = [NSString stringWithFormat:@"hello_world%02d.txt",i];
+    NSString* filePath = [NSString stringWithFormat:@"hello_world%02d.txt", i];
     [self updateFileAtPath:filePath withString:@"Bonjour le monde!\n"];
     [filePaths addObject:filePath];
-    expectedGitCLTOutput = [expectedGitCLTOutput stringByAppendingFormat:@"A  %@\n",filePath];
+    expectedGitCLTOutput = [expectedGitCLTOutput stringByAppendingFormat:@"A  %@\n", filePath];
   }
   expectedGitCLTOutput = [expectedGitCLTOutput stringByAppendingString:@"A  test.txt\n"];
-  
+
   // Add multiple files to index
   XCTAssertTrue([self.repository addFilesToIndex:filePaths error:NULL]);
   [self assertGitCLTOutputEqualsString:expectedGitCLTOutput withRepository:self.repository command:@"status", @"--ignored", @"--porcelain", nil];
-  
+
   // Add remove multiple files from index
   XCTAssertTrue([self.repository removeFilesFromIndex:filePaths error:NULL]);
   expectedGitCLTOutput = [expectedGitCLTOutput stringByReplacingOccurrencesOfString:@"A  test.txt\n" withString:@""];

--- a/GitUpKit/Extensions/GCRepository+Index.h
+++ b/GitUpKit/Extensions/GCRepository+Index.h
@@ -19,12 +19,12 @@
 - (BOOL)resetIndexToHEAD:(NSError**)error;  // Like git reset --mixed HEAD but does not update reflog
 
 - (BOOL)removeFileFromIndex:(NSString*)path error:(NSError**)error;  // git rm --cached {file} - Delete file from index
-- (BOOL)removeFilesFromIndex:(NSArray<NSString *> *)paths error:(NSError**)error; // git rm --cached {file} - Delete files from index
+- (BOOL)removeFilesFromIndex:(NSArray<NSString*>*)paths error:(NSError**)error;  // git rm --cached {file} - Delete files from index
 
 - (BOOL)addFileToIndex:(NSString*)path error:(NSError**)error;  // git add {file} - Copy file from workdir to index (aka stage file)
-- (BOOL)addFilesToIndex:(NSArray<NSString *> *)paths error:(NSError**)error;
+- (BOOL)addFilesToIndex:(NSArray<NSString*>*)paths error:(NSError**)error;
 - (BOOL)resetFileInIndexToHEAD:(NSString*)path error:(NSError**)error;  // git reset --mixed {file} - Copy file from HEAD to index (aka unstage file)
-- (BOOL)resetFilesInIndexToHEAD:(NSArray<NSString *> *)paths error:(NSError**)error;
+- (BOOL)resetFilesInIndexToHEAD:(NSArray<NSString*>*)paths error:(NSError**)error;
 - (BOOL)checkoutFileFromIndex:(NSString*)path error:(NSError**)error;  // git checkout {file} - Copy file from index to workdir (aka discard file)
 - (BOOL)checkoutFilesFromIndex:(NSArray<NSString*>*)paths error:(NSError**)error;
 

--- a/GitUpKit/Extensions/GCRepository+Index.h
+++ b/GitUpKit/Extensions/GCRepository+Index.h
@@ -19,9 +19,12 @@
 - (BOOL)resetIndexToHEAD:(NSError**)error;  // Like git reset --mixed HEAD but does not update reflog
 
 - (BOOL)removeFileFromIndex:(NSString*)path error:(NSError**)error;  // git rm --cached {file} - Delete file from index
+- (BOOL)removeFilesFromIndex:(NSArray<NSString *> *)paths error:(NSError**)error;
 
 - (BOOL)addFileToIndex:(NSString*)path error:(NSError**)error;  // git add {file} - Copy file from workdir to index (aka stage file)
+- (BOOL)addFilesToIndex:(NSArray<NSString *> *)paths error:(NSError**)error;
 - (BOOL)resetFileInIndexToHEAD:(NSString*)path error:(NSError**)error;  // git reset --mixed {file} - Copy file from HEAD to index (aka unstage file)
+- (BOOL)resetFilesInIndexToHEAD:(NSArray<NSString *> *)paths error:(NSError**)error;
 - (BOOL)checkoutFileFromIndex:(NSString*)path error:(NSError**)error;  // git checkout {file} - Copy file from index to workdir (aka discard file)
 
 - (BOOL)addLinesFromFileToIndex:(NSString*)path error:(NSError**)error usingFilter:(GCIndexLineFilter)filter;  // git add -p {file} - Copy only some lines of file from workdir to index (aka stage lines)

--- a/GitUpKit/Extensions/GCRepository+Index.h
+++ b/GitUpKit/Extensions/GCRepository+Index.h
@@ -19,13 +19,14 @@
 - (BOOL)resetIndexToHEAD:(NSError**)error;  // Like git reset --mixed HEAD but does not update reflog
 
 - (BOOL)removeFileFromIndex:(NSString*)path error:(NSError**)error;  // git rm --cached {file} - Delete file from index
-- (BOOL)removeFilesFromIndex:(NSArray<NSString *> *)paths error:(NSError**)error;
+- (BOOL)removeFilesFromIndex:(NSArray<NSString *> *)paths error:(NSError**)error; // git rm --cached {file} - Delete files from index
 
 - (BOOL)addFileToIndex:(NSString*)path error:(NSError**)error;  // git add {file} - Copy file from workdir to index (aka stage file)
 - (BOOL)addFilesToIndex:(NSArray<NSString *> *)paths error:(NSError**)error;
 - (BOOL)resetFileInIndexToHEAD:(NSString*)path error:(NSError**)error;  // git reset --mixed {file} - Copy file from HEAD to index (aka unstage file)
 - (BOOL)resetFilesInIndexToHEAD:(NSArray<NSString *> *)paths error:(NSError**)error;
 - (BOOL)checkoutFileFromIndex:(NSString*)path error:(NSError**)error;  // git checkout {file} - Copy file from index to workdir (aka discard file)
+- (BOOL)checkoutFilesFromIndex:(NSArray<NSString*>*)paths error:(NSError**)error;
 
 - (BOOL)addLinesFromFileToIndex:(NSString*)path error:(NSError**)error usingFilter:(GCIndexLineFilter)filter;  // git add -p {file} - Copy only some lines of file from workdir to index (aka stage lines)
 - (BOOL)resetLinesFromFileInIndexToHEAD:(NSString*)path error:(NSError**)error usingFilter:(GCIndexLineFilter)filter;  // git reset -p {file} - Copy only some lines of file from HEAD to index (aka unstage lines)

--- a/GitUpKit/Extensions/GCRepository+Index.m
+++ b/GitUpKit/Extensions/GCRepository+Index.m
@@ -39,30 +39,30 @@
 }
 
 - (BOOL)removeFileFromIndex:(NSString*)path error:(NSError**)error {
-  return [self removeFilesFromIndex:@[path] error:error];
+  return [self removeFilesFromIndex:@[ path ] error:error];
 }
 
-- (BOOL)removeFilesFromIndex:(NSArray<NSString *> *)paths error:(NSError**)error {
+- (BOOL)removeFilesFromIndex:(NSArray<NSString*>*)paths error:(NSError**)error {
   GCIndex* index = [self readRepositoryIndex:error];
   if (index == nil) {
     return NO;
   }
-  
-  for (NSString *path in paths) {
+
+  for (NSString* path in paths) {
     if (![self removeFile:path fromIndex:index error:error] || (error && *error != nil)) {
       [self writeRepositoryIndex:index error:error];
       return false;
     }
   }
-  
+
   return [self writeRepositoryIndex:index error:error];
 }
 
 - (BOOL)addFileToIndex:(NSString*)path error:(NSError**)error {
-  return [self addFilesToIndex:@[path] error:error];
+  return [self addFilesToIndex:@[ path ] error:error];
 }
 
-- (BOOL)addFilesToIndex:(NSArray<NSString *> *)paths error:(NSError**)error {
+- (BOOL)addFilesToIndex:(NSArray<NSString*>*)paths error:(NSError**)error {
   GCIndex* index = [self readRepositoryIndex:error];
   if (index == nil) {
     return NO;
@@ -70,7 +70,7 @@
 
   BOOL failed = NO;
   BOOL shouldWriteRepository = NO;
-  for (NSString *path in paths) {
+  for (NSString* path in paths) {
     if (![self addFileInWorkingDirectory:path toIndex:index error:error] || (error && *error != nil)) {
       failed = YES;
       break;
@@ -90,10 +90,10 @@
 }
 
 - (BOOL)resetFileInIndexToHEAD:(NSString*)path error:(NSError**)error {
-  return [self resetFilesInIndexToHEAD:@[path] error:error];
+  return [self resetFilesInIndexToHEAD:@[ path ] error:error];
 }
 
-- (BOOL)resetFilesInIndexToHEAD:(NSArray<NSString *> *)paths error:(NSError**)error {
+- (BOOL)resetFilesInIndexToHEAD:(NSArray<NSString*>*)paths error:(NSError**)error {
   GCIndex* index = [self readRepositoryIndex:error];
   if (index == nil) {
     return NO;
@@ -102,8 +102,8 @@
   if (![self lookupHEADCurrentCommit:&headCommit branch:NULL error:error]) {
     return NO;
   }
-  
-  for (NSString *path in paths) {
+
+  for (NSString* path in paths) {
     if (headCommit) {
       if (![self resetFile:path inIndex:index toCommit:headCommit error:error]) {
         [self writeRepositoryIndex:index error:error];
@@ -116,12 +116,12 @@
       }
     }
   }
-  
+
   return [self writeRepositoryIndex:index error:error];
 }
 
 - (BOOL)checkoutFileFromIndex:(NSString*)path error:(NSError**)error {
-  return [self checkoutFilesFromIndex:@[path] error:error];
+  return [self checkoutFilesFromIndex:@[ path ] error:error];
 }
 
 - (BOOL)checkoutFilesFromIndex:(NSArray<NSString*>*)paths error:(NSError**)error {

--- a/GitUpKit/Extensions/GCRepository+Index.m
+++ b/GitUpKit/Extensions/GCRepository+Index.m
@@ -51,7 +51,7 @@
   for (NSString* path in paths) {
     if (![self removeFile:path fromIndex:index error:error] || (error && *error != nil)) {
       [self writeRepositoryIndex:index error:error];
-      return false;
+      return NO;
     }
   }
 
@@ -76,14 +76,14 @@
       break;
     }
 
-    shouldWriteRepository = true;
+    shouldWriteRepository = YES;
   }
 
   if (failed && shouldWriteRepository) {
     if (shouldWriteRepository) {
       [self writeRepositoryIndex:index error:NULL];
     }
-    return FALSE;
+    return NO;
   }
 
   return [self writeRepositoryIndex:index error:error];

--- a/GitUpKit/Utilities/GIViewController+Utilities.h
+++ b/GitUpKit/Utilities/GIViewController+Utilities.h
@@ -51,7 +51,7 @@ extern NSString* const GIViewController_TerminalTool_iTerm;
 - (void)stageAllChangesForFiles:(NSArray<NSString*>*)paths;
 - (void)stageSelectedChangesForFile:(NSString*)path oldLines:(NSIndexSet*)oldLines newLines:(NSIndexSet*)newLines;
 - (void)unstageAllChangesForFile:(NSString*)path;
-- (void)unstageAllChangesForFiles:(NSArray<NSString*>*)path;
+- (void)unstageAllChangesForFiles:(NSArray<NSString*>*)paths;
 - (void)unstageSelectedChangesForFile:(NSString*)path oldLines:(NSIndexSet*)oldLines newLines:(NSIndexSet*)newLines;
 
 - (BOOL)discardAllChangesForFile:(NSString*)path resetIndex:(BOOL)resetIndex error:(NSError**)error;

--- a/GitUpKit/Utilities/GIViewController+Utilities.h
+++ b/GitUpKit/Utilities/GIViewController+Utilities.h
@@ -48,10 +48,10 @@ extern NSString* const GIViewController_TerminalTool_iTerm;
 - (void)discardSubmoduleAtPath:(NSString*)path resetIndex:(BOOL)resetIndex;  // Prompts user
 
 - (void)stageAllChangesForFile:(NSString*)path;
-- (void)stageAllChangesForFiles:(NSArray<NSString *> *)paths;
+- (void)stageAllChangesForFiles:(NSArray<NSString*>*)paths;
 - (void)stageSelectedChangesForFile:(NSString*)path oldLines:(NSIndexSet*)oldLines newLines:(NSIndexSet*)newLines;
 - (void)unstageAllChangesForFile:(NSString*)path;
-- (void)unstageAllChangesForFiles:(NSArray<NSString *>*)path;
+- (void)unstageAllChangesForFiles:(NSArray<NSString*>*)path;
 - (void)unstageSelectedChangesForFile:(NSString*)path oldLines:(NSIndexSet*)oldLines newLines:(NSIndexSet*)newLines;
 
 - (BOOL)discardAllChangesForFile:(NSString*)path resetIndex:(BOOL)resetIndex error:(NSError**)error;

--- a/GitUpKit/Utilities/GIViewController+Utilities.h
+++ b/GitUpKit/Utilities/GIViewController+Utilities.h
@@ -55,6 +55,7 @@ extern NSString* const GIViewController_TerminalTool_iTerm;
 - (void)unstageSelectedChangesForFile:(NSString*)path oldLines:(NSIndexSet*)oldLines newLines:(NSIndexSet*)newLines;
 
 - (BOOL)discardAllChangesForFile:(NSString*)path resetIndex:(BOOL)resetIndex error:(NSError**)error;
+- (BOOL)discardAllChangesForFiles:(NSArray<NSString*>*)paths resetIndex:(BOOL)resetIndex error:(NSError**)error;
 - (void)discardAllChangesForFile:(NSString*)path resetIndex:(BOOL)resetIndex;  // Prompts user
 - (BOOL)discardSelectedChangesForFile:(NSString*)path oldLines:(NSIndexSet*)oldLines newLines:(NSIndexSet*)newLines resetIndex:(BOOL)resetIndex error:(NSError**)error;
 - (void)discardSelectedChangesForFile:(NSString*)path oldLines:(NSIndexSet*)oldLines newLines:(NSIndexSet*)newLines resetIndex:(BOOL)resetIndex;  // Prompts user

--- a/GitUpKit/Utilities/GIViewController+Utilities.h
+++ b/GitUpKit/Utilities/GIViewController+Utilities.h
@@ -48,8 +48,10 @@ extern NSString* const GIViewController_TerminalTool_iTerm;
 - (void)discardSubmoduleAtPath:(NSString*)path resetIndex:(BOOL)resetIndex;  // Prompts user
 
 - (void)stageAllChangesForFile:(NSString*)path;
+- (void)stageAllChangesForFiles:(NSArray<NSString *> *)paths;
 - (void)stageSelectedChangesForFile:(NSString*)path oldLines:(NSIndexSet*)oldLines newLines:(NSIndexSet*)newLines;
 - (void)unstageAllChangesForFile:(NSString*)path;
+- (void)unstageAllChangesForFiles:(NSArray<NSString *>*)path;
 - (void)unstageSelectedChangesForFile:(NSString*)path oldLines:(NSIndexSet*)oldLines newLines:(NSIndexSet*)newLines;
 
 - (BOOL)discardAllChangesForFile:(NSString*)path resetIndex:(BOOL)resetIndex error:(NSError**)error;

--- a/GitUpKit/Utilities/GIViewController+Utilities.m
+++ b/GitUpKit/Utilities/GIViewController+Utilities.m
@@ -207,6 +207,29 @@ static NSString* _diffTemporaryDirectoryPath = nil;
   }
 }
 
+- (void)stageAllChangesForFiles:(NSArray<NSString *> *)paths {
+  NSError* error;
+  NSMutableArray *existingFiles = [NSMutableArray array];
+  NSMutableArray *nonExistingFiles = [NSMutableArray array];
+  for(NSString *path in paths) {
+    if ([[NSFileManager defaultManager] fileExistsAtPath:[self.repository absolutePathForFile:path]]) {
+      [existingFiles addObject:path];
+    } else {
+      [nonExistingFiles addObject:path];
+    }
+  }
+  
+  if (![self.repository addFilesToIndex:existingFiles error:&error]){
+    [self presentError:error];
+  }
+  
+  if (![self.repository removeFilesFromIndex:nonExistingFiles error:&error]){
+    [self presentError:error];
+  }
+  
+  [self.repository notifyRepositoryChanged];
+}
+
 - (void)stageSelectedChangesForFile:(NSString*)path oldLines:(NSIndexSet*)oldLines newLines:(NSIndexSet*)newLines {
   NSError* error;
   if ([self.repository addLinesFromFileToIndex:path
@@ -227,8 +250,12 @@ static NSString* _diffTemporaryDirectoryPath = nil;
 }
 
 - (void)unstageAllChangesForFile:(NSString*)path {
+  [self unstageAllChangesForFiles:@[path]];
+}
+
+- (void)unstageAllChangesForFiles:(NSArray<NSString *>*)filePaths {
   NSError* error;
-  if ([self.repository resetFileInIndexToHEAD:path error:&error]) {
+  if ([self.repository resetFilesInIndexToHEAD:filePaths error:&error]) {
     [self.repository notifyWorkingDirectoryChanged];
   } else {
     [self presentError:error];

--- a/GitUpKit/Utilities/GIViewController+Utilities.m
+++ b/GitUpKit/Utilities/GIViewController+Utilities.m
@@ -111,7 +111,7 @@ static NSString* _diffTemporaryDirectoryPath = nil;
     GIViewController_TerminalTool : GIViewController_TerminalTool_Terminal,
   };
   [[NSUserDefaults standardUserDefaults] registerDefaults:defaults];
-  
+
   NSDictionary* installedApps = [GILaunchServicesLocator installedAppsDictionary];
   [[NSUserDefaults standardUserDefaults] registerDefaults:installedApps];
 
@@ -198,14 +198,14 @@ static NSString* _diffTemporaryDirectoryPath = nil;
 }
 
 - (void)stageAllChangesForFile:(NSString*)path {
-  return [self stageAllChangesForFiles:@[path]];
+  return [self stageAllChangesForFiles:@[ path ]];
 }
 
-- (void)stageAllChangesForFiles:(NSArray<NSString *> *)paths {
+- (void)stageAllChangesForFiles:(NSArray<NSString*>*)paths {
   NSError* error;
-  NSMutableArray *existingFiles = [NSMutableArray array];
-  NSMutableArray *nonExistingFiles = [NSMutableArray array];
-  for(NSString *path in paths) {
+  NSMutableArray* existingFiles = [NSMutableArray array];
+  NSMutableArray* nonExistingFiles = [NSMutableArray array];
+  for (NSString* path in paths) {
     if ([[NSFileManager defaultManager] fileExistsAtPath:[self.repository absolutePathForFile:path]]) {
       [existingFiles addObject:path];
     } else {
@@ -214,17 +214,17 @@ static NSString* _diffTemporaryDirectoryPath = nil;
   }
 
   if (existingFiles.count > 0) {
-    if (![self.repository addFilesToIndex:existingFiles error:&error]){
+    if (![self.repository addFilesToIndex:existingFiles error:&error]) {
       [self presentError:error];
     }
   }
 
   if (nonExistingFiles.count > 0) {
-    if (![self.repository removeFilesFromIndex:nonExistingFiles error:&error]){
+    if (![self.repository removeFilesFromIndex:nonExistingFiles error:&error]) {
       [self presentError:error];
     }
   }
-  
+
   [self.repository notifyRepositoryChanged];
 }
 
@@ -239,7 +239,7 @@ static NSString* _diffTemporaryDirectoryPath = nil;
                                      if (change == kGCLineDiffChange_Deleted) {
                                        return [oldLines containsIndex:oldLineNumber];
                                      }
-    return YES;
+                                     return YES;
                                    }]) {
     [self.repository notifyRepositoryChanged];
   } else {
@@ -248,10 +248,10 @@ static NSString* _diffTemporaryDirectoryPath = nil;
 }
 
 - (void)unstageAllChangesForFile:(NSString*)path {
-  [self unstageAllChangesForFiles:@[path]];
+  [self unstageAllChangesForFiles:@[ path ]];
 }
 
-- (void)unstageAllChangesForFiles:(NSArray<NSString *>*)filePaths {
+- (void)unstageAllChangesForFiles:(NSArray<NSString*>*)filePaths {
   NSError* error;
   if ([self.repository resetFilesInIndexToHEAD:filePaths error:&error]) {
     [self.repository notifyWorkingDirectoryChanged];
@@ -280,7 +280,7 @@ static NSString* _diffTemporaryDirectoryPath = nil;
 }
 
 - (BOOL)discardAllChangesForFile:(NSString*)path resetIndex:(BOOL)resetIndex error:(NSError**)error {
-  return [self discardAllChangesForFiles:@[path]
+  return [self discardAllChangesForFiles:@[ path ]
                               resetIndex:resetIndex
                                    error:error];
 }
@@ -291,7 +291,7 @@ static NSString* _diffTemporaryDirectoryPath = nil;
     GCCommit* commit;
     if ([self.repository lookupHEADCurrentCommit:&commit branch:NULL error:error] && [self.repository resetFilesInIndexToHEAD:paths error:error]) {
       success = YES;
-      for (NSString *path in paths) {
+      for (NSString* path in paths) {
         if (commit && [self.repository checkTreeForCommit:commit containsFile:path error:NULL]) {
           if (![self.repository safeDeleteFileIfExists:path error:error] && [self.repository checkoutFileFromIndex:path error:error]) {
             return NO;
@@ -304,7 +304,7 @@ static NSString* _diffTemporaryDirectoryPath = nil;
       }
     }
   } else {
-    for (NSString *path in paths) {
+    for (NSString* path in paths) {
       if (![self.repository safeDeleteFileIfExists:path error:error]) {
         return NO;
       }
@@ -965,7 +965,7 @@ static NSString* _diffTemporaryDirectoryPath = nil;
   } else if ([identifier isEqualToString:GIViewControllerTool_BeyondCompare]) {
     [self _runBeyondCompareWithArguments:@[ [NSString stringWithFormat:@"-title1=%@", oldTitle], [NSString stringWithFormat:@"-title2=%@", newTitle], oldPath, newPath ]];
   } else if ([identifier isEqualToString:GIViewControllerTool_P4Merge] || [identifier isEqualToString:GIViewControllerTool_GitTool]) {
-      // Handled above
+    // Handled above
   } else if ([identifier isEqualToString:GIViewControllerTool_DiffMerge]) {
     [self _runDiffMergeToolWithArguments:@[ [NSString stringWithFormat:@"-t1=%@", oldTitle], [NSString stringWithFormat:@"-t2=%@", newTitle], oldPath, newPath ]];
   } else {

--- a/GitUpKit/Utilities/GIViewController+Utilities.m
+++ b/GitUpKit/Utilities/GIViewController+Utilities.m
@@ -251,9 +251,9 @@ static NSString* _diffTemporaryDirectoryPath = nil;
   [self unstageAllChangesForFiles:@[ path ]];
 }
 
-- (void)unstageAllChangesForFiles:(NSArray<NSString*>*)filePaths {
+- (void)unstageAllChangesForFiles:(NSArray<NSString*>*)paths {
   NSError* error;
-  if ([self.repository resetFilesInIndexToHEAD:filePaths error:&error]) {
+  if ([self.repository resetFilesInIndexToHEAD:paths error:&error]) {
     [self.repository notifyWorkingDirectoryChanged];
   } else {
     [self presentError:error];

--- a/GitUpKit/Views/GIAdvancedCommitViewController.m
+++ b/GitUpKit/Views/GIAdvancedCommitViewController.m
@@ -189,7 +189,7 @@
   NSMutableArray* deltas = [[NSMutableArray alloc] init];
   NSMutableArray* nonSubmoduleDeltasPaths = [[NSMutableArray alloc] init];
   NSMutableArray* nonSubmoduleDeltas = [[NSMutableArray alloc] init];
-  
+
   for (GCDiffDelta* delta in selectedDeltas) {
     if (![_indexConflicts objectForKey:delta.canonicalPath]) {
       if (delta.submodule) {
@@ -201,10 +201,10 @@
       }
     }
   }
-  
+
   [self stageAllChangesForFiles:nonSubmoduleDeltasPaths];
   [deltas addObjectsFromArray:nonSubmoduleDeltas];
-  
+
   if (deltas.count) {
     _disableFeedback = YES;
     _indexFilesViewController.selectedDeltas = deltas;
@@ -233,10 +233,10 @@
       }
     }
   }
-  
+
   [self unstageAllChangesForFiles:nonSubmoduleDeltasPaths];
   [deltas addObjectsFromArray:nonSubmoduleDeltas];
-  
+
   if (deltas.count) {
     _disableFeedback = YES;
     _workdirFilesViewController.selectedDeltas = deltas;
@@ -270,8 +270,8 @@
                                     button:NSLocalizedString(@"Discard", nil)
                  suppressionUserDefaultKey:nil
                                      block:^{
-                                       NSMutableArray *selectedFiles = [NSMutableArray array];
- 
+                                       NSMutableArray* selectedFiles = [NSMutableArray array];
+
                                        for (GCDiffDelta* delta in deltas) {
                                          NSError* error;
                                          BOOL submodule = delta.submodule;
@@ -281,7 +281,6 @@
                                              break;
                                            } else {
                                              [selectedFiles addObject:delta.canonicalPath];
-
                                            }
                                          }
                                        }
@@ -290,7 +289,6 @@
                                          [self.repository notifyWorkingDirectoryChanged];
                                          [self presentError:error];
                                          if (!_workdirFilesViewController.deltas.count) {
- 
                                            _indexActive = YES;
                                            [self.view.window makeFirstResponder:_indexFilesViewController.preferredFirstResponder];
                                          }
@@ -341,7 +339,7 @@
 
 - (BOOL)diffFilesViewController:(GIDiffFilesViewController*)controller didReceiveDeltas:(NSArray*)deltas fromOtherController:(GIDiffFilesViewController*)otherController {
   if ((controller == _workdirFilesViewController) && (otherController == _indexFilesViewController)) {
-    NSMutableArray *fileDeltas = [NSMutableArray array];
+    NSMutableArray* fileDeltas = [NSMutableArray array];
     for (GCDiffDelta* delta in deltas) {
       if (![_indexConflicts objectForKey:delta.canonicalPath]) {
         if (delta.submodule) {
@@ -361,7 +359,7 @@
     }
     return YES;
   } else if ((controller == _indexFilesViewController) && (otherController == _workdirFilesViewController)) {
-    NSMutableArray *fileDeltas = [NSMutableArray array];
+    NSMutableArray* fileDeltas = [NSMutableArray array];
     for (GCDiffDelta* delta in deltas) {
       if (![_indexConflicts objectForKey:delta.canonicalPath]) {
         if (delta.submodule) {

--- a/GitUpKit/Views/GIAdvancedCommitViewController.m
+++ b/GitUpKit/Views/GIAdvancedCommitViewController.m
@@ -187,16 +187,24 @@
 
 - (void)_stageSelectedFiles:(NSArray*)selectedDeltas {
   NSMutableArray* deltas = [[NSMutableArray alloc] init];
+  NSMutableArray* nonSubmoduleDeltasPaths = [[NSMutableArray alloc] init];
+  NSMutableArray* nonSubmoduleDeltas = [[NSMutableArray alloc] init];
+  
   for (GCDiffDelta* delta in selectedDeltas) {
     if (![_indexConflicts objectForKey:delta.canonicalPath]) {
       if (delta.submodule) {
         [self stageSubmoduleAtPath:delta.canonicalPath];
+        [deltas addObject:delta];
       } else {
-        [self stageAllChangesForFile:delta.canonicalPath];
+        [nonSubmoduleDeltasPaths addObject:delta.canonicalPath];
+        [nonSubmoduleDeltas addObject:delta];
       }
-      [deltas addObject:delta];
     }
   }
+  
+  [self stageAllChangesForFiles:nonSubmoduleDeltasPaths];
+  [deltas addObjectsFromArray:nonSubmoduleDeltas];
+  
   if (deltas.count) {
     _disableFeedback = YES;
     _indexFilesViewController.selectedDeltas = deltas;
@@ -212,16 +220,23 @@
 
 - (void)_unstageSelectedFiles:(NSArray*)selectedDeltas {
   NSMutableArray* deltas = [[NSMutableArray alloc] init];
+  NSMutableArray* nonSubmoduleDeltasPaths = [[NSMutableArray alloc] init];
+  NSMutableArray* nonSubmoduleDeltas = [[NSMutableArray alloc] init];
   for (GCDiffDelta* delta in selectedDeltas) {
     if (![_indexConflicts objectForKey:delta.canonicalPath]) {
       if (delta.submodule) {
         [self unstageSubmoduleAtPath:delta.canonicalPath];
+        [deltas addObject:delta];
       } else {
-        [self unstageAllChangesForFile:delta.canonicalPath];
+        [nonSubmoduleDeltasPaths addObject:delta.canonicalPath];
+        [nonSubmoduleDeltas addObject:delta];
       }
-      [deltas addObject:delta];
     }
   }
+  
+  [self unstageAllChangesForFiles:nonSubmoduleDeltasPaths];
+  [deltas addObjectsFromArray:nonSubmoduleDeltas];
+  
   if (deltas.count) {
     _disableFeedback = YES;
     _workdirFilesViewController.selectedDeltas = deltas;

--- a/GitUpKit/Views/GIAdvancedCommitViewController.m
+++ b/GitUpKit/Views/GIAdvancedCommitViewController.m
@@ -270,14 +270,17 @@
                                          NSError* error;
                                          BOOL submodule = delta.submodule;
                                          if (submodule) {
+                                           // We handle every submodules deltas individually
                                            if (![self discardSubmoduleAtPath:delta.canonicalPath resetIndex:NO error:&error]) {
                                              [self presentError:error];
                                              break;
-                                           } else {
-                                             [selectedFiles addObject:delta.canonicalPath];
                                            }
+                                         } else {
+                                           // Otherwise we collect file delta paths to batch process them afterwards
+                                           [selectedFiles addObject:delta.canonicalPath];
                                          }
                                        }
+
                                        NSError* error;
                                        if (![self discardAllChangesForFiles:selectedFiles resetIndex:NO error:&error]) {
                                          [self.repository notifyWorkingDirectoryChanged];

--- a/GitUpKit/Views/GIAdvancedCommitViewController.m
+++ b/GitUpKit/Views/GIAdvancedCommitViewController.m
@@ -188,22 +188,19 @@
 - (void)_stageSelectedFiles:(NSArray*)selectedDeltas {
   NSMutableArray* deltas = [[NSMutableArray alloc] init];
   NSMutableArray* nonSubmoduleDeltasPaths = [[NSMutableArray alloc] init];
-  NSMutableArray* nonSubmoduleDeltas = [[NSMutableArray alloc] init];
 
   for (GCDiffDelta* delta in selectedDeltas) {
     if (![_indexConflicts objectForKey:delta.canonicalPath]) {
       if (delta.submodule) {
         [self stageSubmoduleAtPath:delta.canonicalPath];
-        [deltas addObject:delta];
       } else {
         [nonSubmoduleDeltasPaths addObject:delta.canonicalPath];
-        [nonSubmoduleDeltas addObject:delta];
       }
+      [deltas addObject:delta];
     }
   }
 
   [self stageAllChangesForFiles:nonSubmoduleDeltasPaths];
-  [deltas addObjectsFromArray:nonSubmoduleDeltas];
 
   if (deltas.count) {
     _disableFeedback = YES;
@@ -221,21 +218,18 @@
 - (void)_unstageSelectedFiles:(NSArray*)selectedDeltas {
   NSMutableArray* deltas = [[NSMutableArray alloc] init];
   NSMutableArray* nonSubmoduleDeltasPaths = [[NSMutableArray alloc] init];
-  NSMutableArray* nonSubmoduleDeltas = [[NSMutableArray alloc] init];
   for (GCDiffDelta* delta in selectedDeltas) {
     if (![_indexConflicts objectForKey:delta.canonicalPath]) {
       if (delta.submodule) {
         [self unstageSubmoduleAtPath:delta.canonicalPath];
-        [deltas addObject:delta];
       } else {
         [nonSubmoduleDeltasPaths addObject:delta.canonicalPath];
-        [nonSubmoduleDeltas addObject:delta];
       }
+      [deltas addObject:delta];
     }
   }
 
   [self unstageAllChangesForFiles:nonSubmoduleDeltasPaths];
-  [deltas addObjectsFromArray:nonSubmoduleDeltas];
 
   if (deltas.count) {
     _disableFeedback = YES;


### PR DESCRIPTION
Staging/unstaging/discarding multiple files takes a long time. Seems to be O(N) where N is multiplied by 1-2 seconds, depending on the repo.

I fixed it by only calling `-[GCRepository writeRepositoryIndex:error:]` once when doing staging/discarding operations on multiple files by adding methods for these operations that take multiple files instead of one.

I tested the changes in a big repository (with thousands of commits, ~50 branches and ~20-30 total submodules) and the time it takes to stage/unstage 19 files went from ~25.5 seconds to ~2.5 seconds. The more files are modified, the bigger the performance increase is.

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT