### PR TITLE
Remove displayMode from title view on tab

### DIFF
--- a/GitUp/Application/WindowController.m
+++ b/GitUp/Application/WindowController.m
@@ -28,15 +28,6 @@
   self.window.delegate = self;
 }
 
-- (NSString*)windowTitleForDocumentDisplayName:(NSString*)displayName {
-  NSString* displayMode = NSLocalizedString([(Document*)self.document windowMode], nil);
-  if (@available(macOS 11, *)) {
-    return [NSString stringWithFormat:@"%@ — %@", displayName, displayMode];
-  } else {
-    return [NSString stringWithFormat:@"%@ • %@", displayName, displayMode];
-  }
-}
-
 - (NSUndoManager*)windowWillReturnUndoManager:(NSWindow*)window {
   return [(Document*)self.document undoManager];
 }


### PR DESCRIPTION
This fixes the issue #742 by removing the `displayMode` from the title view on the tabs and just leaving the repo name.

| Previous | Updated |
|--------- |--------- |
|<img width="1005" alt="GitUp header view showing one tab with the title: GitUp — Map" src="https://user-images.githubusercontent.com/32823124/181420667-69fe96b5-601d-4ff7-b061-5e81c6f43030.png">|<img width="1002" alt="GitUp header view showing one tab with the title: GitUp" src="https://user-images.githubusercontent.com/32823124/181420765-5f4d4098-f706-4e93-a5b0-7207e2cb34e4.png">|



I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT