### PR TITLE
Fix crash when hitting return in search results when nothing is selected

### DIFF
--- a/GitUpKit/Components/GICommitListViewController.m
+++ b/GitUpKit/Components/GICommitListViewController.m
@@ -247,7 +247,9 @@
 
 - (void)smartCheckoutSelectedCommit {
   GCHistoryCommit* commit = [self selectedCommit];
-  [self.repository smartCheckoutCommit:commit window:self.view.window];
+  if (commit) {
+    [self.repository smartCheckoutCommit:commit window:self.view.window];
+  }
 }
 
 - (void)keyDown:(NSEvent*)event {


### PR DESCRIPTION
When we apply a search result (hit return on one), this triggers a change that ultimately deselects all items in the search table view. This means we still have first responder status but have nothing selected. If we hit return now we will try and validate a nil commit and we can't compare nil commits. The solution is to verify that we have a valid commit selection.

Fixes #883