### PR TITLE
Enable Hardened Runtime to prepare for Notarization

### DIFF
--- a/Examples/iGit/iGit.xcodeproj/project.pbxproj
+++ b/Examples/iGit/iGit.xcodeproj/project.pbxproj
@@ -278,6 +278,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB72901622C833E3007AB8F7 /* Debug.xcconfig */;
 			buildSettings = {
+				ENABLE_HARDENED_RUNTIME = NO;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -286,6 +287,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB72901722C833E3007AB8F7 /* Release.xcconfig */;
 			buildSettings = {
+				ENABLE_HARDENED_RUNTIME = NO;
 				SDKROOT = iphoneos;
 			};
 			name = Release;

--- a/Examples/iGit/iGit.xcodeproj/project.pbxproj
+++ b/Examples/iGit/iGit.xcodeproj/project.pbxproj
@@ -278,7 +278,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB72901622C833E3007AB8F7 /* Debug.xcconfig */;
 			buildSettings = {
-				ENABLE_HARDENED_RUNTIME = NO;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -287,7 +286,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB72901722C833E3007AB8F7 /* Release.xcconfig */;
 			buildSettings = {
-				ENABLE_HARDENED_RUNTIME = NO;
 				SDKROOT = iphoneos;
 			};
 			name = Release;

--- a/GitUp/Application/GitUp.entitlements
+++ b/GitUp/Application/GitUp.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+</dict>
+</plist>

--- a/GitUp/GitUp.xcodeproj/project.pbxproj
+++ b/GitUp/GitUp.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		0AD4625A232711B000BE28D1 /* WelcomeWindowController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WelcomeWindowController.m; sourceTree = "<group>"; };
 		0AE7F5EE2312C1B000B06050 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		165C32B51B95739700D2F894 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		1D2DA2F923E9E99700691DEF /* GitUp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = GitUp.entitlements; sourceTree = "<group>"; };
 		31CD50E1203E2E2800360B3A /* ToolbarItemWrapperView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ToolbarItemWrapperView.h; sourceTree = "<group>"; };
 		31CD50E2203E2E2800360B3A /* ToolbarItemWrapperView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ToolbarItemWrapperView.m; sourceTree = "<group>"; };
 		3DB98C7D23E091650039B454 /* DEVELOPMENT_TEAM.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DEVELOPMENT_TEAM.xcconfig; sourceTree = "<group>"; };
@@ -293,6 +294,7 @@
 		E2C338AD19F8562F00063D95 /* Application */ = {
 			isa = PBXGroup;
 			children = (
+				1D2DA2F923E9E99700691DEF /* GitUp.entitlements */,
 				E2C338B019F8562F00063D95 /* AppDelegate.h */,
 				E2C338B119F8562F00063D95 /* AppDelegate.m */,
 				E25EBCEA1AA3F8B700D3AF44 /* Application.xcassets */,
@@ -654,6 +656,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_VERSION = 0;
 				BUNDLE_VERSION_STRING = 1.1;
+				CODE_SIGN_ENTITLEMENTS = Application/GitUp.entitlements;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/Third-Party";
 				INFOPLIST_FILE = Application/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
@@ -669,6 +672,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_VERSION = 0;
 				BUNDLE_VERSION_STRING = 1.1;
+				CODE_SIGN_ENTITLEMENTS = Application/GitUp.entitlements;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/Third-Party";
 				INFOPLIST_FILE = Application/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";

--- a/Xcode-Configurations/Base.xcconfig
+++ b/Xcode-Configurations/Base.xcconfig
@@ -47,6 +47,8 @@ GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE
 GCC_WARN_UNUSED_FUNCTION = YES
 GCC_WARN_UNUSED_VARIABLE = YES
 
+ENABLE_HARDENED_RUNTIME = YES
+
 // GITUP_PLATFORM determines where to find header files and precompiled libs
 // required for build on case-sensitive systems, for ex. headers of libssh2 located in
 // "GitUpKit/Third-Party/libssh2/MacOSX/include" folder.

--- a/Xcode-Configurations/Base.xcconfig
+++ b/Xcode-Configurations/Base.xcconfig
@@ -47,7 +47,7 @@ GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE
 GCC_WARN_UNUSED_FUNCTION = YES
 GCC_WARN_UNUSED_VARIABLE = YES
 
-ENABLE_HARDENED_RUNTIME = YES
+ENABLE_HARDENED_RUNTIME[sdk=macosx*] = YES
 
 // GITUP_PLATFORM determines where to find header files and precompiled libs
 // required for build on case-sensitive systems, for ex. headers of libssh2 located in


### PR DESCRIPTION
If we want to be able to notarize the app (#617) then we'll need to have the Hardened Runtime enabled. This is step 1. The other step is for me to update the scripts with `altool` and `stapler` so we can notarize and upload all in 1 script run.