### PR TITLE
Add key navigation between index and workdir files

### DIFF
--- a/GitUpKit/Interface/GIConstants.h
+++ b/GitUpKit/Interface/GIConstants.h
@@ -31,4 +31,4 @@ typedef NS_ENUM(unsigned short, GIKeyCode) {
   kGIKeyCode_Delete = 0x33
 };
 
-static const long kGIKeyModifiersAll = NSEventModifierFlagShift | NSEventModifierFlagControl | NSEventModifierFlagCommand | NSEventModifierFlagOption;
+static const NSEventModifierFlags kGIKeyModifiersAll = NSEventModifierFlagShift | NSEventModifierFlagControl | NSEventModifierFlagCommand | NSEventModifierFlagOption;

--- a/GitUpKit/Interface/GIConstants.h
+++ b/GitUpKit/Interface/GIConstants.h
@@ -13,6 +13,7 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#import <AppKit/NSEvent.h>
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(unsigned short, GIKeyCode) {
@@ -29,3 +30,5 @@ typedef NS_ENUM(unsigned short, GIKeyCode) {
   kGIKeyCode_Return = 0x24,
   kGIKeyCode_Delete = 0x33
 };
+
+static const long kGIKeyModifiersAll = NSEventModifierFlagShift | NSEventModifierFlagControl | NSEventModifierFlagCommand | NSEventModifierFlagOption;

--- a/GitUpKit/Views/GIAdvancedCommitViewController.m
+++ b/GitUpKit/Views/GIAdvancedCommitViewController.m
@@ -309,6 +309,7 @@
 }
 
 - (BOOL)diffFilesViewController:(GIDiffFilesViewController*)controller handleKeyDownEvent:(NSEvent*)event {
+  // Stage/Unstage files by Return/Delete
   if (!(event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask)) {
     if (event.keyCode == kGIKeyCode_Return) {
       [self _diffFilesViewControllerDidPressReturn:controller];
@@ -319,6 +320,27 @@
     }
   }
 
+  // Navigate beteween stated and unstaged files list by up/down arrows
+  long modifiers = event.modifierFlags & kGIKeyModifiersAll;
+  if (controller == _workdirFilesViewController && !modifiers && event.keyCode == kGIKeyCode_Down) {
+    bool onlyLastFileSelected = (controller.selectedDeltas.count == 1) && (controller.selectedDelta == controller.deltas.lastObject);
+    bool hasIndexFiles = _indexFilesViewController.deltas.count > 0;
+    if (onlyLastFileSelected && hasIndexFiles) {
+      // move focus to next controller
+      [[controller.view window] selectNextKeyView:_workdirFilesViewController.view];
+      return YES;
+    }
+  } else if (controller == _indexFilesViewController && !modifiers && event.keyCode == kGIKeyCode_Up) {
+    bool onlyFirstFileSelected = (controller.selectedDeltas.count == 1) && (controller.selectedDelta == controller.deltas.firstObject);
+    bool hasWorkdirFiles =_workdirFilesViewController.deltas.count > 0;
+    if (onlyFirstFileSelected && hasWorkdirFiles) {
+      // move focus to previous controller
+      [[controller.view window] selectPreviousKeyView:_workdirFilesViewController.view];
+      return YES;
+    }
+  }
+
+  // Perform contextual action on a file
   if (controller == _workdirFilesViewController) {
     return [self handleKeyDownEvent:event forSelectedDeltas:_workdirFilesViewController.selectedDeltas withConflicts:_indexConflicts allowOpen:YES];
   } else if (controller == _indexFilesViewController) {

--- a/GitUpKit/Views/GIAdvancedCommitViewController.m
+++ b/GitUpKit/Views/GIAdvancedCommitViewController.m
@@ -321,7 +321,7 @@
   }
 
   // Navigate beteween stated and unstaged files list by up/down arrows
-  long modifiers = event.modifierFlags & kGIKeyModifiersAll;
+  NSEventModifierFlags modifiers = event.modifierFlags & kGIKeyModifiersAll;
   if (controller == _workdirFilesViewController && !modifiers && event.keyCode == kGIKeyCode_Down) {
     bool onlyLastFileSelected = (controller.selectedDeltas.count == 1) && (controller.selectedDelta == controller.deltas.lastObject);
     bool hasIndexFiles = _indexFilesViewController.deltas.count > 0;


### PR DESCRIPTION
Navigate to index files controller when Down button pressed while on the last file of the workdir list
Navigate to workdir files controller when Up button pressed while on the first files of the index list


**Context**: I'm using keyboard navigation for most of the actions in GitUp but there were no way to quickly navigate b/w staged and un-staged files, and while it's possible with Tab/Shift+Tab it breaks natural up/down navigation that's available in simple mode. This change adds that ability to standard mode as well.

**Testing and considerations**:
- I checked that simple mode still works the same as before
- I added checks to make sure there is not confusing behavior when Arrow key is pressed with a modifier or when multiple files selected to avoid losing selection
- I added checks to prevent navigation to an empty list
- No changes to the documentation page is needed since it simply mentions `Arrow up & Arrow down to select a different file` which is still true