### PR TITLE
GitUp. libgit2 main branch after v1.1.1

### DIFF
--- a/GitUp/GitUp.xcodeproj/project.pbxproj
+++ b/GitUp/GitUp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 48;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -14,6 +14,7 @@
 		0A2F488F23683DC90072C6FB /* AuthenticationWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2F488E23683DC90072C6FB /* AuthenticationWindowController.m */; };
 		0A2F489223683DD60072C6FB /* AuthenticationWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A2F489023683DD60072C6FB /* AuthenticationWindowController.xib */; };
 		0A3388BC2353BD630022528D /* WelcomeWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A3388BA2353BD630022528D /* WelcomeWindowController.xib */; };
+		0A4881DC26C7B98D00289CF9 /* Libgit2Origin in Frameworks */ = {isa = PBXBuildFile; productRef = 0A4881DB26C7B98D00289CF9 /* Libgit2Origin */; };
 		0A58CD77237B4F4B00C2BDD0 /* CloneWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A58CD73237B4F4B00C2BDD0 /* CloneWindowController.m */; };
 		0A58CD7A237B4F9600C2BDD0 /* CloneWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A58CD78237B4F9600C2BDD0 /* CloneWindowController.xib */; };
 		0AC8525123A11F2F00479160 /* PreferencesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AC8525023A11F2F00479160 /* PreferencesWindowController.m */; };
@@ -24,7 +25,6 @@
 		A53C6D0C1E61A9CF0070387E /* FontSizeTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = A53C6D0B1E61A9CF0070387E /* FontSizeTransformer.m */; };
 		DBBEE685256B0A0200F96DAF /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = DBBEE684256B0A0200F96DAF /* libiconv.tbd */; };
 		DBBEE688256B0A0A00F96DAF /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = DBBEE687256B0A0A00F96DAF /* libz.tbd */; };
-		DBBEE6C0256B0B2100F96DAF /* libgit2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DB0D250E256738F600E6F48A /* libgit2.a */; };
 		E21739F71A5080DD00EC6777 /* DocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = E21739F61A5080DD00EC6777 /* DocumentController.m */; };
 		E21DCAEB1B253847006424E8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E21DCAEA1B253847006424E8 /* main.m */; };
 		E21DCAF31B253919006424E8 /* gitup in Copy Tool */ = {isa = PBXBuildFile; fileRef = E21DCAE81B253847006424E8 /* gitup */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -176,7 +176,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DBBEE685256B0A0200F96DAF /* libiconv.tbd in Frameworks */,
-				DBBEE6C0256B0B2100F96DAF /* libgit2.a in Frameworks */,
+				0A4881DC26C7B98D00289CF9 /* Libgit2Origin in Frameworks */,
 				DBBEE688256B0A0A00F96DAF /* libz.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -335,6 +335,9 @@
 				DBBEE6BF256B0B1C00F96DAF /* PBXTargetDependency */,
 			);
 			name = Tool;
+			packageProductDependencies = (
+				0A4881DB26C7B98D00289CF9 /* Libgit2Origin */,
+			);
 			productName = Tool;
 			productReference = E21DCAE81B253847006424E8 /* gitup */;
 			productType = "com.apple.product-type.tool";
@@ -642,7 +645,10 @@
 				CODE_SIGN_ENTITLEMENTS = Application/GitUp.entitlements;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/Third-Party";
 				INFOPLIST_FILE = Application/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
 				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "co.gitup.mac-debug";
 				PRODUCT_NAME = GitUp;
@@ -658,7 +664,10 @@
 				CODE_SIGN_ENTITLEMENTS = Application/GitUp.entitlements;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/Third-Party";
 				INFOPLIST_FILE = Application/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
 				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = co.gitup.mac;
 				PRODUCT_NAME = GitUp;
@@ -696,6 +705,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		0A4881DB26C7B98D00289CF9 /* Libgit2Origin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Libgit2Origin;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = E2C338A319F8562F00063D95 /* Project object */;
 }

--- a/GitUpKit/Core/GCHistory.m
+++ b/GitUpKit/Core/GCHistory.m
@@ -821,13 +821,10 @@ static const void* _associatedObjectUpstreamNameKey = &_associatedObjectUpstream
             XLOG_DEBUG_CHECK(headBranch == nil);
             headBranch = (GCHistoryLocalBranch*)referenceObject;
           }
-          NSString* remoteName = [config objectForKey:[NSString stringWithFormat:@"branch.%s.remote", git_reference_shorthand(reference)]];
-          NSString* mergeName = [config objectForKey:[NSString stringWithFormat:@"branch.%s.merge", git_reference_shorthand(reference)]];
-          if (remoteName.length && mergeName.length) {
-            int status = gitup_branch_upstream_name_from_merge_remote_names(&upstreamName, self.private, remoteName.UTF8String, mergeName.UTF8String);
-            if ((status != GIT_OK) && (status != GIT_ENOTFOUND)) {
-              LOG_LIBGIT2_ERROR(status);  // Don't fail because of corrupted config
-            }
+          
+          int status = gitup_branch_upstream_name(&upstreamName, self.private, git_reference_name(reference));          
+          if ((status != GIT_OK) && (status != GIT_ENOTFOUND)) {
+            LOG_LIBGIT2_ERROR(status);  // Don't fail because of corrupted config
           }
         } else if (git_reference_is_remote(reference)) {
           referenceObject = [[GCHistoryRemoteBranch alloc] initWithRepository:self reference:reference];

--- a/GitUpKit/Core/GCHistory.m
+++ b/GitUpKit/Core/GCHistory.m
@@ -752,7 +752,7 @@ static const void* _associatedObjectUpstreamNameKey = &_associatedObjectUpstream
           CALL_LIBGIT2_FUNCTION_GOTO(cleanup, git_commit_lookup, &headCommit, self.private, resolvedReference.resolvedTarget);
           headTip = [[GCCommit alloc] initWithRepository:self commit:headCommit];
           if (resolvedReference != serializedReference) {
-            CALL_LIBGIT2_FUNCTION_GOTO(cleanup, git_reference_create_virtual, &headReference, self.private, resolvedReference.name, resolvedReference.resolvedTarget);
+            CALL_LIBGIT2_FUNCTION_GOTO(cleanup, gitup_reference_create_virtual, &headReference, self.private, resolvedReference.name, resolvedReference.resolvedTarget);
           }
         }
         break;
@@ -824,7 +824,7 @@ static const void* _associatedObjectUpstreamNameKey = &_associatedObjectUpstream
           NSString* remoteName = [config objectForKey:[NSString stringWithFormat:@"branch.%s.remote", git_reference_shorthand(reference)]];
           NSString* mergeName = [config objectForKey:[NSString stringWithFormat:@"branch.%s.merge", git_reference_shorthand(reference)]];
           if (remoteName.length && mergeName.length) {
-            int status = git_branch_upstream_name_from_merge_remote_names(&upstreamName, self.private, remoteName.UTF8String, mergeName.UTF8String);
+            int status = gitup_branch_upstream_name_from_merge_remote_names(&upstreamName, self.private, remoteName.UTF8String, mergeName.UTF8String);
             if ((status != GIT_OK) && (status != GIT_ENOTFOUND)) {
               LOG_LIBGIT2_ERROR(status);  // Don't fail because of corrupted config
             }
@@ -873,11 +873,11 @@ static const void* _associatedObjectUpstreamNameKey = &_associatedObjectUpstream
       git_reference* reference = NULL;
       switch (serializedReference.type) {
         case GIT_REF_OID:
-          CALL_LIBGIT2_FUNCTION_GOTO(cleanup, git_reference_create_virtual, &reference, self.private, serializedReference.name, serializedReference.directTarget);
+          CALL_LIBGIT2_FUNCTION_GOTO(cleanup, gitup_reference_create_virtual, &reference, self.private, serializedReference.name, serializedReference.directTarget);
           break;
 
         case GIT_REF_SYMBOLIC:
-          CALL_LIBGIT2_FUNCTION_GOTO(cleanup, git_reference_symbolic_create_virtual, &reference, self.private, serializedReference.name, serializedReference.symbolicTarget);
+          CALL_LIBGIT2_FUNCTION_GOTO(cleanup, gitup_reference_symbolic_create_virtual, &reference, self.private, serializedReference.name, serializedReference.symbolicTarget);
           break;
 
         default:

--- a/GitUpKit/Core/GCPrivate.h
+++ b/GitUpKit/Core/GCPrivate.h
@@ -19,6 +19,7 @@
 #pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wpadded"
 #import <git2.h>
+#import <gitup_extensions.h>
 #import <git2/transaction.h>
 #import <git2/sys/commit.h>
 #import <git2/sys/odb_backend.h>

--- a/GitUpKit/Core/GCRemote.m
+++ b/GitUpKit/Core/GCRemote.m
@@ -446,8 +446,8 @@ cleanup:
   git_buf mergeBuffer = {0};
   git_remote* remote = NULL;
 
-  CALL_LIBGIT2_FUNCTION_GOTO(cleanup, git_branch_upstream_remote, &remoteBuffer, self.private, name);
-  CALL_LIBGIT2_FUNCTION_GOTO(cleanup, git_branch_upstream_merge, &mergeBuffer, self.private, name);
+  CALL_LIBGIT2_FUNCTION_GOTO(cleanup, gitup_branch_upstream_remote, &remoteBuffer, self.private, name);
+  CALL_LIBGIT2_FUNCTION_GOTO(cleanup, gitup_branch_upstream_merge, &mergeBuffer, self.private, name);
   CALL_LIBGIT2_FUNCTION_GOTO(cleanup, git_remote_lookup, &remote, self.private, remoteBuffer.ptr);
   if (![self _pushSourceReference:name toRemote:remote destinationReference:mergeBuffer.ptr force:force error:error]) {
     goto cleanup;
@@ -634,11 +634,15 @@ cleanup:
 - (BOOL)cloneUsingRemote:(GCRemote*)remote recursive:(BOOL)recursive error:(NSError**)error {
   [self willStartRemoteTransferWithURL:remote.URL];
 
-  git_fetch_options fetchOptions = GIT_FETCH_OPTIONS_INIT;
-  [self setRemoteCallbacks:&fetchOptions.callbacks];
-  git_checkout_options checkoutOptions = GIT_CHECKOUT_OPTIONS_INIT;
-  checkoutOptions.checkout_strategy = GIT_CHECKOUT_SAFE;
-  int status = git_clone_into(self.private, remote.private, &fetchOptions, &checkoutOptions, NULL);  // This will fail if the repository is not empty
+//  git_fetch_options fetchOptions = GIT_FETCH_OPTIONS_INIT;
+//  [self setRemoteCallbacks:&fetchOptions.callbacks];
+//  git_checkout_options checkoutOptions = GIT_CHECKOUT_OPTIONS_INIT;
+//  checkoutOptions.checkout_strategy = GIT_CHECKOUT_SAFE;
+  
+  git_clone_options cloneOptions = GIT_CLONE_OPTIONS_INIT;
+  [self setRemoteCallbacks:&(cloneOptions.fetch_opts.callbacks)];
+  cloneOptions.checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
+  int status = gitup_clone_into_old(self.private, remote.private, &(cloneOptions.fetch_opts), &(cloneOptions.checkout_opts), NULL);  // This will fail if the repository is not empty
 
   [self didFinishRemoteTransferWithURL:remote.URL success:(status == GIT_OK)];
   CHECK_LIBGIT2_FUNCTION_CALL(return NO, status, == GIT_OK);

--- a/GitUpKit/Core/GCRepository+Config.m
+++ b/GitUpKit/Core/GCRepository+Config.m
@@ -93,7 +93,7 @@ static inline int _FindConfig(git_repository* repo, GCConfigLevel level, git_buf
     case kGCConfigLevel_Global:
       return git_config_find_global(buffer);
     case kGCConfigLevel_Local:
-      return git_config_find_local(repo, buffer);
+      return gitup_config_find_local(repo, buffer);
   }
   return GIT_ERROR;
 }

--- a/GitUpKit/Core/GCRepository+Config.m
+++ b/GitUpKit/Core/GCRepository+Config.m
@@ -93,7 +93,7 @@ static inline int _FindConfig(git_repository* repo, GCConfigLevel level, git_buf
     case kGCConfigLevel_Global:
       return git_config_find_global(buffer);
     case kGCConfigLevel_Local:
-      return gitup_config_find_local(repo, buffer);
+      return gitup_repository_local_config_path(buffer, repo);
   }
   return GIT_ERROR;
 }

--- a/GitUpKit/Core/GCSQLiteRepository.m
+++ b/GitUpKit/Core/GCSQLiteRepository.m
@@ -911,10 +911,10 @@ cleanup:
 
   CALL_LIBGIT2_FUNCTION_GOTO(cleanup, git_config_new, &config);
   if (configPath) {
-    CALL_LIBGIT2_FUNCTION_GOTO(cleanup, git_config_add_file_ondisk, config, configPath.fileSystemRepresentation, GIT_CONFIG_LEVEL_LOCAL, false);
+    CALL_LIBGIT2_FUNCTION_GOTO(cleanup, git_config_add_file_ondisk, config, configPath.fileSystemRepresentation, GIT_CONFIG_LEVEL_LOCAL, repository, false);
   } else {
     _configPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
-    CALL_LIBGIT2_FUNCTION_GOTO(cleanup, git_config_add_file_ondisk, config, _configPath.fileSystemRepresentation, GIT_CONFIG_LEVEL_LOCAL, false);
+    CALL_LIBGIT2_FUNCTION_GOTO(cleanup, git_config_add_file_ondisk, config, _configPath.fileSystemRepresentation, GIT_CONFIG_LEVEL_LOCAL, repository, false);
   }
   git_repository_set_config(repository, config);
 

--- a/GitUpKit/Core/GCSubmodule.m
+++ b/GitUpKit/Core/GCSubmodule.m
@@ -237,7 +237,7 @@ cleanup:
 - (NSArray*)listSubmodules:(NSError**)error {
   NSMutableArray* submodules = [[NSMutableArray alloc] init];
   int status = git_submodule_foreach_block(self.private, ^int(git_submodule* submodule, const char* name) {  // This calls git_submodule_reload_all(false)
-    gitup_submodule_retain(submodule);
+    gitup_submodule_dup(submodule);
     [submodules addObject:[[GCSubmodule alloc] initWithRepository:self submodule:submodule]];
     return GIT_OK;
   });

--- a/GitUpKit/Core/GCSubmodule.m
+++ b/GitUpKit/Core/GCSubmodule.m
@@ -237,7 +237,7 @@ cleanup:
 - (NSArray*)listSubmodules:(NSError**)error {
   NSMutableArray* submodules = [[NSMutableArray alloc] init];
   int status = git_submodule_foreach_block(self.private, ^int(git_submodule* submodule, const char* name) {  // This calls git_submodule_reload_all(false)
-    git_submodule_retain(submodule);
+    gitup_submodule_retain(submodule);
     [submodules addObject:[[GCSubmodule alloc] initWithRepository:self submodule:submodule]];
     return GIT_OK;
   });
@@ -275,7 +275,7 @@ cleanup:
         NSString* modulePath = [[self.repositoryPath stringByAppendingPathComponent:@"modules"] stringByAppendingPathComponent:submodule.path];
         git_repository* moduleRepository;
         CALL_LIBGIT2_FUNCTION_GOTO(cleanup, git_repository_open, &moduleRepository, modulePath.fileSystemRepresentation);  // If the working directory is gone, then we must have a module around, otherwise the submodule was not initialized
-        status = git_repository_update_gitlink(moduleRepository, true);  // This re-creates the workdir and its parent directories and the gitlink inside
+        status = gitup_repository_update_gitlink(moduleRepository, true);  // This re-creates the workdir and its parent directories and the gitlink inside
         git_repository_free(moduleRepository);
         CHECK_LIBGIT2_FUNCTION_CALL(goto cleanup, status, == GIT_OK);
         status = git_submodule_open(&subRepository, submodule.private);

--- a/GitUpKit/GitUpKit.xcodeproj/project.pbxproj
+++ b/GitUpKit/GitUpKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A1DA51E265806140041E737 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A1DA51D265806140041E737 /* Security.framework */; };
+		0A4881D726C7B4CF00289CF9 /* Libgit2Origin in Frameworks */ = {isa = PBXBuildFile; productRef = 0A4881D626C7B4CF00289CF9 /* Libgit2Origin */; };
 		0AC8525923A122C400479160 /* GILaunchServicesLocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AC8525723A122C400479160 /* GILaunchServicesLocator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0AC8525A23A122C400479160 /* GILaunchServicesLocator.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AC8525823A122C400479160 /* GILaunchServicesLocator.m */; };
 		1DADC0DA25A25D54008C2C35 /* libsqlite3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBBEE637256B08D300F96DAF /* libsqlite3.xcframework */; };
@@ -22,10 +24,8 @@
 		DB7CBCA225762721001185AA /* GICustomToolbarItem.h in Headers */ = {isa = PBXBuildFile; fileRef = DB7CBCA025762721001185AA /* GICustomToolbarItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB7CBCA325762721001185AA /* GICustomToolbarItem.m in Sources */ = {isa = PBXBuildFile; fileRef = DB7CBCA125762721001185AA /* GICustomToolbarItem.m */; };
 		DBBEE638256B08D300F96DAF /* libsqlite3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBBEE637256B08D300F96DAF /* libsqlite3.xcframework */; };
-		DBBEE643256B092400F96DAF /* libgit2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E21752F61B914EC000BE234A /* libgit2.a */; };
 		DBBEE64D256B094000F96DAF /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = DBBEE64C256B094000F96DAF /* libz.tbd */; };
 		DBBEE655256B095000F96DAF /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = DBBEE654256B095000F96DAF /* libiconv.tbd */; };
-		DBBEE669256B098A00F96DAF /* libgit2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E21752F61B914EC000BE234A /* libgit2.a */; };
 		DBBEE66A256B099300F96DAF /* libsqlite3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBBEE637256B08D300F96DAF /* libsqlite3.xcframework */; };
 		DBBEE674256B09B500F96DAF /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = DBBEE654256B095000F96DAF /* libiconv.tbd */; };
 		DBBEE675256B09B500F96DAF /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = DBBEE64C256B094000F96DAF /* libz.tbd */; };
@@ -43,7 +43,6 @@
 		E2146C8F1A57F3BC00F4550B /* GCObject.m in Sources */ = {isa = PBXBuildFile; fileRef = E2146C8D1A57F3BC00F4550B /* GCObject.m */; };
 		E21739F41A4FE39E00EC6777 /* GCFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = E21739F21A4FE39E00EC6777 /* GCFunctions.m */; };
 		E21739FF1A51FA6200EC6777 /* GCSubmodule.m in Sources */ = {isa = PBXBuildFile; fileRef = E21739FD1A51FA6200EC6777 /* GCSubmodule.m */; };
-		E21753091B91516600BE234A /* libgit2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E21752F61B914EC000BE234A /* libgit2.a */; };
 		E21753371B91623200BE234A /* XLASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = E267E2AD1B84F27800BAB377 /* XLASLLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E21753381B91623200BE234A /* XLCallbackLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = E267E2AF1B84F27800BAB377 /* XLCallbackLogger.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E21753391B91623200BE234A /* XLFacility.h in Headers */ = {isa = PBXBuildFile; fileRef = E267E2B11B84F27800BAB377 /* XLFacility.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -382,38 +381,10 @@
 		E2FEED4A1AEAA75F00CBED80 /* GCCommitDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = E2FEED451AEAA6AD00CBED80 /* GCCommitDatabase.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		DBBFFF4C256736FF00AE139C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E21752ED1B914EC000BE234A /* libgit2.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = E2174BD41B91240400BE234A;
-			remoteInfo = libgit2;
-		};
-		DBBFFF502567371C00AE139C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E21752ED1B914EC000BE234A /* libgit2.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = E2174BD41B91240400BE234A;
-			remoteInfo = libgit2;
-		};
-		E21752F51B914EC000BE234A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E21752ED1B914EC000BE234A /* libgit2.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = E2174BD51B91240400BE234A;
-			remoteInfo = libgit2;
-		};
-		E217530A1B91517300BE234A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E21752ED1B914EC000BE234A /* libgit2.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = E2174BD41B91240400BE234A;
-			remoteInfo = libgit2;
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXFileReference section */
+		0A1DA512265805C30041E737 /* libcommonCrypto.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcommonCrypto.tbd; path = usr/lib/system/libcommonCrypto.tbd; sourceTree = SDKROOT; };
+		0A1DA51D265806140041E737 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		0A4881D326C7B49700289CF9 /* libgit2 */ = {isa = PBXFileReference; lastKnownFileType = folder; name = libgit2; path = "Third-Party/libgit2"; sourceTree = "<group>"; };
 		0AC8525723A122C400479160 /* GILaunchServicesLocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GILaunchServicesLocator.h; sourceTree = "<group>"; };
 		0AC8525823A122C400479160 /* GILaunchServicesLocator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GILaunchServicesLocator.m; sourceTree = "<group>"; };
 		1DF371CB22F5262300EF7BD9 /* GCLiveRepository+Utilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "GCLiveRepository+Utilities.h"; sourceTree = "<group>"; };
@@ -447,7 +418,6 @@
 		E21739F21A4FE39E00EC6777 /* GCFunctions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCFunctions.m; sourceTree = "<group>"; };
 		E21739FC1A51FA6200EC6777 /* GCSubmodule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCSubmodule.h; sourceTree = "<group>"; };
 		E21739FD1A51FA6200EC6777 /* GCSubmodule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCSubmodule.m; sourceTree = "<group>"; };
-		E21752ED1B914EC000BE234A /* libgit2.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = libgit2.xcodeproj; path = "Third-Party/libgit2.xcodeproj"; sourceTree = "<group>"; };
 		E217531B1B91613300BE234A /* GitUpKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GitUpKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E218A5881A566F6A00DFF1DF /* GCReferenceTransform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCReferenceTransform.h; sourceTree = "<group>"; };
 		E218A5891A566F6A00DFF1DF /* GCReferenceTransform.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCReferenceTransform.m; sourceTree = "<group>"; };
@@ -653,7 +623,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				DBBEE674256B09B500F96DAF /* libiconv.tbd in Frameworks */,
-				DBBEE669256B098A00F96DAF /* libgit2.a in Frameworks */,
 				DBBEE66A256B099300F96DAF /* libsqlite3.xcframework in Frameworks */,
 				DBBEE675256B09B500F96DAF /* libz.tbd in Frameworks */,
 			);
@@ -663,10 +632,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A1DA51E265806140041E737 /* Security.framework in Frameworks */,
 				DBBEE655256B095000F96DAF /* libiconv.tbd in Frameworks */,
-				DBBEE643256B092400F96DAF /* libgit2.a in Frameworks */,
-				DBBEE638256B08D300F96DAF /* libsqlite3.xcframework in Frameworks */,
+				0A4881D726C7B4CF00289CF9 /* Libgit2Origin in Frameworks */,
 				DBBEE64D256B094000F96DAF /* libz.tbd in Frameworks */,
+				DBBEE638256B08D300F96DAF /* libsqlite3.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -675,7 +645,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				1DADC0DE25A25D5D008C2C35 /* libiconv.tbd in Frameworks */,
-				E21753091B91516600BE234A /* libgit2.a in Frameworks */,
 				1DADC0DA25A25D54008C2C35 /* libsqlite3.xcframework in Frameworks */,
 				1DADC0E225A25D63008C2C35 /* libz.tbd in Frameworks */,
 			);
@@ -687,19 +656,13 @@
 		DBBFFF4E2567370900AE139C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				0A1DA51D265806140041E737 /* Security.framework */,
+				0A1DA512265805C30041E737 /* libcommonCrypto.tbd */,
 				DBBEE654256B095000F96DAF /* libiconv.tbd */,
 				DBBEE637256B08D300F96DAF /* libsqlite3.xcframework */,
 				DBBEE64C256B094000F96DAF /* libz.tbd */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		E21752EE1B914EC000BE234A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				E21752F61B914EC000BE234A /* libgit2.a */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		E21A88DC1A942CCA00255AC3 /* Components */ = {
@@ -867,7 +830,7 @@
 		E2C338A219F8562F00063D95 = {
 			isa = PBXGroup;
 			children = (
-				E21752ED1B914EC000BE234A /* libgit2.xcodeproj */,
+				0A4881D326C7B49700289CF9 /* libgit2 */,
 				E267E1AA1B84D6C500BAB377 /* GitUpKit.h */,
 				E267E1AC1B84D6C500BAB377 /* Info.plist */,
 				E22941E61AC11F56000A83AF /* Views */,
@@ -1202,7 +1165,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				DBBFFF512567371C00AE139C /* PBXTargetDependency */,
 			);
 			name = "GitUpKit (iOS)";
 			productName = "GitUpKit (iOS)";
@@ -1222,9 +1184,11 @@
 			buildRules = (
 			);
 			dependencies = (
-				DBBFFF4D256736FF00AE139C /* PBXTargetDependency */,
 			);
 			name = "GitUpKit (macOS)";
+			packageProductDependencies = (
+				0A4881D626C7B4CF00289CF9 /* Libgit2Origin */,
+			);
 			productName = GitUpKit;
 			productReference = E267E1A81B84D6C500BAB377 /* GitUpKit.framework */;
 			productType = "com.apple.product-type.framework";
@@ -1239,7 +1203,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				E217530B1B91517300BE234A /* PBXTargetDependency */,
 			);
 			name = Tests;
 			productName = GitUpTests;
@@ -1280,12 +1243,6 @@
 			mainGroup = E2C338A219F8562F00063D95;
 			productRefGroup = E2C338AC19F8562F00063D95 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = E21752EE1B914EC000BE234A /* Products */;
-					ProjectRef = E21752ED1B914EC000BE234A /* libgit2.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				E267E1A71B84D6C500BAB377 /* GitUpKit (macOS) */,
@@ -1294,16 +1251,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		E21752F61B914EC000BE234A /* libgit2.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libgit2.a;
-			remoteRef = E21752F51B914EC000BE234A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		E267E1A61B84D6C500BAB377 /* Resources */ = {
@@ -1592,24 +1539,6 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
-/* Begin PBXTargetDependency section */
-		DBBFFF4D256736FF00AE139C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = libgit2;
-			targetProxy = DBBFFF4C256736FF00AE139C /* PBXContainerItemProxy */;
-		};
-		DBBFFF512567371C00AE139C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = libgit2;
-			targetProxy = DBBFFF502567371C00AE139C /* PBXContainerItemProxy */;
-		};
-		E217530B1B91517300BE234A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = libgit2;
-			targetProxy = E217530A1B91517300BE234A /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
 /* Begin PBXVariantGroup section */
 		E21A88F81A97173300255AC3 /* GIUnifiedReflogViewController.xib */ = {
 			isa = PBXVariantGroup;
@@ -1803,6 +1732,10 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)/usr/lib/system",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = co.gitup.kit;
 				PRODUCT_NAME = GitUpKit;
 				SDKROOT = macosx;
@@ -1822,6 +1755,10 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)/usr/lib/system",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = co.gitup.kit;
 				PRODUCT_NAME = GitUpKit;
@@ -1918,6 +1855,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		0A4881D626C7B4CF00289CF9 /* Libgit2Origin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Libgit2Origin;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = E2C338A319F8562F00063D95 /* Project object */;
 }


### PR DESCRIPTION
This PR updates libgit2 to version v1.1.1 ( actually, a main branch after version 1.1.1 ).
https://github.com/libgit2/libgit2/commit/e65229ee972c113413eeca77853213352129bd47

The related branch with required libgit2 updates can be found at
https://github.com/lolgear/libgit2/tree/gitup_libgit2_main_after_v1.1.1

I would like to open a PR for git-up/libgit2 fork, but it requires to update libgit2 branch.