### PR TITLE
Added unversioned TeamID infrastructure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 xcuserdata
 project.xcworkspace
 build
+
+# User-specific xcconfig files
+Xcode-Configurations/DEVELOPMENT_TEAM.xcconfig

--- a/GitUp/GitUp.xcodeproj/project.pbxproj
+++ b/GitUp/GitUp.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		165C32B51B95739700D2F894 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		31CD50E1203E2E2800360B3A /* ToolbarItemWrapperView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ToolbarItemWrapperView.h; sourceTree = "<group>"; };
 		31CD50E2203E2E2800360B3A /* ToolbarItemWrapperView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ToolbarItemWrapperView.m; sourceTree = "<group>"; };
+		3DB98C7D23E091650039B454 /* DEVELOPMENT_TEAM.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DEVELOPMENT_TEAM.xcconfig; sourceTree = "<group>"; };
 		A53C6D0A1E61A9CF0070387E /* FontSizeTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FontSizeTransformer.h; sourceTree = "<group>"; };
 		A53C6D0B1E61A9CF0070387E /* FontSizeTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FontSizeTransformer.m; sourceTree = "<group>"; };
 		E212A6DD1B92100E00F62B18 /* libiconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
@@ -244,6 +245,7 @@
 				E27E37561B86F670000A551A /* Base.xcconfig */,
 				E27E37571B86F670000A551A /* Debug.xcconfig */,
 				E27E37591B86F670000A551A /* Release.xcconfig */,
+				3DB98C7D23E091650039B454 /* DEVELOPMENT_TEAM.xcconfig */,
 			);
 			name = "Xcode-Configurations";
 			path = "../Xcode-Configurations";
@@ -394,7 +396,6 @@
 					};
 					E2C338AA19F8562F00063D95 = {
 						CreatedOnToolsVersion = 6.1;
-						DevelopmentTeam = 88W3E55T4B;
 					};
 				};
 			};
@@ -600,7 +601,6 @@
 		E21DCAEC1B253847006424E8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
 				HEADER_SEARCH_PATHS = "../GitUpKit/Third-Party/libgit2/include";
 				OTHER_LDFLAGS = (
 					"$(BUILD_DIR)/$(CONFIGURATION)/libgit2.a",
@@ -615,7 +615,6 @@
 		E21DCAED1B253847006424E8 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
 				HEADER_SEARCH_PATHS = "../GitUpKit/Third-Party/libgit2/include";
 				OTHER_LDFLAGS = (
 					"$(BUILD_DIR)/$(CONFIGURATION)/libgit2.a",
@@ -649,7 +648,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_VERSION = 0;
 				BUNDLE_VERSION_STRING = 1.1;
-				CODE_SIGN_IDENTITY = "Mac Developer";
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/Third-Party";
 				INFOPLIST_FILE = Application/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
@@ -665,7 +663,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_VERSION = 0;
 				BUNDLE_VERSION_STRING = 1.1;
-				CODE_SIGN_IDENTITY = "Mac Developer";
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/Third-Party";
 				INFOPLIST_FILE = Application/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ To build GitUp yourself, simply run the command `git clone --recursive https://g
 <img src="http://i.imgur.com/dWpJExk.png">
 </p>
 
+**Alternatively**, if you do have a developer account, you can create the file "Xcode-Configurations/DEVELOPMENT_TEAM.xcconfig" with the following build setting as its content:
+> DEVELOPMENT_TEAM = [Your TeamID]
+
+For a more detailed description of this, you can have a look at the comments at the end of the file "Xcode-Configurations/Base.xcconfig". 
+
 GitUpKit
 ========
 

--- a/Xcode-Configurations/Base.xcconfig
+++ b/Xcode-Configurations/Base.xcconfig
@@ -53,3 +53,42 @@ GCC_WARN_UNUSED_VARIABLE = YES
 GITUP_PLATFORM[sdk=macosx*] = MacOSX
 GITUP_PLATFORM[sdk=iphonesimulator*] = iPhoneSimulator
 GITUP_PLATFORM[sdk=iphoneos*] = iPhoneOS
+
+#include? "DEVELOPMENT_TEAM.xcconfig"
+
+// Create the file DEVELOPMENT_TEAM.xcconfig
+// in the "Xcode-Configurations" directory within the project directory
+// with the following build setting:
+// DEVELOPMENT_TEAM = [Your TeamID]
+
+// Hint: some recent Xcode versions appear to automatically create an empty file
+// for you on the first build. This build will fail, or course,
+// because code-signing can’t work without the DEVELOPMENT_TEAM set.
+// Just fill it in and everything should work.
+
+// You can find your team ID by logging into your Apple Developer account
+// and going to
+// https://developer.apple.com/account/#/membership
+// It should be listed under “Team ID”.
+
+// To set this system up for your own project,
+// copy the "Xcode-config" directory there,
+// add it to your Xcode project,
+// navigate to your project settings
+// (root icon in the Xcode Project Navigator)
+// click on the project icon there,
+// click on the “Info” tab
+// under “Configurations”
+// open the “Debug”, “Release”,
+// and any other build configurations you might have.
+// There you can set the pull-down menus in the
+// “Based on Configuration File” column to “Shared”.
+// Done.
+
+// Don’t forget to add the DEVELOPMENT_TEAM.xcconfig file to your .gitignore:
+// # User-specific xcconfig files
+// Xcode-config/DEVELOPMENT_TEAM.xcconfig
+
+// You can now remove the “DevelopmentTeam = AB1234C5DE;” entries from the
+// .xcodeproj/project.pbxproj if you want to.
+


### PR DESCRIPTION
This PR makes it possible for multiple developers to build GitUp out of the box. All everyone has to do once is to create a file called "DEVELOPMENT_TEAM.xcconfig" in the "Xcode-Configurations" directory within the project directory with the following build setting:
DEVELOPMENT_TEAM = [personal TeamID]

This used to be hard-coded as "88W3E55T4B" in "Xcode-Configurations/Base.xcconfig".

"DEVELOPMENT_TEAM.xcconfig" is excluded from versioning.

Please give it a go.
