### PR TITLE
Added clone option to the welcome window

### DIFF
--- a/GitUp/Application/Base.lproj/WelcomeWindowController.xib
+++ b/GitUp/Application/Base.lproj/WelcomeWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment version="110000" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
         <capability name="System colors introduced in macOS 10.14" minToolsVersion="10.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,21 +20,21 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="mjY-As-hbN" userLabel="Welcome" customClass="WelcomeWindow">
-            <rect key="contentRect" x="131" y="158" width="280" height="349"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
+            <rect key="contentRect" x="131" y="158" width="280" height="384"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
             <view key="contentView" id="36m-6r-JT2">
-                <rect key="frame" x="0.0" y="0.0" width="280" height="349"/>
+                <rect key="frame" x="0.0" y="0.0" width="280" height="384"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <box fixedFrame="YES" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="10" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="UoN-n1-xSr">
-                        <rect key="frame" x="0.0" y="0.0" width="280" height="349"/>
+                        <rect key="frame" x="0.0" y="0.0" width="280" height="384"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <view key="contentView" id="UVs-2r-EAT" customClass="WelcomeWindowView">
-                            <rect key="frame" x="0.0" y="0.0" width="280" height="349"/>
+                            <rect key="frame" x="0.0" y="0.0" width="280" height="384"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fwx-IU-wXQ">
-                                    <rect key="frame" x="0.0" y="319" width="30" height="30"/>
+                                    <rect key="frame" x="0.0" y="354" width="30" height="30"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSStopProgressFreestandingTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="9ia-bK-Ohr">
                                         <behavior key="behavior" lightByContents="YES"/>
@@ -43,12 +43,12 @@
                                     <accessibility description="Close window"/>
                                 </button>
                                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Apd-kA-Fr2">
-                                    <rect key="frame" x="76" y="180" width="128" height="128"/>
+                                    <rect key="frame" x="76" y="215" width="128" height="128"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSApplicationIcon" id="hqR-yy-x5J"/>
                                 </imageView>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jwH-EW-hhE">
-                                    <rect key="frame" x="58" y="145" width="164" height="17"/>
+                                    <rect key="frame" x="58" y="180" width="164" height="17"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="Welcome to GitUp" id="mWe-61-l7s">
                                         <font key="font" metaFont="systemBold"/>
@@ -57,17 +57,44 @@
                                     </textFieldCell>
                                 </textField>
                                 <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="zd1-ko-kkJ">
-                                    <rect key="frame" x="0.0" y="121" width="280" height="5"/>
+                                    <rect key="frame" x="0.0" y="156" width="280" height="5"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 </box>
                                 <box autoresizesSubviews="NO" fixedFrame="YES" boxType="custom" borderType="none" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Yk1-Lc-GjF">
-                                    <rect key="frame" x="0.0" y="88" width="280" height="35"/>
+                                    <rect key="frame" x="0.0" y="123" width="280" height="35"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <view key="contentView" id="e59-at-kYh">
                                         <rect key="frame" x="0.0" y="0.0" width="280" height="35"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
                                             <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="edN-Xy-LJd" customClass="GILinkButton">
+                                                <rect key="frame" x="50" y="7" width="180" height="20"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="link" value="Clone a Git Repository…"/>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="linkColor">
+                                                        <color key="value" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="alternateLinkColor">
+                                                        <color key="value" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="cloneRepository:" target="-1" id="e3f-ba-Ilm"/>
+                                                </connections>
+                                            </customView>
+                                        </subviews>
+                                    </view>
+                                    <color key="fillColor" name="alternatingContentBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </box>
+                                <box autoresizesSubviews="NO" fixedFrame="YES" boxType="custom" borderType="none" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="xQb-J3-oL4">
+                                    <rect key="frame" x="0.0" y="88" width="280" height="35"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <view key="contentView" id="7dg-K9-ehZ">
+                                        <rect key="frame" x="0.0" y="0.0" width="280" height="35"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <subviews>
+                                            <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ICh-W7-gfv" customClass="GILinkButton">
                                                 <rect key="frame" x="50" y="7" width="180" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                 <userDefinedRuntimeAttributes>
@@ -80,7 +107,7 @@
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
                                                 <connections>
-                                                    <action selector="openDocument:" target="-1" id="PnG-74-JXS"/>
+                                                    <action selector="openDocument:" target="-1" id="Z9o-ql-9Ia"/>
                                                 </connections>
                                             </customView>
                                         </subviews>
@@ -88,11 +115,11 @@
                                     <color key="fillColor" name="alternatingContentBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </box>
                                 <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="FXE-km-lcD">
-                                    <rect key="frame" x="0.0" y="85" width="280" height="5"/>
+                                    <rect key="frame" x="0.0" y="120" width="280" height="5"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 </box>
                                 <box autoresizesSubviews="NO" fixedFrame="YES" boxType="custom" borderType="none" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="ll1-UT-nBS">
-                                    <rect key="frame" x="0.0" y="52" width="280" height="35"/>
+                                    <rect key="frame" x="0.0" y="54" width="280" height="35"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <view key="contentView" id="qq4-a6-dvv">
                                         <rect key="frame" x="0.0" y="0.0" width="280" height="35"/>
@@ -115,10 +142,6 @@
                                         </subviews>
                                     </view>
                                     <color key="fillColor" name="alternatingContentBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                </box>
-                                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="3Ya-QW-NlZ">
-                                    <rect key="frame" x="0.0" y="49" width="280" height="5"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 </box>
                                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TgX-Ty-AUa">
                                     <rect key="frame" x="45" y="20" width="12" height="12"/>
@@ -161,6 +184,14 @@
                                         <action selector="viewIssues:" target="-1" id="aqi-az-ote"/>
                                     </connections>
                                 </customView>
+                                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="3Ya-QW-NlZ">
+                                    <rect key="frame" x="0.0" y="86" width="280" height="5"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                </box>
+                                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="pHv-zS-O89">
+                                    <rect key="frame" x="0.0" y="52" width="280" height="5"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                </box>
                             </subviews>
                             <connections>
                                 <outlet property="imageView" destination="Apd-kA-Fr2" id="22r-bO-hHz"/>


### PR DESCRIPTION
When I first opened GitUp I was confused with a lack of clone option. It is inconvenient to have it hidden behind a menu and as other issues (git-up/GitUp#761,  git-up/GitUp#743,  git-up/GitUp#153) mentioned - it would be better to have it on the welcome screen. It is much better experience for the first time users.
<img width="280" alt="image" src="https://github.com/git-up/GitUp/assets/45892416/385c0cc9-f659-48a7-b8c4-747b92c6c8b4">
Resolves git-up/GitUp#761