### PR TITLE
Fix trackpad scroll performance in files list of a merge conflict

### DIFF
--- a/GitUpKit/Utilities/GIAppKit.h
+++ b/GitUpKit/Utilities/GIAppKit.h
@@ -31,6 +31,8 @@ extern CGFloat const GIDefaultFontSize;
 
 FOUNDATION_EXPORT CGFloat GIFontSize(void);  // Reads GIUserDefaultKey_FontSize, falling back to GIDefaultFontSize if the user defaults value is not usable.
 
+FOUNDATION_EXPORT void GIPerformOnMainRunLoop(dispatch_block_t block);
+
 @interface NSMutableAttributedString (GIAppKit)
 - (void)appendString:(NSString*)string withAttributes:(NSDictionary*)attributes;
 @end

--- a/GitUpKit/Utilities/GIAppKit.m
+++ b/GitUpKit/Utilities/GIAppKit.m
@@ -45,6 +45,17 @@ CGFloat GIFontSize(void) {
 
 static const void* _associatedObjectCommitKey = &_associatedObjectCommitKey;
 
+void GIPerformOnMainRunLoop(dispatch_block_t block) {
+  // Equivalent to `[[NSRunLoop mainRunLoop] performBlock:]` on 10.12+
+  CFRunLoopRef runLoop = CFRunLoopGetMain();
+  CFRunLoopPerformBlock(runLoop, kCFRunLoopCommonModes, ^{
+    @autoreleasepool {
+      block();
+    }
+  });
+  CFRunLoopWakeUp(runLoop);
+}
+
 @implementation NSMutableAttributedString (GIAppKit)
 
 - (void)appendString:(NSString*)string withAttributes:(NSDictionary*)attributes {

--- a/GitUpKit/Utilities/GIWindowController.m
+++ b/GitUpKit/Utilities/GIWindowController.m
@@ -361,7 +361,11 @@ static void _TimerCallBack(CFRunLoopTimerRef timer, void* info) {
   }];
 
   if (_handler) {
-    dispatch_async(dispatch_get_main_queue(), ^{  // Defer the callback a bit to ensure animations run in parallel to callback execution
+    // Defer the callback a bit to ensure animations run in parallel to callback execution
+    //
+    // Performed on the main run loop instead of the main queue to ensure that the
+    // main queue is serviced during a modal session
+    GIPerformOnMainRunLoop(^{
       _handler(success);
       _handler = NULL;
     });


### PR DESCRIPTION
Fixes a problem where scroll performance would suffer in the files list of the merge conflict resolver for a large commit.

Among other things, AppKit’s responsive scrolling mechanism dispatches to the main dispatch queue. Merge conflict resolution services the AppKit event loop manually to emulate modality, so that the conflict is resolved synchronously without having to redesign half of the Git methods. The AppKit event loop naturally causes the main run-loop to be serviced. Servicing the main run-loop services the main dispatch queue.

However, dispatch queues are not reentrant: if the AppKit event loop is manually serviced from inside a block on the main dispatch queue, the main dispatch queue will not be serviced until the loop completes. Thus, scrolling a table view in the merge conflict resolver would hang until AppKit gives up and falls back to old-style scrolling. This can be avoided by taking care in how the merge conflict resolver opens.

### Before

![before](https://user-images.githubusercontent.com/170812/100170249-376ea380-2e93-11eb-8b5e-bfd00962ea6b.gif)

### After

![after](https://user-images.githubusercontent.com/170812/100170255-3a699400-2e93-11eb-8ee8-abf55d032ad2.gif)
