### PR TITLE
Fix delay when cmd tabbing into GitUp

### DIFF
--- a/GitUp/Application/Document.m
+++ b/GitUp/Application/Document.m
@@ -780,12 +780,18 @@ static NSString* _StringFromRepositoryState(GCRepositoryState state) {
 }
 
 - (void)_didBecomeActive:(NSNotification*)notification {
-  [_repository notifyRepositoryChanged];  // Make sure we are up-to-date right now
+  /** 
+   async dispatch on the main queue so we don't block
+   NSApplicationDidBecomeActiveNotification while updating the repos
+   */
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [_repository notifyRepositoryChanged];  // Make sure we are up-to-date right now
 
-  if (_repository.automaticSnapshotsEnabled) {
-    [_repository setUndoActionName:NSLocalizedString(@"External Changes", nil)];
-    _repository.automaticSnapshotsEnabled = NO;
-  }
+    if (_repository.automaticSnapshotsEnabled) {
+      [_repository setUndoActionName:NSLocalizedString(@"External Changes", nil)];
+      _repository.automaticSnapshotsEnabled = NO;
+    }
+  });
 }
 
 - (void)_didResignActive:(NSNotification*)notification {


### PR DESCRIPTION
So `NSApplicationDidBecomeActiveNotification` isn't blocked so command-tabbing into GitUp isn't delayed because we're refreshing all the repositories synchronously. The work will still be done on the main thread, but it will now be less likely to be noticed (especially with Stage Manager activated, the reload will probably be done by the time the Stage Manager animation is done)

**Steps to reproduce the problem before:**
1. Open several big repositories
2. Switch to the Finder or any other app
3. cmd tab back into GitUp

**Before:**
Takes 1-2 seconds before macOS actually switches to GitUp.

**With the async dispatch:**
macOS instantly switches to GitUp, but the app is unresponsive for 1-2 seconds.

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT