### PR TITLE
Check if `SSH_AUTH_SOCK` env var is set before trying to use the SSH agent.

### DIFF
--- a/GitUpKit/Core/GCRepository.m
+++ b/GitUpKit/Core/GCRepository.m
@@ -444,7 +444,7 @@ static int _CredentialsCallback(git_cred** cred, const char* url, const char* us
   GCRepository* repository = (__bridge GCRepository*)payload;
   if (allowed_types & GIT_CREDTYPE_SSH_KEY) {
 #if !TARGET_OS_IPHONE
-    if (!repository->_didTrySSHAgent) {
+    if (!repository->_didTrySSHAgent && getenv("SSH_AUTH_SOCK")) {
       repository->_didTrySSHAgent = YES;
       return git_cred_ssh_key_from_agent(cred, user);
     }


### PR DESCRIPTION
Fixes the cloning test through ssh (`GCSingleCommitRepositoryTests`'s `testClone`) on computers that don't have a correctly setup ssh agent, like mine 🥴 (as the keys in `~/.ssh` will be used instead, and that's going to work as long [as they're not protected by a passphrase](https://github.com/git-up/GitUp/issues/35)).

If `SSH_AUTH_SOCK` isn't there, it will fail later on anyway when libgit2 uses libssh2.

Should also make ssh agent workarounds like this one unnecessary: https://github.com/git-up/GitUp/issues/161#issuecomment-643863909

**I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT**