### PR TITLE
Use user parameter when searching for keychain item

### DIFF
--- a/GitUp/Application/KeychainAccessor.m
+++ b/GitUp/Application/KeychainAccessor.m
@@ -15,7 +15,7 @@
 + (BOOL)loadPlainTextAuthenticationFormKeychainForURL:(NSURL*)url user:(NSString*)user username:(NSString**)username password:(NSString**)password allowInteraction:(BOOL)allowInteraction {
   const char* serverName = url.host.UTF8String;
   if (serverName && serverName[0]) {  // TODO: How can this be NULL?
-    const char* accountName = (*username).UTF8String;
+    const char* accountName = user.UTF8String;
     SecKeychainItemRef itemRef;
     UInt32 passwordLength;
     void* passwordData;
@@ -48,6 +48,7 @@
           XLOG_ERROR(@"SecKeychainItemCopyAttributesAndData() returned error %i", status);
         }
       } else {
+        *username = [user copy];
         success = YES;
       }
       SecKeychainItemFreeContent(NULL, passwordData);


### PR DESCRIPTION
With multiple accounts on the same server, I found that GitUp would often get the wrong credentials from the keychain, returning the username and password for a different account than the one that matched the https git URL.  Looking at KeychainAccessor.m, the `user` parameter was unused and the search was based on the value currently in the in-out `username` parameter (typically empty), so the keychain item search wasn't username-specific.  Changing `accountName` to be based on `user` made the search use the value in `user`.

Once the `user` parameter was used for searching, that meant that `accountName` was no longer `NULL`, so the `username` in-out parameter wasn't being set.  Setting `username` in the `else` block fixed this.

With these changes, I see the correct credentials being used for various accounts on the same server with https git URLs.