### PR TITLE
Handle submodule conflicts

### DIFF
--- a/GitUpKit/Components/Base.lproj/GIDiffContentsViewController.xib
+++ b/GitUpKit/Components/Base.lproj/GIDiffContentsViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -49,7 +49,7 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="700" height="34"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Y1E-lo-5Dv">
+                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Y1E-lo-5Dv">
                                                         <rect key="frame" x="31" y="10" width="540" height="16"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingHead" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Label" id="nPK-ee-7Lf">
@@ -105,7 +105,7 @@
                                                 <rect key="frame" x="0.0" y="234" width="700" height="50"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vEH-U7-166">
+                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vEH-U7-166">
                                                         <rect key="frame" x="170" y="17" width="360" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingMiddle" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="This file is empty or its content has not changed" id="gub-Hg-Iqn">
@@ -130,15 +130,78 @@
                                                     <outlet property="imageView" destination="jMk-52-KEf" id="eB8-Zt-lNU"/>
                                                 </connections>
                                             </tableCellView>
+                                            <tableCellView identifier="submodule" id="cNk-N6-wN7" customClass="GISubmoduleDiffCellView">
+                                                <rect key="frame" x="0.0" y="384" width="700" height="80"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <subviews>
+                                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eWx-eZ-o0j">
+                                                        <rect key="frame" x="100" y="14" width="500" height="80"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <subviews>
+                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YVB-XK-AIP">
+                                                                <rect key="frame" x="180" y="23" width="300" height="17"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;NEW SHA1&gt;" id="PPM-zU-FYS">
+                                                                    <font key="font" usesAppearanceFont="YES"/>
+                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                            </textField>
+                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L5g-ca-cZO">
+                                                                <rect key="frame" x="23" y="20" width="155" height="17"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="New Submodule Commit:" id="Nk1-ps-66X">
+                                                                    <font key="font" metaFont="smallSystemBold"/>
+                                                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                            </textField>
+                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hyb-p0-Qcj">
+                                                                <rect key="frame" x="180" y="44" width="300" height="17"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;OLD SHA1&gt;" id="gOr-Fw-yLH">
+                                                                    <font key="font" usesAppearanceFont="YES"/>
+                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                            </textField>
+                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8lM-kt-fK1">
+                                                                <rect key="frame" x="23" y="41" width="155" height="17"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Old Submodule Commit:" id="T3Y-iO-ztA">
+                                                                    <font key="font" metaFont="smallSystemBold"/>
+                                                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                            </textField>
+                                                        </subviews>
+                                                    </customView>
+                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wbK-Cy-wpg">
+                                                        <rect key="frame" x="98" y="47" width="504" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" lineBreakMode="truncatingMiddle" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;CUSTOM&gt;" id="3fm-2P-o1t">
+                                                            <font key="font" metaFont="system"/>
+                                                            <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                                <connections>
+                                                    <outlet property="contentView" destination="eWx-eZ-o0j" id="tA0-0B-xnu"/>
+                                                    <outlet property="customTextField" destination="wbK-Cy-wpg" id="4mc-uB-s4i"/>
+                                                    <outlet property="newSHA1TextField" destination="YVB-XK-AIP" id="5wO-Fy-xIA"/>
+                                                    <outlet property="oldSHA1TextField" destination="Hyb-p0-Qcj" id="WPA-Xa-Ayx"/>
+                                                </connections>
+                                            </tableCellView>
                                             <tableCellView identifier="conflict" id="hYN-9E-rxQ" customClass="GIConflictDiffCellView">
-                                                <rect key="frame" x="0.0" y="384" width="700" height="60"/>
+                                                <rect key="frame" x="0.0" y="464" width="700" height="60"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IHV-Ry-isd">
                                                         <rect key="frame" x="100" y="0.0" width="500" height="60"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <subviews>
-                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IRV-hg-pLs">
+                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IRV-hg-pLs">
                                                                 <rect key="frame" x="58" y="36" width="384" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;STATUS&gt;" id="da8-F9-EbA">
@@ -190,45 +253,76 @@
                                                     <outlet property="statusTextField" destination="IRV-hg-pLs" id="gRO-Kl-ff5"/>
                                                 </connections>
                                             </tableCellView>
-                                            <tableCellView identifier="submodule" id="cNk-N6-wN7" customClass="GISubmoduleDiffCellView">
-                                                <rect key="frame" x="0.0" y="444" width="700" height="50"/>
+                                            <tableCellView identifier="submodule_conflict" id="BzI-8D-d6N" userLabel="Submodule Conflict Diff Cell View" customClass="GISubmoduleConflictDiffCellView">
+                                                <rect key="frame" x="0.0" y="524" width="700" height="105"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eWx-eZ-o0j">
-                                                        <rect key="frame" x="100" y="-16" width="500" height="80"/>
-                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="57U-X4-Thl">
+                                                        <rect key="frame" x="100" y="0.0" width="500" height="108"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <subviews>
-                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YVB-XK-AIP">
-                                                                <rect key="frame" x="180" y="23" width="300" height="17"/>
+                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Dqh-34-tmL">
+                                                                <rect key="frame" x="58" y="84" width="384" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;NEW SHA1&gt;" id="PPM-zU-FYS">
+                                                                <textFieldCell key="cell" lineBreakMode="truncatingMiddle" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;STATUS&gt;" id="Rzt-1Q-Zm6">
+                                                                    <font key="font" metaFont="system"/>
+                                                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                            </textField>
+                                                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JuB-G8-hG2" userLabel="Choose Ours Button">
+                                                                <rect key="frame" x="106" y="10" width="140" height="17"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                <buttonCell key="cell" type="roundRect" title="Choose Ours" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="CQT-IB-4eo">
+                                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <action selector="chooseOurs:" target="-2" id="LY2-a1-ajJ"/>
+                                                                </connections>
+                                                            </button>
+                                                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Un-yc-6qx" userLabel="Choose Theirs Button">
+                                                                <rect key="frame" x="254" y="10" width="140" height="17"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                <buttonCell key="cell" type="roundRect" title="Choose Theirs" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="pv1-Qs-qUh">
+                                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <action selector="chooseTheirs:" target="-2" id="1tk-wO-T7L"/>
+                                                                </connections>
+                                                            </button>
+                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7H8-BQ-WBn" userLabel="&lt;OURS SHA1&gt;">
+                                                                <rect key="frame" x="123" y="61" width="300" height="17"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;OLD SHA1&gt;" id="98R-9C-80x" userLabel="&lt;OURS SHA1&gt;">
                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                 </textFieldCell>
                                                             </textField>
-                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L5g-ca-cZO">
-                                                                <rect key="frame" x="23" y="20" width="155" height="17"/>
-                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="New Submodule Commit:" id="Nk1-ps-66X">
+                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MJE-MH-NqZ">
+                                                                <rect key="frame" x="77" y="58" width="44" height="17"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Ours:" id="B8P-fk-f1o">
                                                                     <font key="font" metaFont="smallSystemBold"/>
                                                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                 </textFieldCell>
                                                             </textField>
-                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hyb-p0-Qcj">
-                                                                <rect key="frame" x="180" y="44" width="300" height="17"/>
-                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;OLD SHA1&gt;" id="gOr-Fw-yLH">
+                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cZ1-1f-A7i" userLabel="&lt;THEIRS SHA1&gt;">
+                                                                <rect key="frame" x="123" y="40" width="300" height="17"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;NEW SHA1&gt;" id="WDM-jT-bbJ" userLabel="&lt;THEIRS SHA1&gt;">
                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                 </textFieldCell>
                                                             </textField>
-                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8lM-kt-fK1">
-                                                                <rect key="frame" x="23" y="41" width="155" height="17"/>
-                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Old Submodule Commit:" id="T3Y-iO-ztA">
+                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2dj-Qu-d0J">
+                                                                <rect key="frame" x="77" y="37" width="44" height="17"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Theirs:" id="a4e-qe-VRy">
                                                                     <font key="font" metaFont="smallSystemBold"/>
                                                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -236,21 +330,13 @@
                                                             </textField>
                                                         </subviews>
                                                     </customView>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wbK-Cy-wpg">
-                                                        <rect key="frame" x="98" y="17" width="504" height="17"/>
-                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                        <textFieldCell key="cell" lineBreakMode="truncatingMiddle" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;CUSTOM&gt;" id="3fm-2P-o1t">
-                                                            <font key="font" metaFont="system"/>
-                                                            <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                        </textFieldCell>
-                                                    </textField>
                                                 </subviews>
                                                 <connections>
-                                                    <outlet property="contentView" destination="eWx-eZ-o0j" id="tA0-0B-xnu"/>
-                                                    <outlet property="customTextField" destination="wbK-Cy-wpg" id="4mc-uB-s4i"/>
-                                                    <outlet property="newSHA1TextField" destination="YVB-XK-AIP" id="5wO-Fy-xIA"/>
-                                                    <outlet property="oldSHA1TextField" destination="Hyb-p0-Qcj" id="WPA-Xa-Ayx"/>
+                                                    <outlet property="chooseOursButton" destination="JuB-G8-hG2" id="lHH-7c-PX2"/>
+                                                    <outlet property="chooseTheirsButton" destination="9Un-yc-6qx" id="zMn-Td-hzx"/>
+                                                    <outlet property="oursTextField" destination="7H8-BQ-WBn" id="gEA-Vb-DYa"/>
+                                                    <outlet property="statusTextField" destination="Dqh-34-tmL" id="wej-oZ-BYX"/>
+                                                    <outlet property="theirsTextField" destination="cZ1-1f-A7i" id="zUP-zt-dj1"/>
                                                 </connections>
                                             </tableCellView>
                                         </prototypeCellViews>
@@ -272,7 +358,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="esO-al-uQm">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="esO-al-uQm">
                     <rect key="frame" x="0.0" y="359" width="700" height="18"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="&lt;EMPTY&gt;" id="vil-2I-MOS">

--- a/GitUpKit/Core/GCRepository+HEAD.h
+++ b/GitUpKit/Core/GCRepository+HEAD.h
@@ -31,6 +31,7 @@ typedef NS_OPTIONS(NSUInteger, GCCheckoutOptions) {
 - (BOOL)setDetachedHEADToCommit:(GCCommit*)commit error:(NSError**)error;  // git update-ref HEAD {commit}
 
 - (BOOL)moveHEADToCommit:(GCCommit*)commit reflogMessage:(NSString*)message error:(NSError**)error;  // git reset --soft {commit} (but with custom reflog message)
+- (BOOL)updateSubmoduleReferenceAtPath:(NSString *)submodulePath toCommitSHA1:(NSString *)commitSHA1 error:(NSError **)error;
 
 - (BOOL)checkoutCommit:(GCCommit*)commit options:(GCCheckoutOptions)options error:(NSError**)error;  // git checkout {commit}
 - (BOOL)checkoutLocalBranch:(GCLocalBranch*)branch options:(GCCheckoutOptions)options error:(NSError**)error;  // git checkout {branch}

--- a/GitUpKit/Core/GCRepository+HEAD.m
+++ b/GitUpKit/Core/GCRepository+HEAD.m
@@ -216,6 +216,25 @@ cleanup:
   return YES;
 }
 
+- (BOOL)updateSubmoduleReferenceAtPath:(NSString*)submodulePath toCommitSHA1:(NSString*)commitSHA1 error:(NSError**)error {
+  GCSubmodule *submodule = [self lookupSubmoduleWithName:submodulePath error:error];
+  if (!submodule) {
+    return NO;
+  }
+
+  GCRepository *submoduleRepository = [[GCRepository alloc] initWithSubmodule:submodule error:error];
+  if (!submoduleRepository) {
+    return NO;
+  }
+
+  GCCommit *targetCommit = [submoduleRepository findCommitWithSHA1:commitSHA1 error:error];
+  if (!targetCommit) {
+    return NO;
+  }
+
+  return [submoduleRepository checkoutCommit:targetCommit options:kGCCheckoutOption_UpdateSubmodulesRecursively error:error];
+}
+
 // Because by default git_checkout_tree() assumes the baseline (i.e. expected content of workdir) is HEAD we must checkout first, then update HEAD
 - (BOOL)checkoutLocalBranch:(GCLocalBranch*)branch options:(GCCheckoutOptions)options error:(NSError**)error {
   GCCommit* tipCommit = [self lookupTipCommitForBranch:branch error:error];


### PR DESCRIPTION
Resolves https://github.com/git-up/GitUp/issues/282

I use submodules every day at work and I think GitUp is the best Git interface so this has been a regular issue for me for way too long 🤪

The basic UI I came up with looks like this:
<img width="1018" alt="image" src="https://github.com/git-up/GitUp/assets/4634735/417a9da2-d357-4f26-99c3-d3df03845ba5">

It closely matches the current submodule diff UI, but with buttons to choose which commit should be chosen (as a side note, in a future update it would be interesting to also pull the title of each commits and display it in the diff/conflicts views as I don't know my commit SHA1s by heart).

The "sketchiest" part of this PR is probably in GCDiff.m lines 358-377. I've written an explanation in a comment right above the code to justify it, but it would be nice if the superfluous untracked diff entry was not returned by libgit2 at all, but I couldn't find any combination of diff options that could do that.

## Before
Submodule conflicts weren't handled at all and any rebase that involves a submodule conflict errors out in GitUp (and the repository needs to be "Reset to Checkout..." to get a clean working directory again | Submodule conflicts can be handled with a "Choose ours" or "Choose theirs" button

https://github.com/git-up/GitUp/assets/4634735/1c8caddd-e121-49ff-8231-3e0cf76944fc

## After
Submodule conflicts can be handled with a "Choose ours" or "Choose theirs" button

https://github.com/git-up/GitUp/assets/4634735/a5494762-4b77-4285-9a34-ba6f0ac9d552

Here's the repository I used for my tests:
[test-repo-submodules.zip](https://github.com/git-up/GitUp/files/15135693/test-repo-submodules.zip)

Once https://github.com/git-up/GitUp/pull/989 is merged, I could use it as a base to write a unit test that checks that submodule conflicts are well handled.

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT
