### PR TITLE
Update copyright year in Info.plist

### DIFF
--- a/GitUp/Application/Info.plist
+++ b/GitUp/Application/Info.plist
@@ -38,7 +38,7 @@
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Please</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2015-2019 Pierre-Olivier Latour. All rights reserved.</string>
+	<string>Copyright © 2015-2024 Pierre-Olivier Latour. All rights reserved.</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/GitUpKit/Info.plist
+++ b/GitUpKit/Info.plist
@@ -28,6 +28,6 @@
 		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2015-2019 Pierre-Olivier Latour. All rights reserved.</string>
+	<string>Copyright © 2015-2024 Pierre-Olivier Latour. All rights reserved.</string>
 </dict>
 </plist>


### PR DESCRIPTION
I personally wondered if I had the most recent version of Gitup running on my computer because the About window listed the copyright only going until 2019. Since the app is being regularly updated, the copyright date should reflect that.


I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT