### PR TITLE
Fix double click on header to expand window

### DIFF
--- a/GitUp/Application/ToolbarItemWrapperView.m
+++ b/GitUp/Application/ToolbarItemWrapperView.m
@@ -27,6 +27,9 @@
       if (field.enabled && field.selectable) {
         return hit;
       }
+
+      // We recognised the view but it is not enabled and selectable, so we need to break this loop iteration
+      continue;
     }
 
     if ([child isKindOfClass:[NSControl class]]) {


### PR DESCRIPTION
In the `hitTest` of the toolbar item view we need to continue the loop
iteration when we find a `NSTextField` but it is not enabled and selectable

Fixes #556

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT