### PR TITLE
Modal dialogs no longer have focus with macOS Ventura.

### DIFF
--- a/GitUpKit/Utilities/GIViewController.m
+++ b/GitUpKit/Utilities/GIViewController.m
@@ -235,9 +235,7 @@
     NSButton* defaultButton = [alert addButtonWithTitle:button];
     if (type == kGIAlertType_Danger) {
       defaultButton.keyEquivalent = @"";
-    }
-    if (@available(macOS 11, *)) {
-      if (type == kGIAlertType_Stop || type == kGIAlertType_Danger) {
+      if (@available(macOS 11, *)) {
         defaultButton.hasDestructiveAction = YES;
       }
     }


### PR DESCRIPTION
Addresses an issue where macOS Ventura will disable the return key if `hasDestructiveAction` is `YES`.

Fixes #879.