### PR TITLE
Add command line option to open in new tab

### DIFF
--- a/GitUp/ToolProtocol.h
+++ b/GitUp/ToolProtocol.h
@@ -25,7 +25,11 @@
 #define kToolCommand_Commit "commit"
 #define kToolCommand_Stash "stash"
 
+#define kToolOption_Help "-h"
+#define kToolOption_Tab "-t"
+
 #define kToolDictionaryKey_Command @"command"  // NSString
 #define kToolDictionaryKey_Repository @"repository"  // NSString
+#define kToolDictionaryKey_Option @"option"  // NSString
 
 #define kToolDictionaryKey_Error @"error"  // NSString


### PR DESCRIPTION
Addresses #685. Adds `-t` and `-h` flags to the `gitup` CLI.
`-t` allows for repo to be opened in new tab
`-h` is an alternative to the help command.