### PR TITLE
Handle differences in user environments while executing hooks

### DIFF
--- a/GitUpKit/Core/GCPrivate.h
+++ b/GitUpKit/Core/GCPrivate.h
@@ -138,6 +138,7 @@ extern int git_submodule_foreach_block(git_repository* repo, int (^block)(git_su
 @property(nonatomic) NSTimeInterval executionTimeOut;  // Default is 0.0 i.e. no timeout
 @property(nonatomic, copy) NSDictionary* additionalEnvironment;
 @property(nonatomic, copy) NSString* currentDirectoryPath;
+@property(nonatomic) BOOL fallBackToDefaultInterpreter;
 - (instancetype)initWithExecutablePath:(NSString*)path;
 - (BOOL)runWithArguments:(NSArray*)arguments stdin:(NSData*)stdin stdout:(NSData**)stdout stderr:(NSData**)stderr exitStatus:(int*)exitStatus error:(NSError**)error;  // Returns NO if "exitStatus" is NULL and executable exits with a non-zero status
 @end

--- a/GitUpKit/Core/GCRepository.m
+++ b/GitUpKit/Core/GCRepository.m
@@ -335,6 +335,7 @@ static int _ReferenceForEachCallback(const char* refname, void* payload) {
     GCTask* task = [[GCTask alloc] initWithExecutablePath:path];
     task.currentDirectoryPath = self.workingDirectoryPath;  // TODO: Is this the right working directory?
     task.additionalEnvironment = @{@"PATH" : cachedPATH};
+    task.fallBackToDefaultInterpreter = YES;
     int status;
     NSData* stdoutData;
     NSData* stderrData;

--- a/GitUpKit/Core/GCRepository.m
+++ b/GitUpKit/Core/GCRepository.m
@@ -315,7 +315,8 @@ static int _ReferenceForEachCallback(const char* refname, void* payload) {
   if (path) {
     static NSString* cachedPATH = nil;
     if (cachedPATH == nil) {
-      GCTask* task = [[GCTask alloc] initWithExecutablePath:@"/bin/bash"];  // TODO: Handle user shell not being bash
+      NSString* shell = NSProcessInfo.processInfo.environment[@"SHELL"] ?: @"/bin/bash";
+      GCTask* task = [[GCTask alloc] initWithExecutablePath:shell];
       NSData* data;
       if (![task runWithArguments:@[ @"-l", @"-c", @"echo -n $PATH" ] stdin:NULL stdout:&data stderr:NULL exitStatus:NULL error:error]) {
         return NO;


### PR DESCRIPTION
Addresses a TODO that can cause hooks to fail if they a) reference items in the `PATH` set by fish or (new macOS system default) zsh or b) lack a shebang statement.

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT