### PR TITLE
Swapped Diff Splitter "Old Commit" and "New Commit" panel order

### DIFF
--- a/GitUpKit/Views/Base.lproj/GICommitSplitterViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GICommitSplitterViewController.xib
@@ -46,7 +46,7 @@
                             <rect key="frame" x="127" y="8" width="855" height="16"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                             <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;TITLE&gt;" id="2Ta-mo-RyA">
-                                <font key="font" metaFont="controlContent"/>
+                                <font key="font" metaFont="cellTitle"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
@@ -69,38 +69,8 @@
                                     <rect key="frame" x="0.0" y="46" width="300" height="424"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <customView id="VtZ-UX-sFq">
-                                            <rect key="frame" x="0.0" y="0.0" width="300" height="212"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                            <subviews>
-                                                <customView id="7j5-Pz-Pse" customClass="GIColorView">
-                                                    <rect key="frame" x="0.0" y="178" width="300" height="34"/>
-                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                                                    <subviews>
-                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="JBE-2n-Fmz">
-                                                            <rect key="frame" x="8" y="9" width="154" height="17"/>
-                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                            <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Old Commit" id="CSN-Cf-azv">
-                                                                <font key="font" metaFont="systemBold"/>
-                                                                <color key="textColor" name="alternateSelectedControlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                        </textField>
-                                                    </subviews>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                                                            <color key="value" name="commit/header_background"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                    </userDefinedRuntimeAttributes>
-                                                </customView>
-                                                <customView id="Scn-lW-rL0">
-                                                    <rect key="frame" x="0.0" y="0.0" width="300" height="178"/>
-                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                </customView>
-                                            </subviews>
-                                        </customView>
                                         <customView id="ots-w9-o6k">
-                                            <rect key="frame" x="0.0" y="213" width="300" height="211"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="300" height="211"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <customView id="i0X-9n-k1u" customClass="GIColorView">
@@ -125,6 +95,36 @@
                                                 </customView>
                                                 <customView id="IfV-FZ-t0W">
                                                     <rect key="frame" x="0.0" y="0.0" width="300" height="177"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                </customView>
+                                            </subviews>
+                                        </customView>
+                                        <customView id="VtZ-UX-sFq">
+                                            <rect key="frame" x="0.0" y="212" width="300" height="212"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <subviews>
+                                                <customView id="7j5-Pz-Pse" customClass="GIColorView">
+                                                    <rect key="frame" x="0.0" y="178" width="300" height="34"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                    <subviews>
+                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="JBE-2n-Fmz">
+                                                            <rect key="frame" x="8" y="9" width="154" height="17"/>
+                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                            <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Old Commit" id="CSN-Cf-azv">
+                                                                <font key="font" metaFont="systemBold"/>
+                                                                <color key="textColor" name="alternateSelectedControlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
+                                                    </subviews>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                                            <color key="value" name="commit/header_background"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </customView>
+                                                <customView id="Scn-lW-rL0">
+                                                    <rect key="frame" x="0.0" y="0.0" width="300" height="178"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 </customView>
                                             </subviews>
@@ -207,56 +207,8 @@ DQ
             <rect key="frame" x="0.0" y="0.0" width="590" height="354"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="VJr-bi-EjL">
-                    <rect key="frame" x="18" y="322" width="183" height="17"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Old commit message:" id="3xC-Vl-BIN">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <scrollView autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="sdt-ps-l95">
-                    <rect key="frame" x="20" y="214" width="550" height="100"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <clipView key="contentView" drawsBackground="NO" id="sKA-Dg-4u7">
-                        <rect key="frame" x="1" y="1" width="548" height="98"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="panel" allowsUndo="YES" smartInsertDelete="YES" id="C9q-53-7wr" customClass="GICommitMessageView">
-                                <rect key="frame" x="0.0" y="0.0" width="548" height="98"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                <size key="minSize" width="548" height="98"/>
-                                <size key="maxSize" width="608" height="10000000"/>
-                                <attributedString key="textStorage">
-                                    <fragment content="&lt;MESSAGE&gt;">
-                                        <attributes>
-                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                            <font key="NSFont" metaFont="toolTip"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural"/>
-                                        </attributes>
-                                    </fragment>
-                                </attributedString>
-                                <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                <connections>
-                                    <outlet property="delegate" destination="-2" id="kk3-aI-fXa"/>
-                                </connections>
-                            </textView>
-                        </subviews>
-                    </clipView>
-                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="IXc-Ye-G0z">
-                        <rect key="frame" x="-100" y="-100" width="87" height="18"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </scroller>
-                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="itL-Vx-dgv">
-                        <rect key="frame" x="224" y="1" width="15" height="133"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </scroller>
-                </scrollView>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Mi2-Di-27H">
-                    <rect key="frame" x="18" y="189" width="183" height="17"/>
+                    <rect key="frame" x="18" y="322" width="183" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="New commit message:" id="Rs6-wQ-uAF">
                         <font key="font" metaFont="system"/>
@@ -265,7 +217,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="FGz-GT-MFK">
-                    <rect key="frame" x="20" y="81" width="550" height="100"/>
+                    <rect key="frame" x="20" y="214" width="550" height="100"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" drawsBackground="NO" id="iv1-rd-iqv">
                         <rect key="frame" x="1" y="1" width="548" height="98"/>
@@ -299,6 +251,54 @@ DQ
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="b0J-i3-bDd">
+                        <rect key="frame" x="224" y="1" width="15" height="133"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </scroller>
+                </scrollView>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="VJr-bi-EjL">
+                    <rect key="frame" x="18" y="189" width="183" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Old commit message:" id="3xC-Vl-BIN">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <scrollView autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="sdt-ps-l95">
+                    <rect key="frame" x="20" y="81" width="550" height="100"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <clipView key="contentView" drawsBackground="NO" id="sKA-Dg-4u7">
+                        <rect key="frame" x="1" y="1" width="548" height="98"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="panel" allowsUndo="YES" smartInsertDelete="YES" id="C9q-53-7wr" customClass="GICommitMessageView">
+                                <rect key="frame" x="0.0" y="0.0" width="548" height="98"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                <size key="minSize" width="548" height="98"/>
+                                <size key="maxSize" width="608" height="10000000"/>
+                                <attributedString key="textStorage">
+                                    <fragment content="&lt;MESSAGE&gt;">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" metaFont="toolTip"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural"/>
+                                        </attributes>
+                                    </fragment>
+                                </attributedString>
+                                <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                <connections>
+                                    <outlet property="delegate" destination="-2" id="kk3-aI-fXa"/>
+                                </connections>
+                            </textView>
+                        </subviews>
+                    </clipView>
+                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="IXc-Ye-G0z">
+                        <rect key="frame" x="-100" y="-100" width="87" height="18"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </scroller>
+                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="itL-Vx-dgv">
                         <rect key="frame" x="224" y="1" width="15" height="133"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>


### PR DESCRIPTION
This PR swaps the panel order for the "Old Commit" and the "New Commit".

The "Old Commit" when visualized in gitup will be the bottom commit, so it makes sense intuitively that by having it in the bottom-left corner of the split window, and the "New Commit" in the top-left corner of the window, when I drag changes from the old commit to the new commit, I'm dragging changes from the original commit into a new commit that will be on-top of the original commit.

Fixes #642 

Test-Plan
- Launched gitup from within the xCode project.
- Verified that when splitting a commit the old commit was in the bottom left hand corner and dragging files into the new commit panel on the top-left corner of the screen worked as expected.
- Verified that when rewriting the messages of the commits, the new commit message was on top and the old commit message was on the bottom of the opened dialog matching the order of the primary split commit view.
- Split a commit with gitup successfully.
- Verified that the new commit was above the old commit in the tree as expected and that both the new and old messages were correct.

The XIB views in XCode:

![XIB View](https://user-images.githubusercontent.com/6243881/73389918-febd6800-4289-11ea-85d4-352c53945c45.png)
