### PR TITLE
Update tooltip of a pull button when it changes (#957)

### DIFF
--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -763,6 +763,7 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
     NSRect frame = _pullButton.frame;
     if (isBehind) {
       _pullButton.image = [NSImage imageNamed:@"icon_action_fetch_new"];
+      _pullButton.toolTip = NSLocalizedString(@"Local tip is behind - pull current branch from upstream", nil);
       _pullButton.frame = NSMakeRect(frame.origin.x + frame.size.width - 53, frame.origin.y, 53, frame.size.height);
     } else {
       _pullButton.image = [NSImage imageNamed:@"icon_action_fetch"];


### PR DESCRIPTION
The change in pull button when the tip is behind is also reflected in an updated tooltip. Resolves git-up/GitUp#957

Also, the following line should be added to the [wiki page](https://github.com/git-up/GitUp/wiki/Using-GitUp-Map-View)'s **Tips** section:
- When the local tip is behind the origin a blue dot is shown next to a pull button to indicate new changes on the remote.