### PR TITLE
Correcting snapshot toggle state when navigating using escape button

### DIFF
--- a/GitUp/Application/Base.lproj/Document.xib
+++ b/GitUp/Application/Base.lproj/Document.xib
@@ -278,7 +278,7 @@
                             <outlet property="secondaryControl" destination="khT-H7-lYh" id="3YC-ek-EN6"/>
                         </connections>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="B5339F67-DADA-4EB4-8EBA-79AA8C91CC9C" label="Snapshots" paletteLabel="Snapshots" image="clock.arrow.circlepath" catalog="system" sizingBehavior="auto" id="Aag-2S-fcP" customClass="GICustomToolbarItem">
+                    <toolbarItem implicitItemIdentifier="B5339F67-DADA-4EB4-8EBA-79AA8C91CC9C" label="Snapshots" toolTip="Snapshots pane" paletteLabel="Snapshots" image="clock.arrow.circlepath" catalog="system" sizingBehavior="auto" id="Aag-2S-fcP" customClass="GICustomToolbarItem">
                         <nil key="toolTip"/>
                         <button key="view" verticalHuggingPriority="750" id="9B3-Yw-IMy">
                             <rect key="frame" x="17" y="14" width="29" height="23"/>

--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -1279,6 +1279,8 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
           handled = YES;
         } else if (_snapshotsView.superview) {
           [self toggleSnapshots:nil];
+          // Correct button toggle state if toggled by esc
+          [(NSButton *)_snapshotsItem.view setState:NSOffState];
           handled = YES;
         } else if (_reflogView.superview) {
           [self toggleReflog:nil];

--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -1279,8 +1279,6 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
           handled = YES;
         } else if (_snapshotsView.superview) {
           [self toggleSnapshots:nil];
-          // Correct button toggle state if toggled by esc
-          [(NSButton *)_snapshotsItem.view setState:NSOffState];
           handled = YES;
         } else if (_reflogView.superview) {
           [self toggleReflog:nil];

--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -1773,10 +1773,12 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
 
 - (IBAction)toggleSnapshots:(id)sender {
   if (_snapshotsView.superview) {
+    [self setSnapshotToggleState:NSOffState];
     _mapViewController.previewHistory = nil;
     [self _removeSideView:_snapshotsView completion:NULL];
     [_mainWindow makeFirstResponder:_mapViewController.preferredFirstResponder];
   } else {
+    [self setSnapshotToggleState:NSOnState];
     [_mainWindow makeFirstResponder:nil];  // Force end-editing in search field to avoid close button remaining around
     [self _addSideView:_snapshotsView withIdentifier:kSideViewIdentifier_Snapshots completion:NULL];
     [_mainWindow makeFirstResponder:_snapshotListViewController.preferredFirstResponder];

--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -1783,6 +1783,16 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
   }
 }
 
+- (void)setSnapshotToggleState:(NSControlStateValue)state {
+  NSButton* button = (NSButton*)_snapshotsItem.view;
+  if (![button isKindOfClass:[NSButton class]]) {
+    XLOG_ERROR(@"This used to be a button, update this function if the layout has changed.");
+    return;
+  }
+  
+  [button setState:state];
+}
+
 - (IBAction)toggleReflog:(id)sender {
   if (_reflogView.superview) {
     _mapViewController.forceShowAllTips = NO;


### PR DESCRIPTION
As the Snapshot view button is not part of the navigation group its state is not cleared when the view is switched programatically. Therefore another correction is needed to set the toggle state to off if exited using escape button.
Fixes git-up/GitUp#897