### PR TITLE
Don't force Sparkle updates in background

### DIFF
--- a/GitUp/Application/AboutWindowController.h
+++ b/GitUp/Application/AboutWindowController.h
@@ -10,7 +10,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface AboutWindowController : NSWindowController
-@property(assign, nonatomic, readwrite) BOOL updatePending;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/GitUp/Application/AboutWindowController.m
+++ b/GitUp/Application/AboutWindowController.m
@@ -20,19 +20,15 @@
 
 - (void)windowDidLoad {
   [super windowDidLoad];
-  [self populateWithDataWhenUpdateIsPending:self.updatePending];
+  [self configureUI];
 }
 
-- (void)populateWithDataWhenUpdateIsPending:(BOOL)updatePending {
+- (void)configureUI {
   NSString* version = nil;
 #if DEBUG
   version = @"DEBUG";
 #else
-  if (updatePending) {
-    version = NSLocalizedString(@"Update Pending", nil);
-  } else {
-    version = [NSString stringWithFormat:NSLocalizedString(@"Version %@ (%@)", nil), [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"], [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"]];
-  }
+  version = [NSString stringWithFormat:NSLocalizedString(@"Version %@ (%@)", nil), [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"], [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"]];
 #endif
   self.versionTextField.stringValue = version;
   self.copyrightTextField.stringValue = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSHumanReadableCopyright"];

--- a/GitUp/Application/AppDelegate.m
+++ b/GitUp/Application/AppDelegate.m
@@ -51,7 +51,6 @@
 
 @implementation AppDelegate {
   SUUpdater* _updater;
-  BOOL _updatePending;
   BOOL _manualCheck;
 
   CFMessagePortRef _messagePort;
@@ -212,9 +211,8 @@
   if (![[NSUserDefaults standardUserDefaults] boolForKey:kUserDefaultsKey_DisableSparkle]) {
     _updater = [SUUpdater sharedUpdater];
     _updater.delegate = self;
-    _updater.automaticallyChecksForUpdates = NO;
+    _updater.automaticallyChecksForUpdates = YES;
     _updater.sendsSystemProfile = NO;
-    _updater.automaticallyDownloadsUpdates = YES;
 
     _manualCheck = NO;
     [_updater checkForUpdatesInBackground];
@@ -382,9 +380,9 @@ static CFDataRef _MessagePortCallBack(CFMessagePortRef local, SInt32 msgid, CFDa
 
 #pragma mark - Actions
 
-- (BOOL)validateUserInterfaceItem:(id<NSValidatedUserInterfaceItem>)anItem {
-  if (anItem.action == @selector(checkForUpdates:)) {
-    return _updater && !_updatePending && ![_updater updateInProgress];
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem {
+  if (menuItem.action == @selector(checkForUpdates:)) {
+    return [_updater validateMenuItem:menuItem];
   }
   return YES;
 }
@@ -406,7 +404,6 @@ static CFDataRef _MessagePortCallBack(CFMessagePortRef local, SInt32 msgid, CFDa
 }
 
 - (IBAction)showAboutPanel:(id)sender {
-  self.aboutWindowController.updatePending = _updatePending;
   [self.aboutWindowController showWindow:nil];
 }
 
@@ -562,14 +559,6 @@ static CFDataRef _MessagePortCallBack(CFMessagePortRef local, SInt32 msgid, CFDa
 - (void)updater:(SUUpdater*)updater didFindValidUpdate:(SUAppcastItem*)item {
   NSString* channel = [[NSUserDefaults standardUserDefaults] stringForKey:kUserDefaultsKey_ReleaseChannel];
   XLOG_INFO(@"Did find app update on channel '%@' for version %@", channel, item.versionString);
-  if (_manualCheck) {
-    NSAlert* alert = [[NSAlert alloc] init];
-    alert.messageText = NSLocalizedString(@"A GitUp update is available!", nil);
-    alert.informativeText = NSLocalizedString(@"The update will download automatically in the background and be installed when you quit GitUp.", nil);
-    [alert addButtonWithTitle:NSLocalizedString(@"OK", nil)];
-    alert.type = kGIAlertType_Note;
-    [alert runModal];
-  }
 }
 
 - (void)updaterDidNotFindUpdate:(SUUpdater*)updater {
@@ -593,14 +582,6 @@ static CFDataRef _MessagePortCallBack(CFMessagePortRef local, SInt32 msgid, CFDa
 
 - (void)updater:(SUUpdater*)updater willInstallUpdate:(SUAppcastItem*)item {
   XLOG_INFO(@"Installing app update for version %@", item.versionString);
-}
-
-- (void)updater:(SUUpdater*)updater willInstallUpdateOnQuit:(SUAppcastItem*)item immediateInstallationInvocation:(NSInvocation*)invocation {
-  XLOG_INFO(@"Will install app update for version %@ on quit", item.versionString);
-  _updatePending = YES;
-  [self _showNotificationWithTitle:NSLocalizedString(@"Update Available", nil)
-                            action:NULL
-                           message:NSLocalizedString(@"Relaunch GitUp to update to version %@ (%@).", nil), item.displayVersionString, item.versionString];
 }
 
 @end


### PR DESCRIPTION
Addresses #738. We'll prompt the user with the option of installing the latest updates.

Reasons for this change:
- When deprecating older versions of macOS we want to be able to let existing software to keep working without forcing an update. This allows GitUp to move to newer versions of macOS as necessary.
- We'll still allow automatic updates to happen if the user opts in. We'll continue to check on launch for a new version regardless.
- We don't create updates frequenly so it shouldn't be spammy