### PR TITLE
Fixes an issue where part of the selected node border would stay visible

### DIFF
--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -57,6 +57,7 @@
 #define kSelectedOffsetX 28
 #define kSelectedCornerRadius 5.0
 #define kSelectedTipHeight 8.0
+#define kSelectedBorderWidth 2.0
 
 #define kContextualMenuOffsetX 10
 #define kContextualMenuOffsetY -10
@@ -74,7 +75,7 @@
 #define CONVERT_X(x) (kSpacingX + (x)*kSpacingX)
 #define CONVERT_Y(y) (kSpacingY + (y)*kSpacingY)
 #define SQUARE(x) ((x) * (x))
-#define SELECTED_NODE_BOUNDS(x, y) NSMakeRect(x - kSpacingX / 2, y - kSelectedLabelMaxHeight / 2, kSelectedLabelMaxWidth + kSpacingX / 2 + 40, kSelectedLabelMaxHeight)
+#define SELECTED_NODE_BOUNDS(x, y) NSMakeRect(x - kSpacingX / 2, y - (kSelectedLabelMaxHeight / 2) - kSelectedBorderWidth, kSelectedLabelMaxWidth + kSpacingX / 2 + 40, kSelectedLabelMaxHeight + (kSelectedBorderWidth * 2))
 #define NODE_LABEL_BOUNDS(x, y) NSMakeRect(x - kSpacingX / 2, y - kSpacingY / 2, kNodeLabelMaxWidth + kSpacingX / 2 + 30, kNodeLabelMaxHeight + kSpacingY / 2)
 #define HEAD_BOUNDS(x, y) NSMakeRect(x - 20, y - 10, 40, 20)
 
@@ -1366,7 +1367,7 @@ static void _DrawSelectedNode(CGContextRef context, CGFloat x, CGFloat y, GINode
   CGContextFillPath(context);
 
   CGContextSetStrokeColorWithColor(context, NSColor.textBackgroundColor.CGColor);
-  CGContextSetLineWidth(context, 2);
+  CGContextSetLineWidth(context, kSelectedBorderWidth);
   CGContextAddPath(context, labelPath);
   CGContextStrokePath(context);
 


### PR DESCRIPTION
Fixes a math issue where the rim of a selected node would still be visible on a retina display under certain conditions.

Image of the issue (squint hard!)

<img width="427" alt="Screen Shot 2020-11-24 at 5 16 39 PM" src="https://user-images.githubusercontent.com/170812/100158459-341aee00-2e7a-11eb-889d-8037085d37a5.png">
