### PR TITLE
Null out modification date of index entries when (un)staging lines

### DIFF
--- a/GitUpKit/Core/GCIndex.m
+++ b/GitUpKit/Core/GCIndex.m
@@ -357,7 +357,7 @@ cleanup:
 - (BOOL)addLinesInWorkingDirectoryFile:(NSString*)path toIndex:(GCIndex*)index error:(NSError**)error usingFilter:(GCIndexLineFilter)filter {
   const char* filePath = GCGitPathFromFileSystemPath(path);
 
-  // If the file is already in the index, preserve the entry, otherwise create a new entry from the file metadata
+  // If the file is already in the index, mutate the entry, otherwise create a new entry from the file metadata
   git_index_entry entry;
   const git_index_entry* entryPtr = git_index_get_bypath(index.private, filePath, 0);
   if (entryPtr == NULL) {
@@ -366,6 +366,11 @@ cleanup:
     bzero(&entry, sizeof(git_index_entry));
     entry.path = filePath;
     git_index_entry__init_from_stat(&entry, &info, true);
+    entryPtr = &entry;
+  } else {
+    // Null out the entry's modification date: otherwise Git might assume the file is unchanged from the on-disk version, and produce incorrect diffs
+    bcopy(entryPtr, &entry, sizeof(git_index_entry));
+    entry.mtime = (git_index_time){.seconds = 0, .nanoseconds = 0};
     entryPtr = &entry;
   }
   NSMutableData* data = [[NSMutableData alloc] initWithCapacity:(1024 * 1024)];
@@ -453,7 +458,7 @@ cleanup:
 - (BOOL)resetLinesInFile:(NSString*)path index:(GCIndex*)index toCommit:(GCCommit*)commit error:(NSError**)error usingFilter:(GCIndexLineFilter)filter {
   const char* filePath = GCGitPathFromFileSystemPath(path);
 
-  // If the file is already in the index, preserve the entry, otherwise create a new entry from the file blob
+  // If the file is already in the index, mutate the entry, otherwise create a new entry from the file blob
   git_index_entry entry;
   const git_index_entry* entryPtr = git_index_get_bypath(index.private, filePath, 0);
   if (entryPtr == NULL) {
@@ -468,6 +473,11 @@ cleanup:
     entry.mode = git_tree_entry_filemode(treeEntry);
     entryPtr = &entry;
     git_tree_entry_free(treeEntry);
+  } else {
+    // Null out the entry's modification date: otherwise Git might assume the file is unchanged from the on-disk version, and produce incorrect diffs
+    bcopy(entryPtr, &entry, sizeof(git_index_entry));
+    entry.mtime = (git_index_time){.seconds = 0, .nanoseconds = 0};
+    entryPtr = &entry;
   }
   NSMutableData* data = [[NSMutableData alloc] initWithCapacity:(1024 * 1024)];
 


### PR DESCRIPTION
This fixes an issue where GitUp wrote incorrect data to the index, causing both the Git CLI and GitUp itself to produce incorrect diffs.

# Reproducing

- Download the [bear-themes](https://github.com/user-attachments/files/17879934/bear-themes.zip) repo
- The file `Red Graphite.theme` has changes, and is fully staged. In it, unstage the remove/add deltas at line 9.
- The index is now corrupted: GitUp doesn't show those line 9 changes in the workdir nor stage views, and the Git CLI thinks they're still staged.

# Fix

For performance, when producing diffs, Git skips reading the contents of files under some conditions. Here, the bug is that Git skips reading our file because it assumes it's identical between the working directory and the stage. Setting the file's date to null in the index prevents that behavior.

# Notes

This fix has been in use in Retcon since January 2024, with no noticed adverse effect.