### PR TITLE
Specify `initial_head` when initializing a repository for tests so the global git config doesn't make it fail

### DIFF
--- a/GitUpKit/Core/GCRepository.h
+++ b/GitUpKit/Core/GCRepository.h
@@ -62,6 +62,7 @@ typedef NS_ENUM(NSUInteger, GCFileMode) {
 @property(nonatomic, readonly) GCRepositoryState state;  // Do NOT use on a bare repository
 - (instancetype)initWithExistingLocalRepository:(NSString*)path error:(NSError**)error;
 - (instancetype)initWithNewLocalRepository:(NSString*)path bare:(BOOL)bare error:(NSError**)error;  // git init {path}
+- (instancetype)initWithNewLocalRepository:(NSString*)path bare:(BOOL)bare defaultBranchName:(NSString*)defaultBranchName error:(NSError**)error;
 
 - (BOOL)cleanupState:(NSError**)error;  // Do NOT use on a bare repository
 

--- a/GitUpKit/Core/GCRepository.m
+++ b/GitUpKit/Core/GCRepository.m
@@ -159,11 +159,20 @@ static int _GitLFSApply(git_filter* self, void** payload, git_buf* to, const git
 }
 
 - (instancetype)initWithNewLocalRepository:(NSString*)path bare:(BOOL)bare error:(NSError**)error {
+  return [self initWithNewLocalRepository:path bare:bare defaultBranchName:nil error:error];
+}
+
+- (instancetype)initWithNewLocalRepository:(NSString*)path bare:(BOOL)bare defaultBranchName:(NSString*)defaultBranchName error:(NSError**)error {
   git_repository_init_options options = GIT_REPOSITORY_INIT_OPTIONS_INIT;
   options.flags = GIT_REPOSITORY_INIT_NO_REINIT | GIT_REPOSITORY_INIT_MKPATH;
   if (bare) {
     options.flags |= GIT_REPOSITORY_INIT_BARE;
   }
+
+  if (defaultBranchName) {
+    options.initial_head = defaultBranchName.UTF8String;
+  }
+
   git_repository* repository;
   CALL_LIBGIT2_FUNCTION_RETURN(nil, git_repository_init_ext, &repository, path.fileSystemRepresentation, &options);
   return [self initWithRepository:repository error:error];

--- a/GitUpKit/Core/GCTestCase.m
+++ b/GitUpKit/Core/GCTestCase.m
@@ -36,7 +36,7 @@ static const void* _associatedObjectKey = &_associatedObjectKey;
 }
 
 - (GCRepository*)createLocalRepositoryAtPath:(NSString*)path bare:(BOOL)bare {
-  GCRepository* repo = [[GCRepository alloc] initWithNewLocalRepository:path bare:bare error:NULL];
+  GCRepository* repo = [[GCRepository alloc] initWithNewLocalRepository:path bare:bare defaultBranchName:@"master" error:NULL];
   XCTAssertNotNil(repo);
 
   NSString* configDirectory = [[NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]] stringByAppendingPathComponent:@"git"];


### PR DESCRIPTION
My global git config includes `init.defaultbranch` set to `develop` so two thirds of the tests would fail on my computer. This change makes the tests work on more computers by explicitly specifying "master" as the default branch name (through libgit2's `initial_head` option) so the computer's global git config is ignored.

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT