### PR TITLE
Big Sur bare minimum

### DIFF
--- a/GitUp/Application/Base.lproj/Document.xib
+++ b/GitUp/Application/Base.lproj/Document.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -67,53 +67,53 @@
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="253" y="204" width="1000" height="500"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
             <value key="minSize" type="size" width="800" height="400"/>
             <view key="contentView" id="gIp-Ho-8D9">
                 <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <customView hidden="YES" appearanceType="aqua" id="Zjf-1c-7Wk" customClass="GIColorView">
+                    <customView hidden="YES" appearanceType="aqua" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zjf-1c-7Wk" customClass="GIColorView">
                         <rect key="frame" x="0.0" y="450" width="1000" height="50"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" id="hTO-MR-3XZ">
-                                <rect key="frame" x="8" y="8" width="718" height="31"/>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hTO-MR-3XZ">
+                                <rect key="frame" x="8" y="8" width="818" height="31"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" controlSize="small" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;HELP&gt;" id="de5-iD-6RU">
-                                    <font key="font" metaFont="toolTip"/>
+                                    <font key="font" metaFont="smallSystem"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <button verticalHuggingPriority="750" id="W0y-nq-maS">
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W0y-nq-maS">
                                 <rect key="frame" x="910" y="16" width="80" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="roundRect" title="Continue" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3Bn-bb-IAI">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="toolTip"/>
+                                    <font key="font" usesAppearanceFont="YES"/>
                                 </buttonCell>
                                 <connections>
                                     <action selector="dismissHelp:" target="-2" id="6SE-nM-Khn"/>
                                 </connections>
                             </button>
-                            <button verticalHuggingPriority="750" id="etB-ce-0PB">
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="etB-ce-0PB">
                                 <rect key="frame" x="832" y="16" width="60" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="roundRect" title="Got It!" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="U4W-Zh-R2B">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="toolTip"/>
+                                    <font key="font" usesAppearanceFont="YES"/>
                                 </buttonCell>
                                 <connections>
                                     <action selector="dismissHelp:" target="-2" id="ZhX-zZ-Pix"/>
                                 </connections>
                             </button>
-                            <button verticalHuggingPriority="750" id="cA6-Ht-e3Z">
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cA6-Ht-e3Z">
                                 <rect key="frame" x="900" y="16" width="90" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="roundRect" title="Learn More…" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ux0-pi-0du">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="toolTip"/>
+                                    <font key="font" usesAppearanceFont="YES"/>
                                 </buttonCell>
                                 <connections>
                                     <action selector="openHelp:" target="-2" id="9JT-bA-cXq"/>
@@ -126,7 +126,7 @@
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </customView>
-                    <tabView drawsBackground="NO" allowsTruncatedLabels="NO" type="noTabsNoBorder" id="8LX-i4-RBG">
+                    <tabView fixedFrame="YES" drawsBackground="NO" allowsTruncatedLabels="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="8LX-i4-RBG">
                         <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <font key="font" metaFont="system"/>
@@ -203,15 +203,15 @@
             <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="399-bl-TuH">
+                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="399-bl-TuH">
                     <rect key="frame" x="0.0" y="46" width="1000" height="454"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 </customView>
-                <customView hidden="YES" id="4K3-nK-X1O">
+                <customView hidden="YES" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4K3-nK-X1O">
                     <rect key="frame" x="385" y="71" width="230" height="48"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <subviews>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" id="O4P-2Y-hlm">
+                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="O4P-2Y-hlm">
                             <rect key="frame" x="8" y="8" width="214" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                             <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" id="xrs-OY-P88">
@@ -224,16 +224,16 @@ Adjust settings in Show menu</string>
                         </textField>
                     </subviews>
                 </customView>
-                <box verticalHuggingPriority="750" boxType="separator" id="mWX-Pk-UvH">
+                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="mWX-Pk-UvH">
                     <rect key="frame" x="0.0" y="43" width="1000" height="5"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                 </box>
-                <popUpButton id="Fov-GV-gD7">
+                <popUpButton fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fov-GV-gD7">
                     <rect key="frame" x="11" y="9" width="82" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Show" bezelStyle="rounded" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" pullsDown="YES" preferredEdge="maxY" selectedItem="9kl-kD-1vf" id="6Tc-ix-fh5">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="FSB-Wc-ZmT">
                             <items>
                                 <menuItem title="Show" state="on" hidden="YES" id="hR8-Mf-qwD"/>
@@ -275,38 +275,38 @@ Adjust settings in Show menu</string>
                         </menu>
                     </popUpButtonCell>
                 </popUpButton>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="cbp-6y-jbG">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cbp-6y-jbG">
                     <rect key="frame" x="100" y="24" width="800" height="14"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;INFO LINE 1&gt;" id="1X5-xy-mOw">
-                        <font key="font" metaFont="toolTip"/>
+                        <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="eEA-mo-3Uq">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eEA-mo-3Uq">
                     <rect key="frame" x="100" y="8" width="800" height="14"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;INFO LINE 2&gt;" id="ecG-9J-PlG">
-                        <font key="font" metaFont="toolTip"/>
+                        <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="dry-dR-hSD">
+                <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dry-dR-hSD">
                     <rect key="frame" x="363" y="23" width="274" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="Remote operation in progress - Please wait…" id="vXh-uB-Jji">
-                        <font key="font" metaFont="toolTip"/>
+                        <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <progressIndicator hidden="YES" maxValue="100" indeterminate="YES" style="bar" id="O1S-WY-ikg">
+                <progressIndicator hidden="YES" fixedFrame="YES" maxValue="100" indeterminate="YES" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="O1S-WY-ikg">
                     <rect key="frame" x="378" y="4" width="244" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 </progressIndicator>
-                <button toolTip="Pull current branch from upstream" verticalHuggingPriority="750" id="bVm-VR-ap5">
+                <button toolTip="Pull current branch from upstream" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bVm-VR-ap5">
                     <rect key="frame" x="926" y="5" width="37" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="push" bezelStyle="rounded" image="icon_action_fetch" imagePosition="only" alignment="center" borderStyle="border" inset="2" id="SFq-Wx-Us0">
@@ -317,7 +317,7 @@ Adjust settings in Show menu</string>
                         <action selector="pullCurrentBranch:" target="-1" id="Dna-1c-lER"/>
                     </connections>
                 </button>
-                <button toolTip="Push current branch to upstream" verticalHuggingPriority="750" id="NjF-Aj-I7c">
+                <button toolTip="Push current branch to upstream" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NjF-Aj-I7c">
                     <rect key="frame" x="955" y="5" width="37" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="push" bezelStyle="rounded" image="icon_action_push" imagePosition="only" alignment="center" borderStyle="border" inset="2" id="dhk-Ry-6pb">
@@ -335,7 +335,7 @@ Adjust settings in Show menu</string>
             <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="7Lz-mJ-yDg">
+                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Lz-mJ-yDg">
                     <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 </customView>
@@ -346,7 +346,7 @@ Adjust settings in Show menu</string>
             <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="wgF-0m-Wo6">
+                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wgF-0m-Wo6">
                     <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 </customView>
@@ -357,7 +357,7 @@ Adjust settings in Show menu</string>
             <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="bDk-TS-Gf5">
+                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bDk-TS-Gf5">
                     <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 </customView>
@@ -368,11 +368,11 @@ Adjust settings in Show menu</string>
             <rect key="frame" x="0.0" y="0.0" width="261" height="500"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="TAF-BH-RXj">
+                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TAF-BH-RXj">
                     <rect key="frame" x="1" y="46" width="260" height="454"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                 </customView>
-                <button verticalHuggingPriority="750" id="bvP-z4-n9x">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bvP-z4-n9x">
                     <rect key="frame" x="86" y="5" width="88" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="push" title="Done" bezelStyle="rounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="QV1-K4-raG">
@@ -383,11 +383,11 @@ Adjust settings in Show menu</string>
                         <action selector="toggleTags:" target="-2" id="eYy-3x-jbj"/>
                     </connections>
                 </button>
-                <box horizontalHuggingPriority="750" boxType="separator" id="gbn-Tx-Mt6">
+                <box horizontalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="gbn-Tx-Mt6">
                     <rect key="frame" x="-2" y="0.0" width="5" height="500"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                 </box>
-                <box verticalHuggingPriority="750" boxType="separator" id="IFu-ad-WoU">
+                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="IFu-ad-WoU">
                     <rect key="frame" x="1" y="43" width="260" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 </box>
@@ -398,11 +398,11 @@ Adjust settings in Show menu</string>
             <rect key="frame" x="0.0" y="0.0" width="261" height="500"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="4Od-pU-cwC">
+                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Od-pU-cwC">
                     <rect key="frame" x="1" y="46" width="260" height="454"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                 </customView>
-                <button verticalHuggingPriority="750" id="6Ni-2N-Ux7">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6Ni-2N-Ux7">
                     <rect key="frame" x="86" y="5" width="88" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="push" title="Done" bezelStyle="rounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="G4D-l9-GAh">
@@ -413,11 +413,11 @@ Adjust settings in Show menu</string>
                         <action selector="toggleAncestors:" target="-2" id="cRN-q3-d3h"/>
                     </connections>
                 </button>
-                <box horizontalHuggingPriority="750" boxType="separator" id="i5t-9R-reS">
+                <box horizontalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="i5t-9R-reS">
                     <rect key="frame" x="-2" y="0.0" width="5" height="500"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                 </box>
-                <box verticalHuggingPriority="750" boxType="separator" id="lo1-B5-5pc">
+                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="lo1-B5-5pc">
                     <rect key="frame" x="1" y="43" width="260" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 </box>
@@ -430,11 +430,11 @@ Adjust settings in Show menu</string>
             <rect key="frame" x="0.0" y="0.0" width="261" height="500"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="8Xd-B3-3KB">
+                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8Xd-B3-3KB">
                     <rect key="frame" x="1" y="46" width="260" height="454"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                 </customView>
-                <button verticalHuggingPriority="750" id="rOD-bh-eJs">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rOD-bh-eJs">
                     <rect key="frame" x="86" y="5" width="88" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="push" title="Done" bezelStyle="rounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="mu6-y9-mEl">
@@ -445,11 +445,11 @@ Adjust settings in Show menu</string>
                         <action selector="toggleSnapshots:" target="-2" id="xEj-EP-Pu2"/>
                     </connections>
                 </button>
-                <box horizontalHuggingPriority="750" boxType="separator" id="BaD-c2-XFv">
+                <box horizontalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="BaD-c2-XFv">
                     <rect key="frame" x="-2" y="0.0" width="5" height="500"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                 </box>
-                <box verticalHuggingPriority="750" boxType="separator" id="Usm-DE-GWR">
+                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Usm-DE-GWR">
                     <rect key="frame" x="1" y="43" width="260" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 </box>
@@ -460,11 +460,11 @@ Adjust settings in Show menu</string>
             <rect key="frame" x="0.0" y="0.0" width="261" height="500"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="2JB-mH-NdY">
+                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2JB-mH-NdY">
                     <rect key="frame" x="1" y="46" width="260" height="454"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                 </customView>
-                <button verticalHuggingPriority="750" id="l3F-kQ-tsG">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="l3F-kQ-tsG">
                     <rect key="frame" x="86" y="5" width="88" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="push" title="Done" bezelStyle="rounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Vb7-E2-czh">
@@ -475,11 +475,11 @@ Adjust settings in Show menu</string>
                         <action selector="toggleReflog:" target="-2" id="iy2-Rc-GIe"/>
                     </connections>
                 </button>
-                <box horizontalHuggingPriority="750" boxType="separator" id="2s4-Rc-CUd">
+                <box horizontalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="2s4-Rc-CUd">
                     <rect key="frame" x="-2" y="0.0" width="5" height="500"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                 </box>
-                <box verticalHuggingPriority="750" boxType="separator" id="eoI-52-5pL">
+                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="eoI-52-5pL">
                     <rect key="frame" x="1" y="43" width="260" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 </box>
@@ -490,11 +490,11 @@ Adjust settings in Show menu</string>
             <rect key="frame" x="0.0" y="0.0" width="261" height="500"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="Km9-N7-i9Z">
+                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Km9-N7-i9Z">
                     <rect key="frame" x="1" y="0.0" width="260" height="500"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                 </customView>
-                <box horizontalHuggingPriority="750" boxType="separator" id="kME-Ra-FDy">
+                <box horizontalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="kME-Ra-FDy">
                     <rect key="frame" x="-2" y="0.0" width="5" height="500"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                 </box>
@@ -505,7 +505,7 @@ Adjust settings in Show menu</string>
             <rect key="frame" x="0.0" y="0.0" width="320" height="32"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="tYR-pC-pUm">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tYR-pC-pUm">
                     <rect key="frame" x="0.0" y="14" width="320" height="17"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;REPOSITORY&gt;" usesSingleLineMode="YES" id="IrL-wK-jB6">
@@ -514,7 +514,7 @@ Adjust settings in Show menu</string>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="FYB-ck-ZCF">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FYB-ck-ZCF">
                     <rect key="frame" x="0.0" y="2" width="320" height="11"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;INFO&gt;" usesSingleLineMode="YES" id="ueS-Kv-b9C">
@@ -530,7 +530,7 @@ Adjust settings in Show menu</string>
             <rect key="frame" x="0.0" y="0.0" width="220" height="32"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
-                <button toolTip="Select next commit" verticalHuggingPriority="750" id="XLH-eo-cDO">
+                <button toolTip="Select next commit" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XLH-eo-cDO">
                     <rect key="frame" x="3" y="3" width="28" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="icon_nav_up" imagePosition="only" alignment="center" state="on" borderStyle="border" inset="2" id="6oq-0x-6JA">
@@ -543,7 +543,7 @@ Adjust settings in Show menu</string>
                         <action selector="selectNextCommit:" target="-2" id="ELb-0V-1uX"/>
                     </connections>
                 </button>
-                <button toolTip="Select previous commit" verticalHuggingPriority="750" id="Xfs-0l-8it">
+                <button toolTip="Select previous commit" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xfs-0l-8it">
                     <rect key="frame" x="33" y="3" width="28" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="icon_nav_down" imagePosition="only" alignment="center" state="on" borderStyle="border" inset="2" id="hN6-p6-EDX">
@@ -556,7 +556,7 @@ Adjust settings in Show menu</string>
                         <action selector="selectPreviousCommit:" target="-2" id="cHX-Hx-4Op"/>
                     </connections>
                 </button>
-                <segmentedControl verticalHuggingPriority="750" id="RvM-Rz-Je8">
+                <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RvM-Rz-Je8">
                     <rect key="frame" x="3" y="3" width="118" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <segmentedCell key="cell" borderStyle="border" alignment="left" style="texturedSquare" trackingMode="selectOne" id="vbd-3d-MTF">
@@ -584,7 +584,7 @@ Adjust settings in Show menu</string>
             <rect key="frame" x="0.0" y="0.0" width="260" height="32"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
-                <searchField toolTip="Search repository" wantsLayer="YES" verticalHuggingPriority="750" id="mcD-hz-JrS">
+                <searchField toolTip="Search repository" wantsLayer="YES" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mcD-hz-JrS">
                     <rect key="frame" x="77" y="5" width="180" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                     <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" allowsUndo="NO" borderStyle="bezel" placeholderString="" usesSingleLineMode="YES" bezelStyle="round" id="3QH-Xd-ctD">
@@ -597,7 +597,7 @@ Adjust settings in Show menu</string>
                         <outlet property="delegate" destination="-2" id="aY0-ts-HbB"/>
                     </connections>
                 </searchField>
-                <button toolTip="Show or hide Snapshots" verticalHuggingPriority="750" id="yWu-L8-6Ms">
+                <button toolTip="Show or hide Snapshots" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yWu-L8-6Ms">
                     <rect key="frame" x="43" y="3" width="25" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="icon_nav_snapshot" imagePosition="only" alignment="center" borderStyle="border" inset="2" id="rrq-JQ-Zyn">
@@ -608,7 +608,7 @@ Adjust settings in Show menu</string>
                         <action selector="toggleSnapshots:" target="-2" id="AYc-qO-01Q"/>
                     </connections>
                 </button>
-                <button id="FEG-0e-0JW">
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FEG-0e-0JW">
                     <rect key="frame" x="241" y="3" width="16" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="icon_nav_min" imagePosition="only" alignment="center" inset="2" id="x0U-ct-UgO">
@@ -623,30 +623,35 @@ Adjust settings in Show menu</string>
             <point key="canvasLocation" x="150" y="496"/>
         </customView>
         <customView id="ifo-84-dTf" userLabel="Reset View">
-            <rect key="frame" x="0.0" y="0.0" width="300" height="19"/>
+            <rect key="frame" x="0.0" y="0.0" width="192" height="16"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <button id="YLR-fG-kTA">
-                    <rect key="frame" x="-2" y="-2" width="223" height="18"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="YLR-fG-kTA">
+                    <rect key="frame" x="-2" y="-1" width="194" height="18"/>
                     <buttonCell key="cell" type="check" title="Also remove untracked files" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Idb-eZ-oUH">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                 </button>
             </subviews>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="YLR-fG-kTA" secondAttribute="trailing" id="8cg-2R-xci"/>
+                <constraint firstAttribute="bottom" secondItem="YLR-fG-kTA" secondAttribute="bottom" id="KHD-gE-rP8"/>
+                <constraint firstItem="YLR-fG-kTA" firstAttribute="top" secondItem="ifo-84-dTf" secondAttribute="top" id="N0G-GI-wNu"/>
+                <constraint firstItem="YLR-fG-kTA" firstAttribute="leading" secondItem="ifo-84-dTf" secondAttribute="leading" id="qpT-Z2-YPV"/>
+            </constraints>
             <point key="canvasLocation" x="960" y="1327.5"/>
         </customView>
         <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="F4T-LV-HgR" userLabel="Settings Window">
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="131" y="158" width="450" height="173"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
             <view key="contentView" id="l4r-5b-f0f">
                 <rect key="frame" x="0.0" y="0.0" width="450" height="173"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <button id="8hM-1U-Hhn">
+                    <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8hM-1U-Hhn">
                         <rect key="frame" x="18" y="137" width="176" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <buttonCell key="cell" type="check" title="Search commit diffs" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="c4v-9V-r5S">
@@ -654,18 +659,18 @@ Adjust settings in Show menu</string>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
-                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="de2-Yp-MzO">
+                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="de2-Yp-MzO">
                         <rect key="frame" x="36" y="61" width="396" height="70"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="nO1-ig-ikF">
-                            <font key="font" metaFont="toolTip"/>
+                            <font key="font" metaFont="smallSystem"/>
                             <string key="title">GitUp searches only commit messages by default, but it can also search their diffs (text files only). This requires indexing the diffs of all commits in the repository which can take a long time.
 Changing this setting requires re-indexing the repository, which will automatically happen the next time you open it in GitUp.</string>
                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <button verticalHuggingPriority="750" id="dhw-0H-Z8w">
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dhw-0H-Z8w">
                         <rect key="frame" x="324" y="13" width="112" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Done" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Vef-Dr-NCs">

--- a/GitUp/Application/Base.lproj/Document.xib
+++ b/GitUp/Application/Base.lproj/Document.xib
@@ -91,7 +91,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="roundRect" title="Continue" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3Bn-bb-IAI">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" usesAppearanceFont="YES"/>
+                                    <font key="font" metaFont="smallSystem"/>
                                 </buttonCell>
                                 <connections>
                                     <action selector="dismissHelp:" target="-2" id="6SE-nM-Khn"/>
@@ -102,7 +102,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="roundRect" title="Got It!" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="U4W-Zh-R2B">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" usesAppearanceFont="YES"/>
+                                    <font key="font" metaFont="smallSystem"/>
                                 </buttonCell>
                                 <connections>
                                     <action selector="dismissHelp:" target="-2" id="ZhX-zZ-Pix"/>
@@ -113,7 +113,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="roundRect" title="Learn More…" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ux0-pi-0du">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" usesAppearanceFont="YES"/>
+                                    <font key="font" metaFont="smallSystem"/>
                                 </buttonCell>
                                 <connections>
                                     <action selector="openHelp:" target="-2" id="9JT-bA-cXq"/>

--- a/GitUp/Application/Base.lproj/WelcomeWindowController.xib
+++ b/GitUp/Application/Base.lproj/WelcomeWindowController.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15400" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15400"/>
+        <deployment version="110000" identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <capability name="System colors introduced in macOS 10.14" minToolsVersion="10.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,7 +21,7 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="mjY-As-hbN" userLabel="Welcome" customClass="WelcomeWindow">
             <rect key="contentRect" x="131" y="158" width="280" height="349"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="900"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
             <view key="contentView" id="36m-6r-JT2">
                 <rect key="frame" x="0.0" y="0.0" width="280" height="349"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -28,7 +29,7 @@
                     <box fixedFrame="YES" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="10" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="UoN-n1-xSr">
                         <rect key="frame" x="0.0" y="0.0" width="280" height="349"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <view key="contentView" ambiguous="YES" id="UVs-2r-EAT" customClass="WelcomeWindowView">
+                        <view key="contentView" id="UVs-2r-EAT" customClass="WelcomeWindowView">
                             <rect key="frame" x="0.0" y="0.0" width="280" height="349"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
@@ -84,7 +85,7 @@
                                             </customView>
                                         </subviews>
                                     </view>
-                                    <color key="fillColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="fillColor" name="alternatingContentBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </box>
                                 <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="FXE-km-lcD">
                                     <rect key="frame" x="0.0" y="85" width="280" height="5"/>
@@ -102,7 +103,7 @@
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                 <popUpButtonCell key="cell" type="bevel" title="Recently Opened…" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" pullsDown="YES" autoenablesItems="NO" altersStateOfSelectedItem="NO" selectedItem="BnD-OX-t50" id="TkZ-yA-jfp">
                                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                    <font key="font" metaFont="system"/>
+                                                    <font key="font" metaFont="menu"/>
                                                     <string key="keyEquivalent"></string>
                                                     <menu key="menu" autoenablesItems="NO" id="SuZ-b2-YNW">
                                                         <items>
@@ -113,7 +114,7 @@
                                             </popUpButton>
                                         </subviews>
                                     </view>
-                                    <color key="fillColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="fillColor" name="alternatingContentBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </box>
                                 <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="3Ya-QW-NlZ">
                                     <rect key="frame" x="0.0" y="49" width="280" height="5"/>
@@ -169,12 +170,12 @@
                     </box>
                 </subviews>
             </view>
-            <point key="canvasLocation" x="-185" y="548"/>
+            <point key="canvasLocation" x="-185" y="547.5"/>
         </window>
     </objects>
     <resources>
         <image name="NSApplicationIcon" width="32" height="32"/>
-        <image name="NSStopProgressFreestandingTemplate" width="14" height="14"/>
+        <image name="NSStopProgressFreestandingTemplate" width="15" height="15"/>
         <image name="icon_forum" width="12" height="12"/>
         <image name="icon_twitter" width="12" height="12"/>
     </resources>

--- a/GitUpKit/Components/Base.lproj/GICommitListViewController.xib
+++ b/GitUpKit/Components/Base.lproj/GICommitListViewController.xib
@@ -30,6 +30,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="310" height="500"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
                                     <tableColumn editable="NO" width="298" minWidth="40" maxWidth="1000" id="jYE-Dh-d6l">

--- a/GitUpKit/Components/Base.lproj/GICommitListViewController.xib
+++ b/GitUpKit/Components/Base.lproj/GICommitListViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -26,13 +26,13 @@
                         <rect key="frame" x="0.0" y="0.0" width="310" height="500"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="71" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="XD8-on-AQk" customClass="GITableView">
+                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="71" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="XD8-on-AQk" customClass="GITableView">
                                 <rect key="frame" x="0.0" y="0.0" width="310" height="500"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn editable="NO" width="310" minWidth="40" maxWidth="1000" id="jYE-Dh-d6l">
+                                    <tableColumn editable="NO" width="298" minWidth="40" maxWidth="1000" id="jYE-Dh-d6l">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -52,7 +52,7 @@
                                                         <rect key="frame" x="12" y="52" width="84" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;SHA1&gt;" id="vGZ-yd-Q3L">
-                                                            <font key="font" metaFont="controlContent" size="11"/>
+                                                            <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -61,7 +61,7 @@
                                                         <rect key="frame" x="164" y="52" width="128" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="&lt;DATE&gt;" id="fnB-nM-Xez">
-                                                            <font key="font" metaFont="controlContent" size="11"/>
+                                                            <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -70,7 +70,7 @@
                                                         <rect key="frame" x="12" y="30" width="280" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;SUMMARY&gt;" id="ldy-6V-89y">
-                                                            <font key="font" metaFont="controlContent" size="11"/>
+                                                            <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -79,7 +79,7 @@
                                                         <rect key="frame" x="12" y="8" width="280" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" truncatesLastVisibleLine="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;AUTHOR&gt;" id="Wfd-kf-H2a">
-                                                            <font key="font" metaFont="controlContent" size="11"/>
+                                                            <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -100,7 +100,7 @@
                                                         <rect key="frame" x="12" y="30" width="84" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;TYPE&gt;" id="opM-4b-OCF">
-                                                            <font key="font" metaFont="controlContent" size="11"/>
+                                                            <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -109,7 +109,7 @@
                                                         <rect key="frame" x="12" y="8" width="280" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;NAME&gt;" id="HEY-qh-9fe">
-                                                            <font key="font" metaFont="controlContent" size="11"/>
+                                                            <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -144,7 +144,7 @@
                     <rect key="frame" x="73" y="252" width="164" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;EMPTY&gt;" id="t3C-dG-D6U">
-                        <font key="font" metaFont="menu" size="14"/>
+                        <font key="font" metaFont="system" size="14"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>

--- a/GitUpKit/Components/Base.lproj/GIDiffContentsViewController.xib
+++ b/GitUpKit/Components/Base.lproj/GIDiffContentsViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,18 +16,18 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <view translatesAutoresizingMaskIntoConstraints="NO" id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
+        <view id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
             <rect key="frame" x="0.0" y="0.0" width="700" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="100" horizontalPageScroll="10" verticalLineScroll="100" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" id="OCe-0p-vJs" customClass="GIDiffContentScrollView">
+                <scrollView fixedFrame="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="100" horizontalPageScroll="10" verticalLineScroll="100" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="OCe-0p-vJs" customClass="GIDiffContentScrollView">
                     <rect key="frame" x="0.0" y="0.0" width="700" height="500"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="KvI-YZ-5JJ">
                         <rect key="frame" x="0.0" y="0.0" width="700" height="500"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="100" rowSizeStyle="automatic" viewBased="YES" id="vcn-19-sDY" customClass="GIContentsTableView">
+                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="plain" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="100" rowSizeStyle="automatic" viewBased="YES" id="vcn-19-sDY" customClass="GIContentsTableView">
                                 <rect key="frame" x="0.0" y="0.0" width="700" height="500"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -35,7 +35,6 @@
                                 <tableColumns>
                                     <tableColumn editable="NO" width="700" minWidth="40" maxWidth="10000" id="M5W-6M-rLe">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -50,7 +49,7 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="700" height="34"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Y1E-lo-5Dv">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Y1E-lo-5Dv">
                                                         <rect key="frame" x="31" y="10" width="540" height="16"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingHead" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Label" id="nPK-ee-7Lf">
@@ -59,12 +58,12 @@
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="Zb1-BY-EEo">
+                                                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zb1-BY-EEo">
                                                         <rect key="frame" x="10" y="10" width="15" height="15"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" image="icon_file_a" id="KWC-dz-6Or"/>
                                                     </imageView>
-                                                    <button id="bOi-6n-v6r">
+                                                    <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bOi-6n-v6r">
                                                         <rect key="frame" x="676" y="11" width="12" height="12"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="icon_gear" imagePosition="only" alignment="center" inset="2" id="m6t-8O-cFd">
@@ -75,12 +74,12 @@
                                                             <action selector="showActionMenu:" target="-2" id="hqU-SU-GJQ"/>
                                                         </connections>
                                                     </button>
-                                                    <button verticalHuggingPriority="750" id="Eig-8E-1uy">
+                                                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Eig-8E-1uy">
                                                         <rect key="frame" x="577" y="8" width="90" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                                         <buttonCell key="cell" type="roundTextured" title="&lt;ACTION&gt;" bezelStyle="texturedRounded" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="VeI-zL-X3B">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                            <font key="font" metaFont="toolTip"/>
+                                                            <font key="font" metaFont="smallSystem"/>
                                                         </buttonCell>
                                                         <connections>
                                                             <action selector="performAction:" target="-2" id="Wbt-vP-fPC"/>
@@ -91,7 +90,7 @@
                                                     <outlet property="actionButton" destination="Eig-8E-1uy" id="rHE-pa-aWl"/>
                                                     <outlet property="imageView" destination="Zb1-BY-EEo" id="jZU-d3-rbR"/>
                                                     <outlet property="menuButton" destination="bOi-6n-v6r" id="pZy-e5-MDX"/>
-                                                    <outlet property="textField" destination="Y1E-lo-5Dv" id="PFZ-12-FqB"/>
+                                                    <outlet property="titleField" destination="Y1E-lo-5Dv" id="Yn2-nO-6NQ"/>
                                                 </connections>
                                             </tableCellView>
                                             <tableCellView identifier="text" id="6zJ-8v-jV4" customClass="GITextDiffCellView">
@@ -102,7 +101,7 @@
                                                 <rect key="frame" x="0.0" y="134" width="700" height="50"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="vEH-U7-166">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vEH-U7-166">
                                                         <rect key="frame" x="170" y="17" width="360" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingMiddle" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="This file is empty or its content has not changed" id="gub-Hg-Iqn">
@@ -117,7 +116,7 @@
                                                 <rect key="frame" x="0.0" y="184" width="700" height="100"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="jMk-52-KEf">
+                                                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jMk-52-KEf">
                                                         <rect key="frame" x="318" y="18" width="64" height="64"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSApplicationIcon" id="LNY-Ju-mOz"/>
@@ -131,11 +130,11 @@
                                                 <rect key="frame" x="0.0" y="284" width="700" height="60"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <customView id="IHV-Ry-isd">
+                                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IHV-Ry-isd">
                                                         <rect key="frame" x="100" y="0.0" width="500" height="60"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <subviews>
-                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="IRV-hg-pLs">
+                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IRV-hg-pLs">
                                                                 <rect key="frame" x="58" y="36" width="384" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;STATUS&gt;" id="da8-F9-EbA">
@@ -144,34 +143,34 @@
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                 </textFieldCell>
                                                             </textField>
-                                                            <button verticalHuggingPriority="750" id="ExV-md-eBo">
+                                                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ExV-md-eBo">
                                                                 <rect key="frame" x="195" y="10" width="140" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <buttonCell key="cell" type="roundRect" title="Resolve In Merge Tool" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="2hY-W8-dmT">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                    <font key="font" metaFont="toolTip"/>
+                                                                    <font key="font" metaFont="smallSystem"/>
                                                                 </buttonCell>
                                                                 <connections>
                                                                     <action selector="resolveWithTool:" target="-2" id="eCp-oZ-6IS"/>
                                                                 </connections>
                                                             </button>
-                                                            <button verticalHuggingPriority="750" id="tzT-vz-KNa">
+                                                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tzT-vz-KNa">
                                                                 <rect key="frame" x="343" y="10" width="120" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <buttonCell key="cell" type="roundRect" title="Mark as Resolved" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="02c-Oc-Qz1">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                    <font key="font" metaFont="toolTip"/>
+                                                                    <font key="font" metaFont="smallSystem"/>
                                                                 </buttonCell>
                                                                 <connections>
                                                                     <action selector="markAsResolved:" target="-2" id="3Lm-ej-j9V"/>
                                                                 </connections>
                                                             </button>
-                                                            <button verticalHuggingPriority="750" id="71g-yK-uy8">
+                                                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="71g-yK-uy8">
                                                                 <rect key="frame" x="37" y="10" width="150" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <buttonCell key="cell" type="roundRect" title="Open with Default Editor" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="fuY-XZ-7Ig">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                    <font key="font" metaFont="toolTip"/>
+                                                                    <font key="font" metaFont="smallSystem"/>
                                                                 </buttonCell>
                                                                 <connections>
                                                                     <action selector="openWithEditor:" target="-2" id="t8s-DW-SZd"/>
@@ -191,20 +190,20 @@
                                                 <rect key="frame" x="0.0" y="344" width="700" height="50"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <customView id="eWx-eZ-o0j">
+                                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eWx-eZ-o0j">
                                                         <rect key="frame" x="100" y="-16" width="500" height="80"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <subviews>
-                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="YVB-XK-AIP">
+                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YVB-XK-AIP">
                                                                 <rect key="frame" x="180" y="23" width="300" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;NEW SHA1&gt;" id="PPM-zU-FYS">
-                                                                    <font key="font" metaFont="fixedUser" size="11"/>
+                                                                    <font key="font" usesAppearanceFont="YES"/>
                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                 </textFieldCell>
                                                             </textField>
-                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="L5g-ca-cZO">
+                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L5g-ca-cZO">
                                                                 <rect key="frame" x="23" y="20" width="155" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="New Submodule Commit:" id="Nk1-ps-66X">
@@ -213,16 +212,16 @@
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                 </textFieldCell>
                                                             </textField>
-                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Hyb-p0-Qcj">
+                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hyb-p0-Qcj">
                                                                 <rect key="frame" x="180" y="44" width="300" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;OLD SHA1&gt;" id="gOr-Fw-yLH">
-                                                                    <font key="font" metaFont="fixedUser" size="11"/>
+                                                                    <font key="font" usesAppearanceFont="YES"/>
                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                 </textFieldCell>
                                                             </textField>
-                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="8lM-kt-fK1">
+                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8lM-kt-fK1">
                                                                 <rect key="frame" x="23" y="41" width="155" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Old Submodule Commit:" id="T3Y-iO-ztA">
@@ -233,7 +232,7 @@
                                                             </textField>
                                                         </subviews>
                                                     </customView>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="wbK-Cy-wpg">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wbK-Cy-wpg">
                                                         <rect key="frame" x="98" y="17" width="504" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingMiddle" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;CUSTOM&gt;" id="3fm-2P-o1t">
@@ -269,11 +268,11 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="esO-al-uQm">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="esO-al-uQm">
                     <rect key="frame" x="0.0" y="252" width="700" height="18"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;EMPTY&gt;" id="vil-2I-MOS">
-                        <font key="font" metaFont="menu" size="14"/>
+                        <font key="font" metaFont="system" size="14"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>

--- a/GitUpKit/Components/Base.lproj/GISnapshotListViewController.xib
+++ b/GitUpKit/Components/Base.lproj/GISnapshotListViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,26 +14,25 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <view translatesAutoresizingMaskIntoConstraints="NO" id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
+        <view id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
             <rect key="frame" x="0.0" y="0.0" width="310" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="67" horizontalPageScroll="10" verticalLineScroll="67" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" id="AJL-NY-aX0">
+                <scrollView fixedFrame="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="67" horizontalPageScroll="10" verticalLineScroll="67" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="AJL-NY-aX0">
                     <rect key="frame" x="0.0" y="0.0" width="310" height="500"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="rt3-aj-SED">
                         <rect key="frame" x="0.0" y="0.0" width="310" height="500"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="67" viewBased="YES" floatsGroupRows="NO" id="XD8-on-AQk" customClass="GITableView">
+                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="67" viewBased="YES" floatsGroupRows="NO" id="XD8-on-AQk" customClass="GITableView">
                                 <rect key="frame" x="0.0" y="0.0" width="310" height="500"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn editable="NO" width="310" minWidth="40" maxWidth="1000" id="jYE-Dh-d6l">
+                                    <tableColumn editable="NO" width="298" minWidth="40" maxWidth="1000" id="jYE-Dh-d6l">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                            <font key="font" metaFont="toolTip"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -48,34 +47,34 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="310" height="67"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="l20-Zd-aeU">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="l20-Zd-aeU">
                                                         <rect key="frame" x="12" y="46" width="215" height="16"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;DATE&gt;" id="fnB-nM-Xez">
-                                                            <font key="font" metaFont="controlContent"/>
+                                                            <font key="font" metaFont="cellTitle"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="aSE-41-Faa">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aSE-41-Faa">
                                                         <rect key="frame" x="12" y="26" width="215" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;BRANCH&gt;" id="vGZ-yd-Q3L">
-                                                            <font key="font" metaFont="toolTip"/>
+                                                            <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="31p-sM-rNo">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="31p-sM-rNo">
                                                         <rect key="frame" x="12" y="7" width="290" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;REASON&gt;" id="4To-hs-ccb">
-                                                            <font key="font" metaFont="toolTip"/>
+                                                            <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <button verticalHuggingPriority="750" id="cJ8-TQ-t4A">
+                                                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cJ8-TQ-t4A">
                                                         <rect key="frame" x="238" y="25" width="62" height="23"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                                         <buttonCell key="cell" type="roundTextured" title="Restore" bezelStyle="texturedRounded" alignment="center" borderStyle="border" inset="2" id="P9e-AC-Ggf">

--- a/GitUpKit/Components/Base.lproj/GISnapshotListViewController.xib
+++ b/GitUpKit/Components/Base.lproj/GISnapshotListViewController.xib
@@ -29,6 +29,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="310" height="500"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
                                     <tableColumn editable="NO" width="298" minWidth="40" maxWidth="1000" id="jYE-Dh-d6l">

--- a/GitUpKit/Components/Base.lproj/GIUnifiedReflogViewController.xib
+++ b/GitUpKit/Components/Base.lproj/GIUnifiedReflogViewController.xib
@@ -31,6 +31,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="310" height="500"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
                                     <tableColumn editable="NO" width="298" minWidth="40" maxWidth="1000" id="Utu-ea-oof">

--- a/GitUpKit/Components/Base.lproj/GIUnifiedReflogViewController.xib
+++ b/GitUpKit/Components/Base.lproj/GIUnifiedReflogViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,22 +20,21 @@
             <rect key="frame" x="0.0" y="0.0" width="310" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="64" horizontalPageScroll="10" verticalLineScroll="64" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" id="bhy-go-cbZ">
+                <scrollView fixedFrame="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="64" horizontalPageScroll="10" verticalLineScroll="64" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="bhy-go-cbZ">
                     <rect key="frame" x="0.0" y="0.0" width="310" height="500"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="hSz-33-pAu">
                         <rect key="frame" x="0.0" y="0.0" width="310" height="500"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="64" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="eCC-8p-v0T" customClass="GITableView">
+                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="64" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="eCC-8p-v0T" customClass="GITableView">
                                 <rect key="frame" x="0.0" y="0.0" width="310" height="500"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn editable="NO" width="310" minWidth="40" maxWidth="1000" id="Utu-ea-oof">
+                                    <tableColumn editable="NO" width="298" minWidth="40" maxWidth="1000" id="Utu-ea-oof">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                            <font key="font" metaFont="toolTip"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -50,16 +49,16 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="310" height="64"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="UUH-Ya-qgL">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UUH-Ya-qgL">
                                                         <rect key="frame" x="12" y="43" width="215" height="16"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;DATE&gt;" id="CAx-qO-hcQ">
-                                                            <font key="font" metaFont="controlContent"/>
+                                                            <font key="font" metaFont="cellTitle"/>
                                                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" id="gN3-DV-uz9">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gN3-DV-uz9">
                                                         <rect key="frame" x="12" y="6" width="290" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <textFieldCell key="cell" controlSize="mini" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;MESSAGE&gt;" id="tIJ-TL-cTH">
@@ -68,7 +67,7 @@
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <button verticalHuggingPriority="750" id="XZF-t8-MmI">
+                                                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XZF-t8-MmI">
                                                         <rect key="frame" x="238" y="27" width="62" height="23"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                                         <buttonCell key="cell" type="roundTextured" title="Restore" bezelStyle="texturedRounded" alignment="center" borderStyle="border" inset="2" id="kM9-bW-ZyX">
@@ -79,11 +78,11 @@
                                                             <action selector="restoreEntry:" target="-2" id="9vW-4e-Rhc"/>
                                                         </connections>
                                                     </button>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="cAX-w7-opq">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cAX-w7-opq">
                                                         <rect key="frame" x="12" y="25" width="215" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;ACTION&gt;" id="aCu-57-Md1">
-                                                            <font key="font" metaFont="toolTip"/>
+                                                            <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -118,11 +117,11 @@
             </subviews>
             <point key="canvasLocation" x="232" y="388"/>
         </view>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="hZQ-gb-8kq" userLabel="Restore View">
+        <customView id="hZQ-gb-8kq" userLabel="Restore View">
             <rect key="frame" x="0.0" y="0.0" width="358" height="22"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" id="1Ft-qn-oYj">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Ft-qn-oYj">
                     <rect key="frame" x="113" y="0.0" width="240" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" id="68O-Ht-dLG">
@@ -131,7 +130,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="FMA-JZ-b0c">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FMA-JZ-b0c">
                     <rect key="frame" x="-2" y="2" width="109" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Branch Name:" id="VGx-PL-1V0">

--- a/GitUpKit/Components/GIDiffContentsViewController.m
+++ b/GitUpKit/Components/GIDiffContentsViewController.m
@@ -41,6 +41,7 @@
 @end
 
 @interface GIHeaderDiffCellView : NSTableCellView
+@property(nonatomic, weak) IBOutlet NSTextField* titleField;
 @property(nonatomic, weak) IBOutlet NSButton* menuButton;
 @property(nonatomic, weak) IBOutlet NSButton* actionButton;
 @property(nonatomic, strong) NSColor* backgroundColor;
@@ -118,7 +119,7 @@ NSString* const GIDiffContentsViewControllerUserDefaultKey_DiffViewMode = @"GIDi
 }
 
 - (void)setActionButtonLabel:(NSString*)label {
-  NSTextField* titleField = self.textField;
+  NSTextField* titleField = self.titleField;
   NSRect titleFrame = titleField.frame;
   NSRect buttonFrame = _actionButton.frame;
   if (label.length) {
@@ -597,9 +598,9 @@ static inline NSString* _StringFromFileMode(GCFileMode mode) {
     [string setAttributes:attributes range:oldPathRange];
     [string setAttributes:attributes range:newPathRange];
     [string endEditing];
-    view.textField.attributedStringValue = string;
+    view.titleField.attributedStringValue = string;
   } else {
-    view.textField.stringValue = label;
+    view.titleField.stringValue = label;
   }
   BOOL hasActionMenu = [_delegate respondsToSelector:@selector(diffContentsViewController:willShowContextualMenuForDelta:conflict:)];
   view.menuButton.hidden = !hasActionMenu;

--- a/GitUpKit/Components/GIDiffFilesViewController.m
+++ b/GitUpKit/Components/GIDiffFilesViewController.m
@@ -25,7 +25,7 @@
 static const NSPasteboardType GIPasteboardTypeFileRowIndex = @"co.gitup.mac.file-row-index";
 static const NSPasteboardType GIPasteboardTypeFileURL = @"public.file-url";
 
-@interface GIFileCellView : NSTableCellView
+@interface GIFileCellView : GITableCellView
 @end
 
 @interface GIFilesTableView : GITableView

--- a/GitUpKit/Utilities/GIAppKit.m
+++ b/GitUpKit/Utilities/GIAppKit.m
@@ -286,24 +286,14 @@ static const void* _associatedObjectCommitKey = &_associatedObjectCommitKey;
   }
 }
 
-- (void)drawRect:(NSRect)dirtyRect {
-  NSRect bounds = self.bounds;
-  CGContextRef context = [[NSGraphicsContext currentContext] graphicsPort];
-
-  [NSColor.gitUpSeparatorColor setStroke];
-  CGContextMoveToPoint(context, 0, 0.5);
-  CGContextAddLineToPoint(context, bounds.size.width, 0.5);
-  CGContextStrokePath(context);
-  if (_row == 0) {
-    CGContextMoveToPoint(context, 0, bounds.size.height - 0.5);
-    CGContextAddLineToPoint(context, bounds.size.width, bounds.size.height - 0.5);
-    CGContextStrokePath(context);
-  }
-}
-
 @end
 
 @implementation GITableView
+
+- (void)awakeFromNib {
+  [super awakeFromNib];
+  self.gridColor = NSColor.gitUpSeparatorColor;
+}
 
 - (BOOL)validateProposedFirstResponder:(NSResponder*)responder forEvent:(NSEvent*)event {
   return YES;

--- a/GitUpKit/Utilities/NSColor+GINamedColors.h
+++ b/GitUpKit/Utilities/NSColor+GINamedColors.h
@@ -38,4 +38,6 @@
 @property(class, strong, readonly) NSColor* gitUpConfigGlobalBackgroundColor;
 @property(class, strong, readonly) NSColor* gitUpConfigHighlightBackgroundColor;
 
+@property(class, strong, readonly) NSColor* gitUpCommitHeaderBackgroundColor;
+
 @end

--- a/GitUpKit/Utilities/NSColor+GINamedColors.m
+++ b/GitUpKit/Utilities/NSColor+GINamedColors.m
@@ -116,6 +116,7 @@ IMPLEMENT_NAMED_COLOR(DiffUntrackedBackground, "diff/untracked_background", 0.75
 IMPLEMENT_NAMED_COLOR(ConfigConflictBackground, "config/conflict_background", 1, 0.95, 0.95, 1)
 IMPLEMENT_NAMED_COLOR(ConfigGlobalBackground, "config/global_background", 0.95, 1, 0.95, 1)
 IMPLEMENT_NAMED_COLOR(ConfigHighlightBackground, "config/highlight_background", 1, 1, 0, 0.5)
+IMPLEMENT_NAMED_COLOR(CommitHeaderBackground, "commit/header_background", 0.5, 0.5, 0.5, 1)
 
 #undef IMPLEMENT_NAMED_COLOR
 

--- a/GitUpKit/Views/Base.lproj/GIAdvancedCommitViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GIAdvancedCommitViewController.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,49 +13,51 @@
                 <outlet property="diffContentsView" destination="hwM-6S-E69" id="ze2-KZ-coi"/>
                 <outlet property="discardButton" destination="4zE-Zk-8sX" id="dm8-Vg-dZ6"/>
                 <outlet property="indexFilesView" destination="SLl-qM-6U5" id="q90-XG-uOo"/>
+                <outlet property="indexHeaderView" destination="0zR-9s-ty2" id="BLn-7k-Ti2"/>
                 <outlet property="infoTextField" destination="H0U-9x-3Cl" id="xIS-An-utS"/>
                 <outlet property="messageTextView" destination="ZGk-oR-MNP" id="bmf-B6-urc"/>
                 <outlet property="stageButton" destination="nf2-5l-LHg" id="Y5g-wM-FRo"/>
                 <outlet property="unstageButton" destination="0n6-Tx-H9g" id="RRF-VA-co7"/>
                 <outlet property="view" destination="Mge-gB-T5T" id="Dk7-8C-xIa"/>
                 <outlet property="workdirFilesView" destination="b2z-ev-lVE" id="t3L-3T-o0g"/>
+                <outlet property="workdirHeaderView" destination="EEr-wZ-rpO" id="1D0-9i-ne5"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <view translatesAutoresizingMaskIntoConstraints="NO" id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
+        <view id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
             <rect key="frame" x="0.0" y="0.0" width="1000" height="600"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <splitView dividerStyle="thin" id="ZbB-IP-Zuo" customClass="GIDualSplitView">
+                <splitView fixedFrame="YES" dividerStyle="thin" translatesAutoresizingMaskIntoConstraints="NO" id="ZbB-IP-Zuo" customClass="GIDualSplitView">
                     <rect key="frame" x="0.0" y="0.0" width="1000" height="600"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <subviews>
-                        <customView id="KtH-4j-g0D">
+                        <customView fixedFrame="YES" id="KtH-4j-g0D">
                             <rect key="frame" x="0.0" y="0.0" width="1000" height="452"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
-                                <splitView dividerStyle="thin" vertical="YES" id="O4G-mD-5bu" customClass="GIDualSplitView">
+                                <splitView fixedFrame="YES" dividerStyle="thin" vertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="O4G-mD-5bu" customClass="GIDualSplitView">
                                     <rect key="frame" x="0.0" y="0.0" width="1000" height="452"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <customView id="hyR-9a-6mn">
+                                        <customView fixedFrame="YES" id="hyR-9a-6mn">
                                             <rect key="frame" x="0.0" y="0.0" width="300" height="452"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <splitView dividerStyle="thin" id="oRD-oN-b2v" customClass="GIDualSplitView">
+                                                <splitView fixedFrame="YES" dividerStyle="thin" translatesAutoresizingMaskIntoConstraints="NO" id="oRD-oN-b2v" customClass="GIDualSplitView">
                                                     <rect key="frame" x="0.0" y="0.0" width="300" height="452"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
-                                                        <customView id="WHS-6x-fR7">
+                                                        <customView fixedFrame="YES" id="WHS-6x-fR7">
                                                             <rect key="frame" x="0.0" y="0.0" width="300" height="249"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
-                                                                <customView id="EEr-wZ-rpO" customClass="GIColorView">
+                                                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EEr-wZ-rpO" customClass="GIColorView">
                                                                     <rect key="frame" x="0.0" y="215" width="300" height="34"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                     <subviews>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="GEC-hP-IwB">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GEC-hP-IwB">
                                                                             <rect key="frame" x="8" y="9" width="138" height="17"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Working Directory" id="fB8-dk-yEW">
@@ -66,21 +67,16 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                     </subviews>
-                                                                    <userDefinedRuntimeAttributes>
-                                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                                                                            <color key="value" name="commit/header_background"/>
-                                                                        </userDefinedRuntimeAttribute>
-                                                                    </userDefinedRuntimeAttributes>
                                                                 </customView>
-                                                                <box verticalHuggingPriority="750" boxType="separator" id="qxb-gR-CFd">
+                                                                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="qxb-gR-CFd">
                                                                     <rect key="frame" x="0.0" y="39" width="300" height="5"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                                                 </box>
-                                                                <customView id="b2z-ev-lVE">
+                                                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="b2z-ev-lVE">
                                                                     <rect key="frame" x="0.0" y="42" width="300" height="173"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 </customView>
-                                                                <button verticalHuggingPriority="750" id="4zE-Zk-8sX">
+                                                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4zE-Zk-8sX">
                                                                     <rect key="frame" x="8" y="4" width="120" height="32"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                     <buttonCell key="cell" type="push" title="Discard All…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ld8-vc-cxM">
@@ -93,7 +89,7 @@
                                                                         <action selector="discardAll:" target="-2" id="yfG-b0-hpM"/>
                                                                     </connections>
                                                                 </button>
-                                                                <button verticalHuggingPriority="750" id="nf2-5l-LHg">
+                                                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nf2-5l-LHg">
                                                                     <rect key="frame" x="172" y="4" width="120" height="32"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                                                     <buttonCell key="cell" type="push" title="Stage All" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ia5-7P-vyF">
@@ -107,15 +103,15 @@
                                                                 </button>
                                                             </subviews>
                                                         </customView>
-                                                        <customView id="1t4-og-I2D">
+                                                        <customView fixedFrame="YES" id="1t4-og-I2D">
                                                             <rect key="frame" x="0.0" y="250" width="300" height="202"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
-                                                                <customView id="0zR-9s-ty2" customClass="GIColorView">
+                                                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0zR-9s-ty2" customClass="GIColorView">
                                                                     <rect key="frame" x="0.0" y="168" width="300" height="34"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                     <subviews>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="hEs-Hp-dbT">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hEs-Hp-dbT">
                                                                             <rect key="frame" x="8" y="9" width="60" height="17"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Index" id="UV4-jc-9yJ">
@@ -125,13 +121,8 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                     </subviews>
-                                                                    <userDefinedRuntimeAttributes>
-                                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                                                                            <color key="value" name="commit/header_background"/>
-                                                                        </userDefinedRuntimeAttribute>
-                                                                    </userDefinedRuntimeAttributes>
                                                                 </customView>
-                                                                <customView id="SLl-qM-6U5">
+                                                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SLl-qM-6U5">
                                                                     <rect key="frame" x="0.0" y="0.0" width="300" height="168"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 </customView>
@@ -153,11 +144,11 @@
                                                 </splitView>
                                             </subviews>
                                         </customView>
-                                        <customView id="R7z-QE-KSZ">
+                                        <customView fixedFrame="YES" id="R7z-QE-KSZ">
                                             <rect key="frame" x="301" y="0.0" width="699" height="452"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <customView id="hwM-6S-E69">
+                                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hwM-6S-E69">
                                                     <rect key="frame" x="0.0" y="0.0" width="699" height="452"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 </customView>
@@ -179,11 +170,11 @@
                                 </splitView>
                             </subviews>
                         </customView>
-                        <customView id="yf9-6S-SRZ">
+                        <customView fixedFrame="YES" id="yf9-6S-SRZ">
                             <rect key="frame" x="0.0" y="453" width="1000" height="147"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
-                                <scrollView focusRingType="exterior" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="JJQ-Rg-cUm">
+                                <scrollView focusRingType="exterior" fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JJQ-Rg-cUm">
                                     <rect key="frame" x="14" y="45" width="972" height="90"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <clipView key="contentView" drawsBackground="NO" id="MSi-0x-dun">
@@ -197,15 +188,6 @@
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 <size key="minSize" width="970" height="88"/>
                                                 <size key="maxSize" width="10000000" height="10000000"/>
-                                                <attributedString key="textStorage">
-                                                    <fragment content="&lt;MESSAGE&gt;">
-                                                        <attributes>
-                                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                            <font key="NSFont" metaFont="toolTip"/>
-                                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural"/>
-                                                        </attributes>
-                                                    </fragment>
-                                                </attributedString>
                                                 <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                 <connections>
                                                     <outlet property="delegate" destination="-2" id="N5I-f7-WzM"/>
@@ -222,7 +204,7 @@
                                         <autoresizingMask key="autoresizingMask"/>
                                     </scroller>
                                 </scrollView>
-                                <button id="eFu-23-SH3">
+                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eFu-23-SH3">
                                     <rect key="frame" x="748" y="14" width="114" height="18"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                     <buttonCell key="cell" type="check" title="Amend HEAD" bezelStyle="regularSquare" imagePosition="left" inset="2" id="C2R-ad-b2o">
@@ -234,7 +216,7 @@
                                         <action selector="toggleAmend:" target="-2" id="sJx-aM-le4"/>
                                     </connections>
                                 </button>
-                                <button verticalHuggingPriority="750" id="mNK-0g-48P">
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mNK-0g-48P">
                                     <rect key="frame" x="872" y="5" width="120" height="32"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                     <buttonCell key="cell" type="push" title="Commit" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="GtK-Iv-qM4">
@@ -249,16 +231,16 @@ DQ
                                         </connections>
                                     </buttonCell>
                                 </button>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="H0U-9x-3Cl">
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="H0U-9x-3Cl">
                                     <rect key="frame" x="130" y="16" width="614" height="14"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;INFO&gt;" id="dbO-mu-br6">
-                                        <font key="font" metaFont="toolTip"/>
+                                        <font key="font" metaFont="smallSystem"/>
                                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <button verticalHuggingPriority="750" id="0n6-Tx-H9g">
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0n6-Tx-H9g">
                                     <rect key="frame" x="8" y="5" width="122" height="32"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <buttonCell key="cell" type="push" title="Unstage All" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="oqv-6o-u68">
@@ -290,9 +272,4 @@ DQ
             <point key="canvasLocation" x="576" y="511"/>
         </view>
     </objects>
-    <resources>
-        <namedColor name="commit/header_background">
-            <color white="0.5" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </namedColor>
-    </resources>
 </document>

--- a/GitUpKit/Views/Base.lproj/GICommitSplitterViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GICommitSplitterViewController.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,7 +11,9 @@
                 <outlet property="continueButton" destination="kyp-MO-xu5" id="LRR-6V-vFc"/>
                 <outlet property="diffContentsView" destination="weo-in-1Ld" id="WAI-ja-NrZ"/>
                 <outlet property="filesViewNew" destination="IfV-FZ-t0W" id="s6S-bX-wFN"/>
+                <outlet property="filesViewNewHeader" destination="i0X-9n-k1u" id="QM7-Kd-cEm"/>
                 <outlet property="filesViewOld" destination="Scn-lW-rL0" id="Ixn-qz-kmQ"/>
+                <outlet property="filesViewOldHeader" destination="7j5-Pz-Pse" id="ZCb-hZ-CUN"/>
                 <outlet property="infoTextField" destination="J4i-ca-hW8" id="SsC-49-2T9"/>
                 <outlet property="messageTextView" destination="C9q-53-7wr" id="Yf2-ha-bpr"/>
                 <outlet property="messageView" destination="mcb-9I-AWZ" id="5WM-be-w0L"/>
@@ -25,15 +26,15 @@
             <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="eJw-Ro-RO2">
+                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eJw-Ro-RO2">
                     <rect key="frame" x="0.0" y="470" width="1000" height="30"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <subviews>
-                        <box verticalHuggingPriority="750" boxType="separator" id="9kw-yf-Rw7">
+                        <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="9kw-yf-Rw7">
                             <rect key="frame" x="0.0" y="-2" width="1000" height="5"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                         </box>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="ZXE-Q8-0tE">
+                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZXE-Q8-0tE">
                             <rect key="frame" x="13" y="8" width="114" height="16"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Splitting Commit:" id="MLR-4B-XXd">
@@ -42,7 +43,7 @@
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="otg-FV-eFd">
+                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="otg-FV-eFd">
                             <rect key="frame" x="127" y="8" width="855" height="16"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                             <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;TITLE&gt;" id="2Ta-mo-RyA">
@@ -53,31 +54,31 @@
                         </textField>
                     </subviews>
                 </customView>
-                <splitView dividerStyle="thin" vertical="YES" id="GbO-qM-CQw" customClass="GIDualSplitView">
+                <splitView fixedFrame="YES" dividerStyle="thin" vertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GbO-qM-CQw" customClass="GIDualSplitView">
                     <rect key="frame" x="0.0" y="0.0" width="1000" height="470"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <subviews>
-                        <customView id="hef-Ad-4nX">
+                        <customView fixedFrame="YES" id="hef-Ad-4nX">
                             <rect key="frame" x="0.0" y="0.0" width="300" height="470"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
-                                <box verticalHuggingPriority="750" boxType="separator" id="GiE-tn-bRu">
+                                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="GiE-tn-bRu">
                                     <rect key="frame" x="0.0" y="43" width="300" height="5"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 </box>
-                                <splitView dividerStyle="thin" id="e6i-iT-slV" customClass="GIDualSplitView">
+                                <splitView fixedFrame="YES" dividerStyle="thin" translatesAutoresizingMaskIntoConstraints="NO" id="e6i-iT-slV" customClass="GIDualSplitView">
                                     <rect key="frame" x="0.0" y="46" width="300" height="424"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <customView id="ots-w9-o6k">
+                                        <customView fixedFrame="YES" id="ots-w9-o6k">
                                             <rect key="frame" x="0.0" y="0.0" width="300" height="211"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <customView id="i0X-9n-k1u" customClass="GIColorView">
+                                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="i0X-9n-k1u" customClass="GIColorView">
                                                     <rect key="frame" x="0.0" y="177" width="300" height="34"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                     <subviews>
-                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Zg3-mt-YHc">
+                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zg3-mt-YHc">
                                                             <rect key="frame" x="8" y="9" width="154" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                             <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="New Commit" id="C06-wj-5uc">
@@ -87,27 +88,22 @@
                                                             </textFieldCell>
                                                         </textField>
                                                     </subviews>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                                                            <color key="value" name="commit/header_background"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                    </userDefinedRuntimeAttributes>
                                                 </customView>
-                                                <customView id="IfV-FZ-t0W">
+                                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IfV-FZ-t0W">
                                                     <rect key="frame" x="0.0" y="0.0" width="300" height="177"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 </customView>
                                             </subviews>
                                         </customView>
-                                        <customView id="VtZ-UX-sFq">
+                                        <customView fixedFrame="YES" id="VtZ-UX-sFq">
                                             <rect key="frame" x="0.0" y="212" width="300" height="212"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <customView id="7j5-Pz-Pse" customClass="GIColorView">
+                                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7j5-Pz-Pse" customClass="GIColorView">
                                                     <rect key="frame" x="0.0" y="178" width="300" height="34"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                     <subviews>
-                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="JBE-2n-Fmz">
+                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JBE-2n-Fmz">
                                                             <rect key="frame" x="8" y="9" width="154" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                             <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Old Commit" id="CSN-Cf-azv">
@@ -117,13 +113,8 @@
                                                             </textFieldCell>
                                                         </textField>
                                                     </subviews>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                                                            <color key="value" name="commit/header_background"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                    </userDefinedRuntimeAttributes>
                                                 </customView>
-                                                <customView id="Scn-lW-rL0">
+                                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Scn-lW-rL0">
                                                     <rect key="frame" x="0.0" y="0.0" width="300" height="178"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 </customView>
@@ -143,7 +134,7 @@
                                         </userDefinedRuntimeAttribute>
                                     </userDefinedRuntimeAttributes>
                                 </splitView>
-                                <button verticalHuggingPriority="750" id="GmQ-B6-tjv">
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GmQ-B6-tjv">
                                     <rect key="frame" x="8" y="5" width="100" height="32"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="rco-aZ-vl2">
@@ -157,7 +148,7 @@ Gw
                                         <action selector="cancel:" target="-2" id="nii-dL-QPl"/>
                                     </connections>
                                 </button>
-                                <button verticalHuggingPriority="750" id="kyp-MO-xu5">
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kyp-MO-xu5">
                                     <rect key="frame" x="180" y="5" width="112" height="32"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                     <buttonCell key="cell" type="push" title="Continue…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="khk-i1-Bqu">
@@ -174,11 +165,11 @@ DQ
                                 </button>
                             </subviews>
                         </customView>
-                        <customView id="XQf-N4-jx3">
+                        <customView fixedFrame="YES" id="XQf-N4-jx3">
                             <rect key="frame" x="301" y="0.0" width="699" height="470"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
-                                <customView id="weo-in-1Ld">
+                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="weo-in-1Ld">
                                     <rect key="frame" x="0.0" y="0.0" width="699" height="470"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </customView>
@@ -207,7 +198,7 @@ DQ
             <rect key="frame" x="0.0" y="0.0" width="590" height="354"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Mi2-Di-27H">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Mi2-Di-27H">
                     <rect key="frame" x="18" y="322" width="183" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="New commit message:" id="Rs6-wQ-uAF">
@@ -216,7 +207,7 @@ DQ
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <scrollView autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="FGz-GT-MFK">
+                <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FGz-GT-MFK">
                     <rect key="frame" x="20" y="214" width="550" height="100"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" drawsBackground="NO" id="iv1-rd-iqv">
@@ -230,15 +221,6 @@ DQ
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <size key="minSize" width="548" height="98"/>
                                 <size key="maxSize" width="562" height="10000000"/>
-                                <attributedString key="textStorage">
-                                    <fragment content="&lt;MESSAGE&gt;">
-                                        <attributes>
-                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                            <font key="NSFont" metaFont="toolTip"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural"/>
-                                        </attributes>
-                                    </fragment>
-                                </attributedString>
                                 <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                 <connections>
                                     <outlet property="delegate" destination="-2" id="r9O-yb-7mj"/>
@@ -255,7 +237,7 @@ DQ
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="VJr-bi-EjL">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VJr-bi-EjL">
                     <rect key="frame" x="18" y="189" width="183" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Old commit message:" id="3xC-Vl-BIN">
@@ -264,7 +246,7 @@ DQ
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <scrollView autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="sdt-ps-l95">
+                <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sdt-ps-l95">
                     <rect key="frame" x="20" y="81" width="550" height="100"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" drawsBackground="NO" id="sKA-Dg-4u7">
@@ -278,15 +260,6 @@ DQ
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <size key="minSize" width="548" height="98"/>
                                 <size key="maxSize" width="608" height="10000000"/>
-                                <attributedString key="textStorage">
-                                    <fragment content="&lt;MESSAGE&gt;">
-                                        <attributes>
-                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                            <font key="NSFont" metaFont="toolTip"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural"/>
-                                        </attributes>
-                                    </fragment>
-                                </attributedString>
                                 <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                 <connections>
                                     <outlet property="delegate" destination="-2" id="kk3-aI-fXa"/>
@@ -303,16 +276,16 @@ DQ
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="J4i-ca-hW8">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="J4i-ca-hW8">
                     <rect key="frame" x="18" y="59" width="554" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;INFO&gt;" id="29G-mk-yTd">
-                        <font key="font" metaFont="toolTip"/>
+                        <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" id="Nxe-6I-8Yc">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nxe-6I-8Yc">
                     <rect key="frame" x="446" y="13" width="130" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Split Commit" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="I9A-6a-Tsc">
@@ -327,7 +300,7 @@ DQ
                         <action selector="finishModalView:" target="-2" id="vTp-E1-o2W"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" id="BjK-xU-1uM">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BjK-xU-1uM">
                     <rect key="frame" x="346" y="13" width="100" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ad8-SM-Ixv">
@@ -345,9 +318,4 @@ Gw
             <point key="canvasLocation" x="347" y="803"/>
         </customView>
     </objects>
-    <resources>
-        <namedColor name="commit/header_background">
-            <color white="0.5" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </namedColor>
-    </resources>
 </document>

--- a/GitUpKit/Views/Base.lproj/GIConfigViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GIConfigViewController.xib
@@ -38,6 +38,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="1000" height="454"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
                                     <tableColumn editable="NO" width="988" minWidth="40" maxWidth="10000" id="oyg-mA-s9h">
@@ -69,7 +70,7 @@
                                                         <rect key="frame" x="78" y="14" width="904" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;HELP&gt;" id="4Xe-ni-5m6">
-                                                            <font key="font" metaFont="toolTip"/>
+                                                            <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -78,7 +79,7 @@
                                                         <rect key="frame" x="78" y="36" width="904" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;OPTION&gt;" id="b4Q-Ad-COB">
-                                                            <font key="font" metaFont="systemBold"/>
+                                                            <font key="font" metaFont="smallSystemBold"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>

--- a/GitUpKit/Views/Base.lproj/GIConfigViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GIConfigViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,30 +19,29 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <view translatesAutoresizingMaskIntoConstraints="NO" id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
+        <view id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
             <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <box verticalHuggingPriority="750" boxType="separator" id="zs3-CD-2TT">
+                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="zs3-CD-2TT">
                     <rect key="frame" x="0.0" y="43" width="1000" height="5"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                 </box>
-                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="58" horizontalPageScroll="10" verticalLineScroll="58" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" id="0y0-9P-6v1">
+                <scrollView fixedFrame="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="58" horizontalPageScroll="10" verticalLineScroll="58" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="0y0-9P-6v1">
                     <rect key="frame" x="0.0" y="46" width="1000" height="454"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="Z2V-p9-Fdu">
                         <rect key="frame" x="0.0" y="0.0" width="1000" height="454"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="58" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="rIc-OO-A36" customClass="GITableView">
+                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="58" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="rIc-OO-A36" customClass="GITableView">
                                 <rect key="frame" x="0.0" y="0.0" width="1000" height="454"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn editable="NO" width="1000" minWidth="40" maxWidth="10000" id="oyg-mA-s9h">
+                                    <tableColumn editable="NO" width="988" minWidth="40" maxWidth="10000" id="oyg-mA-s9h">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                            <font key="font" metaFont="toolTip"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -57,7 +56,7 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="1000" height="58"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="vZK-ii-fJx">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vZK-ii-fJx">
                                                         <rect key="frame" x="8" y="21" width="55" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="LEVEL" id="WAs-6x-3SX">
@@ -66,7 +65,7 @@
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" id="YEf-Fm-0JU">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YEf-Fm-0JU">
                                                         <rect key="frame" x="78" y="14" width="904" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;HELP&gt;" id="4Xe-ni-5m6">
@@ -75,7 +74,7 @@
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Kgc-QS-TeT">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kgc-QS-TeT">
                                                         <rect key="frame" x="78" y="36" width="904" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;OPTION&gt;" id="b4Q-Ad-COB">
@@ -110,7 +109,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
-                <button toolTip="Add new option" verticalHuggingPriority="750" id="czt-SE-8sZ">
+                <button toolTip="Add new option" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="czt-SE-8sZ">
                     <rect key="frame" x="8" y="5" width="37" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="push" bezelStyle="rounded" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="nyb-dg-sa2">
@@ -122,7 +121,7 @@
                         <action selector="addOption:" target="-2" id="BHN-Je-aCy"/>
                     </connections>
                 </button>
-                <button toolTip="Delete selected option" verticalHuggingPriority="750" id="agS-he-C87">
+                <button toolTip="Delete selected option" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="agS-he-C87">
                     <rect key="frame" x="38" y="5" width="37" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="push" bezelStyle="rounded" image="NSRemoveTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="fe4-5j-J96">
@@ -136,7 +135,7 @@ CA
                         <action selector="deleteOption:" target="-2" id="2Kp-SO-sN1"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" id="DmR-oW-YvH">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DmR-oW-YvH">
                     <rect key="frame" x="900" y="5" width="92" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="push" title="Edit…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Zpv-vW-DFj">
@@ -157,7 +156,7 @@ DQ
             <rect key="frame" x="0.0" y="0.0" width="439" height="131"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" id="LoL-ry-aDR">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LoL-ry-aDR">
                     <rect key="frame" x="119" y="89" width="300" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" id="bWI-iO-Sp8">
@@ -169,7 +168,7 @@ DQ
                         <outlet property="delegate" destination="-2" id="q9E-su-cDY"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="011-37-CLH">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="011-37-CLH">
                     <rect key="frame" x="18" y="91" width="95" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Option name:" id="E3T-2C-Mr5">
@@ -178,7 +177,7 @@ DQ
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" id="FZ4-x9-dSW">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FZ4-x9-dSW">
                     <rect key="frame" x="119" y="59" width="300" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" id="mm6-7u-AuS">
@@ -190,7 +189,7 @@ DQ
                         <outlet property="delegate" destination="-2" id="yE4-CQ-vjt"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="4bC-3z-9pS">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4bC-3z-9pS">
                     <rect key="frame" x="18" y="61" width="95" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Option value:" id="sLn-lG-0q9">
@@ -199,7 +198,7 @@ DQ
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" id="Izp-cY-xRo">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Izp-cY-xRo">
                     <rect key="frame" x="321" y="13" width="104" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="BPh-Xi-7ho">
@@ -213,7 +212,7 @@ DQ
                         <action selector="finishModalView:" target="-2" id="mOr-L8-lRM"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" id="C12-Mj-uSf">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="C12-Mj-uSf">
                     <rect key="frame" x="227" y="13" width="92" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="qo3-bg-4sZ">
@@ -232,7 +231,7 @@ Gw
         </customView>
     </objects>
     <resources>
-        <image name="NSAddTemplate" width="11" height="11"/>
-        <image name="NSRemoveTemplate" width="11" height="11"/>
+        <image name="NSAddTemplate" width="14" height="13"/>
+        <image name="NSRemoveTemplate" width="14" height="4"/>
     </resources>
 </document>

--- a/GitUpKit/Views/Base.lproj/GIStashListViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GIStashListViewController.xib
@@ -49,6 +49,7 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="300" height="454"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
                                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                 <tableColumns>
                                                     <tableColumn editable="NO" width="268" minWidth="40" maxWidth="1000" id="sMJ-Ww-cFI">
@@ -121,7 +122,7 @@
                                     </scroller>
                                 </scrollView>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2vp-ts-xnS">
-                                    <rect key="frame" x="68" y="272" width="164" height="18"/>
+                                    <rect key="frame" x="10" y="252" width="280" height="18"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="No Stashes" id="zsp-Bw-JJB">
                                         <font key="font" metaFont="system" size="14"/>

--- a/GitUpKit/Views/Base.lproj/GIStashListViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GIStashListViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -22,38 +22,37 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <view translatesAutoresizingMaskIntoConstraints="NO" id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
+        <view id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
             <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <splitView dividerStyle="thin" vertical="YES" id="M8I-h4-KwC" customClass="GIDualSplitView">
+                <splitView fixedFrame="YES" dividerStyle="thin" vertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M8I-h4-KwC" customClass="GIDualSplitView">
                     <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <subviews>
-                        <customView id="Xfi-Nn-lMB">
+                        <customView fixedFrame="YES" id="Xfi-Nn-lMB">
                             <rect key="frame" x="0.0" y="0.0" width="300" height="500"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
-                                <box verticalHuggingPriority="750" boxType="separator" id="R5I-cO-ijQ">
+                                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="R5I-cO-ijQ">
                                     <rect key="frame" x="0.0" y="43" width="300" height="5"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 </box>
-                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="50" horizontalPageScroll="10" verticalLineScroll="50" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" id="9JY-At-FkM">
+                                <scrollView fixedFrame="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="50" horizontalPageScroll="10" verticalLineScroll="50" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="9JY-At-FkM">
                                     <rect key="frame" x="0.0" y="46" width="300" height="454"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <clipView key="contentView" id="30S-bg-Q3C">
                                         <rect key="frame" x="0.0" y="0.0" width="300" height="454"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="50" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="PuJ-qB-scf" customClass="GITableView">
+                                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="inset" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="50" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="PuJ-qB-scf" customClass="GITableView">
                                                 <rect key="frame" x="0.0" y="0.0" width="300" height="454"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                 <tableColumns>
-                                                    <tableColumn editable="NO" width="300" minWidth="40" maxWidth="1000" id="sMJ-Ww-cFI">
+                                                    <tableColumn editable="NO" width="268" minWidth="40" maxWidth="1000" id="sMJ-Ww-cFI">
                                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                            <font key="font" metaFont="toolTip"/>
                                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                         </tableHeaderCell>
@@ -65,32 +64,32 @@
                                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                         <prototypeCellViews>
                                                             <tableCellView id="bQD-xg-B71" customClass="GIStashCellView">
-                                                                <rect key="frame" x="0.0" y="0.0" width="300" height="50"/>
+                                                                <rect key="frame" x="10" y="0.0" width="280" height="50"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 <subviews>
-                                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="kMa-x0-GwY">
-                                                                        <rect key="frame" x="160" y="31" width="128" height="14"/>
+                                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kMa-x0-GwY">
+                                                                        <rect key="frame" x="140" y="31" width="128" height="14"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="&lt;DATE&gt;" id="SY5-XT-Mrl">
-                                                                            <font key="font" metaFont="toolTip"/>
+                                                                            <font key="font" metaFont="smallSystem"/>
                                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                         </textFieldCell>
                                                                     </textField>
-                                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="ciy-df-V4O">
+                                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ciy-df-V4O">
                                                                         <rect key="frame" x="12" y="31" width="84" height="14"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;SHA1&gt;" id="3Ul-3u-DTt">
-                                                                            <font key="font" metaFont="toolTip"/>
+                                                                            <font key="font" metaFont="smallSystem"/>
                                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                         </textFieldCell>
                                                                     </textField>
-                                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" id="lq0-ph-7oD">
-                                                                        <rect key="frame" x="12" y="8" width="276" height="15"/>
+                                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lq0-ph-7oD">
+                                                                        <rect key="frame" x="12" y="8" width="256" height="15"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <textFieldCell key="cell" controlSize="small" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;MESSAGE&gt;" id="RFY-3j-XbF">
-                                                                            <font key="font" metaFont="toolTip"/>
+                                                                            <font key="font" metaFont="smallSystem"/>
                                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                         </textFieldCell>
@@ -121,16 +120,16 @@
                                         <autoresizingMask key="autoresizingMask"/>
                                     </scroller>
                                 </scrollView>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="2vp-ts-xnS">
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2vp-ts-xnS">
                                     <rect key="frame" x="68" y="272" width="164" height="18"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="No Stashes" id="zsp-Bw-JJB">
-                                        <font key="font" metaFont="menu" size="14"/>
+                                        <font key="font" metaFont="system" size="14"/>
                                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <button verticalHuggingPriority="750" id="BQO-hB-uyJ">
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BQO-hB-uyJ">
                                     <rect key="frame" x="200" y="5" width="92" height="32"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                     <buttonCell key="cell" type="push" title="Apply" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="tfe-JD-fS9">
@@ -144,7 +143,7 @@ DQ
                                         <action selector="applyStash:" target="-2" id="307-iv-B8n"/>
                                     </connections>
                                 </button>
-                                <button toolTip="Save new stash" verticalHuggingPriority="750" id="OrZ-IL-bI8">
+                                <button toolTip="Save new stash" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OrZ-IL-bI8">
                                     <rect key="frame" x="8" y="5" width="37" height="32"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <buttonCell key="cell" type="push" bezelStyle="rounded" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" inset="2" id="hGa-5V-ckv">
@@ -156,7 +155,7 @@ DQ
                                         <action selector="saveStash:" target="-2" id="cFs-bg-Klk"/>
                                     </connections>
                                 </button>
-                                <button toolTip="Delete selected stash" verticalHuggingPriority="750" id="Nb7-TT-Jjt">
+                                <button toolTip="Delete selected stash" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nb7-TT-Jjt">
                                     <rect key="frame" x="38" y="5" width="37" height="32"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <buttonCell key="cell" type="push" bezelStyle="rounded" image="NSRemoveTemplate" imagePosition="only" alignment="center" borderStyle="border" inset="2" id="REa-ay-zbm">
@@ -172,11 +171,11 @@ CA
                                 </button>
                             </subviews>
                         </customView>
-                        <customView id="h9c-cK-1on">
+                        <customView fixedFrame="YES" id="h9c-cK-1on">
                             <rect key="frame" x="301" y="0.0" width="699" height="500"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
-                                <customView id="z83-ov-Iwr">
+                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z83-ov-Iwr">
                                     <rect key="frame" x="0.0" y="0.0" width="699" height="500"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </customView>
@@ -199,11 +198,11 @@ CA
             </subviews>
             <point key="canvasLocation" x="432" y="321"/>
         </view>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="hZQ-gb-8kq" userLabel="Save View">
+        <customView id="hZQ-gb-8kq" userLabel="Save View">
             <rect key="frame" x="0.0" y="0.0" width="413" height="152"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" id="1Ft-qn-oYj">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Ft-qn-oYj">
                     <rect key="frame" x="93" y="110" width="300" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Optional" drawsBackground="YES" id="68O-Ht-dLG">
@@ -215,7 +214,7 @@ CA
                         <outlet property="delegate" destination="-2" id="Cdj-ac-GxD"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="FMA-JZ-b0c">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FMA-JZ-b0c">
                     <rect key="frame" x="18" y="112" width="69" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Message:" id="VGx-PL-1V0">
@@ -224,7 +223,7 @@ CA
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button id="gS5-gJ-uvH">
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gS5-gJ-uvH">
                     <rect key="frame" x="91" y="62" width="193" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Don't reset the index" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Thq-wo-bXn">
@@ -232,7 +231,7 @@ CA
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                 </button>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="W1J-su-S4N">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W1J-su-S4N">
                     <rect key="frame" x="25" y="83" width="62" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Options:" id="vp5-Mn-0Tn">
@@ -241,7 +240,7 @@ CA
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button id="4M1-G4-Gro">
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4M1-G4-Gro">
                     <rect key="frame" x="91" y="82" width="193" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Include untracked files" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="m4P-xH-uzL">
@@ -249,7 +248,7 @@ CA
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                 </button>
-                <button verticalHuggingPriority="750" id="vJY-XB-liH">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vJY-XB-liH">
                     <rect key="frame" x="277" y="13" width="122" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Save Stash" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="C2U-GN-V9l">
@@ -263,7 +262,7 @@ DQ
                         <action selector="finishModalView:" target="-2" id="wJa-tV-op1"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" id="7wW-wx-tLU">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7wW-wx-tLU">
                     <rect key="frame" x="177" y="13" width="100" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="fFT-El-nrs">
@@ -282,7 +281,7 @@ Gw
         </customView>
     </objects>
     <resources>
-        <image name="NSAddTemplate" width="11" height="11"/>
-        <image name="NSRemoveTemplate" width="11" height="11"/>
+        <image name="NSAddTemplate" width="14" height="13"/>
+        <image name="NSRemoveTemplate" width="14" height="4"/>
     </resources>
 </document>

--- a/GitUpKit/Views/GIAdvancedCommitViewController.m
+++ b/GitUpKit/Views/GIAdvancedCommitViewController.m
@@ -22,12 +22,15 @@
 #import "GIDiffContentsViewController.h"
 #import "GIViewController+Utilities.h"
 
+#import "GIColorView.h"
 #import "GIInterface.h"
 #import "GIWindowController.h"
 #import "XLFacilityMacros.h"
 
 @interface GIAdvancedCommitViewController () <GIDiffFilesViewControllerDelegate, GIDiffContentsViewControllerDelegate>
+@property(nonatomic, weak) IBOutlet GIColorView* workdirHeaderView;
 @property(nonatomic, weak) IBOutlet NSView* workdirFilesView;
+@property(nonatomic, weak) IBOutlet GIColorView* indexHeaderView;
 @property(nonatomic, weak) IBOutlet NSView* indexFilesView;
 @property(nonatomic, weak) IBOutlet NSView* diffContentsView;
 @property(nonatomic, weak) IBOutlet NSButton* unstageButton;
@@ -50,11 +53,15 @@
 - (void)loadView {
   [super loadView];
 
+  _workdirHeaderView.backgroundColor = NSColor.gitUpCommitHeaderBackgroundColor;
+
   _workdirFilesViewController = [[GIDiffFilesViewController alloc] initWithRepository:self.repository];
   _workdirFilesViewController.delegate = self;
   _workdirFilesViewController.allowsMultipleSelection = YES;
   _workdirFilesViewController.emptyLabel = NSLocalizedString(@"No changes in working directory", nil);
   [_workdirFilesView replaceWithView:_workdirFilesViewController.view];
+
+  _indexHeaderView.backgroundColor = NSColor.gitUpCommitHeaderBackgroundColor;
 
   _indexFilesViewController = [[GIDiffFilesViewController alloc] initWithRepository:self.repository];
   _indexFilesViewController.delegate = self;

--- a/GitUpKit/Views/GICommitSplitterViewController.m
+++ b/GitUpKit/Views/GICommitSplitterViewController.m
@@ -22,6 +22,7 @@
 #import "GIDiffContentsViewController.h"
 
 #import "GCCore.h"
+#import "GIColorView.h"
 #import "GIInterface.h"
 #import "GCHistory+Rewrite.h"
 #import "GIWindowController.h"
@@ -31,7 +32,9 @@
 
 @interface GICommitSplitterViewController () <GIDiffFilesViewControllerDelegate, GIDiffContentsViewControllerDelegate>
 @property(nonatomic, weak) IBOutlet NSTextField* titleTextField;
+@property(nonatomic, weak) IBOutlet GIColorView* filesViewNewHeader;
 @property(nonatomic, weak) IBOutlet NSView* filesViewNew;
+@property(nonatomic, weak) IBOutlet GIColorView* filesViewOldHeader;
 @property(nonatomic, weak) IBOutlet NSView* filesViewOld;
 @property(nonatomic, weak) IBOutlet NSView* diffContentsView;
 @property(nonatomic, weak) IBOutlet NSButton* continueButton;
@@ -65,11 +68,15 @@
 - (void)loadView {
   [super loadView];
 
+  _filesViewNewHeader.backgroundColor = NSColor.gitUpCommitHeaderBackgroundColor;
+
   _filesViewControllerNew = [[GIDiffFilesViewController alloc] initWithRepository:self.repository];
   _filesViewControllerNew.delegate = self;
   _filesViewControllerNew.allowsMultipleSelection = YES;
   _filesViewControllerNew.emptyLabel = NSLocalizedString(@"No changes in commit", nil);
   [_filesViewNew replaceWithView:_filesViewControllerNew.view];
+
+  _filesViewOldHeader.backgroundColor = NSColor.gitUpCommitHeaderBackgroundColor;
 
   _filesViewControllerOld = [[GIDiffFilesViewController alloc] initWithRepository:self.repository];
   _filesViewControllerOld.delegate = self;

--- a/GitUpKit/Views/GIStashListViewController.m
+++ b/GitUpKit/Views/GIStashListViewController.m
@@ -114,9 +114,11 @@
 
   if (_stashes.count == 0) {
     _emptyLabel.hidden = NO;
+    _tableView.gridStyleMask = 0;
     [self tableViewSelectionDidChange:nil];  // Work around a bug where -tableViewSelectionDidChange is not called when emptying the table
   } else {
     _emptyLabel.hidden = YES;
+    _tableView.gridStyleMask = NSTableViewSolidHorizontalGridLineMask;
   }
 }
 


### PR DESCRIPTION
This performs the absolute minimum changes in order to not cause visible breakage when running under the new SDK, chiefly by making changes to the app’s table views.

Note that this is not the same as making optimizations for Big Sur’s design; that can (will) come later.

- Fixes display issues in the welcome window.
- Disables inset tables where appropriate (diff contents, sidebar).
- Allow system to determine grid lines in tables.
- Fixes font decoding in updated nibs.
- Fixes some colors rendering as black on 10.13 once built using the new Xcode.

### Screenshots

<details>
<summary>macOS 11</summary>
<img width="1000" alt="11.0 Dark" src="https://user-images.githubusercontent.com/170812/100158040-91fb0600-2e79-11eb-8a17-a6beb9a64a32.png">
<img width="1000" alt="11.0 Light" src="https://user-images.githubusercontent.com/170812/100158042-91fb0600-2e79-11eb-82be-1ddfdc054d4e.png">
</details>

<details>
<summary>macOS 10.15</summary>
<img width="1112" alt="10.15 Light" src="https://user-images.githubusercontent.com/170812/100158072-9b846e00-2e79-11eb-9d06-1768ee304dc5.png">
<img width="1112" alt="10.15 Dark" src="https://user-images.githubusercontent.com/170812/100158075-9b846e00-2e79-11eb-92b2-8549ebd4a850.png">
</details>

<details>
<summary>macOS 10.14</summary>
<img width="1112" alt="10.14 Dark" src="https://user-images.githubusercontent.com/170812/100158104-a3dca900-2e79-11eb-8de9-65041f1a0aaa.png">
<img width="1068" alt="10.14 Light" src="https://user-images.githubusercontent.com/170812/100158108-a4753f80-2e79-11eb-85fe-3c475c1381d6.png">
</details>

<details>
<summary>macOS 10.13</summary>
<img width="1112" alt="10.13 Light" src="https://user-images.githubusercontent.com/170812/100158122-aa6b2080-2e79-11eb-9969-b78396fdf249.png">
</details>

<details>
<summary>macOS 10.12</summary>
<img width="1112" alt="10.12 Light" src="https://user-images.githubusercontent.com/170812/100158136-b0610180-2e79-11eb-815c-6fd3c8ce0888.png">
</details>

<details>
<summary>macOS 10.11</summary>
<img width="1112" alt="10.11 Light" src="https://user-images.githubusercontent.com/170812/100158144-b48d1f00-2e79-11eb-9833-c881eb6fe87f.png">
</details>

<details>
<summary>macOS 10.10</summary>
<img width="1112" alt="10.10 Light" src="https://user-images.githubusercontent.com/170812/100158151-b8b93c80-2e79-11eb-90f5-d8e48da2b79a.png">
</details>

I agree to the contributor agreement, etc etc.