### PR TITLE
Fix untracked files problem in multiple commits rebases with conflicts

### DIFF
--- a/GitUpKit/Core/GCRepository+HEAD.h
+++ b/GitUpKit/Core/GCRepository+HEAD.h
@@ -17,7 +17,8 @@
 
 typedef NS_OPTIONS(NSUInteger, GCCheckoutOptions) {
   kGCCheckoutOption_Force = (1 << 0),
-  kGCCheckoutOption_UpdateSubmodulesRecursively = (1 << 1)
+  kGCCheckoutOption_UpdateSubmodulesRecursively = (1 << 1),
+  kGCCheckoutOption_RemoveUntrackedFiles = (1 << 2),
 };
 
 @interface GCRepository (HEAD)

--- a/GitUpKit/Core/GCRepository+HEAD.m
+++ b/GitUpKit/Core/GCRepository+HEAD.m
@@ -194,6 +194,11 @@ cleanup:
   git_tree* tree = NULL;
   git_checkout_options checkoutOptions = GIT_CHECKOUT_OPTIONS_INIT;
   checkoutOptions.checkout_strategy = options & kGCCheckoutOption_Force ? GIT_CHECKOUT_FORCE : GIT_CHECKOUT_SAFE;
+
+  if (options & kGCCheckoutOption_RemoveUntrackedFiles) {
+    checkoutOptions.checkout_strategy |= GIT_CHECKOUT_REMOVE_UNTRACKED;
+  }
+
   if (baseline) {
     CALL_LIBGIT2_FUNCTION_RETURN(NO, git_commit_tree, &tree, baseline.private);
     checkoutOptions.baseline = tree;

--- a/GitUpKit/Extensions/GCRepository+Utilities.m
+++ b/GitUpKit/Extensions/GCRepository+Utilities.m
@@ -292,7 +292,7 @@ NSString* GCNameFromHostingService(GCHostingService service) {
   if (![self lookupHEADCurrentCommit:&headCommit branch:NULL error:error]) {
     return NO;
   }
-  GCCheckoutOptions options = kGCCheckoutOption_Force;
+  GCCheckoutOptions options = kGCCheckoutOption_Force | kGCCheckoutOption_RemoveUntrackedFiles;
   if (recursive) {
     options |= kGCCheckoutOption_UpdateSubmodulesRecursively;
   }


### PR DESCRIPTION
Fixes https://github.com/git-up/GitUp/issues/882

Added and implement `kGCCheckoutOption_RemoveUntrackedFiles` to fix issue where untracked files are left behind after forceCheckoutHEAD is called during a rebase. 

I was able to reproduce the issue in the `-[GCEmptyLiveRepositoryTestCase testMultipleCommitsRebaseWithConflict]` test I implemented in https://github.com/git-up/GitUp/pull/989 (I would've based this branch on the branch I used for PR 989 but I can't open a PR on another PR from my fork).

Then I dug deeper and deeper until I found that `-[GCRepository forceCheckoutHEAD:error:]` didn't remove untracked files, but that this was required for rebases. I still don't fully understand what caused this regression, but this does seem to fix it (and all the other tests pass).


I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT