### PR TITLE
Trimming whitespaces from url while cloning (Fixes #952)

### DIFF
--- a/GitUp/Application/CloneWindowController.m
+++ b/GitUp/Application/CloneWindowController.m
@@ -68,7 +68,7 @@
     [self beforeRunInModal];
   }
   if ([NSApp runModalForWindow:self.window] && self.urlExists) {
-    NSURL* url = GCURLFromGitURL(self.urlTextField.stringValue);
+    NSURL* url = GCURLFromGitURL([self.urlTextField.stringValue stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet]);
     if (url) {
       NSString* name = [url.path.lastPathComponent stringByDeletingPathExtension];
       NSSavePanel* savePanel = [NSSavePanel savePanel];


### PR DESCRIPTION
Added in CloneWindowController.m a trimming operation before passing contents of a text field into GitUpKit
Fixes git-up/GitUp#952