### PR TITLE
Fix some “Stage All” special cases

### DIFF
--- a/GitUpKit/Extensions/GCRepository+Utilities.m
+++ b/GitUpKit/Extensions/GCRepository+Utilities.m
@@ -205,7 +205,9 @@ NSString* GCNameFromHostingService(GCHostingService service) {
         if (delta.submodule) {
           GCSubmodule* submodule = [self lookupSubmoduleWithName:delta.canonicalPath error:error];
           if (!submodule || ![self addSubmoduleToRepositoryIndex:submodule error:error]) {
-            return NO;
+            if (![[*error localizedDescription] hasSuffix:@"' has not been added yet"]) {
+              return NO;
+            }
           }
         } else {
           if (![self addFileInWorkingDirectory:delta.canonicalPath toIndex:index error:error]) {

--- a/GitUpKit/Extensions/GCRepository+Utilities.m
+++ b/GitUpKit/Extensions/GCRepository+Utilities.m
@@ -209,7 +209,13 @@ NSString* GCNameFromHostingService(GCHostingService service) {
           }
         } else {
           if (![self addFileInWorkingDirectory:delta.canonicalPath toIndex:index error:error]) {
-            return NO;
+            BOOL wasJustTryingToStageADeletedConflictingFile =
+              delta.change == kGCFileDiffChange_Conflicted
+              && [[*error localizedDescription] isEqualToString:@"No such file or directory"];
+            
+            if (!wasJustTryingToStageADeletedConflictingFile) {
+              return NO;
+            }
           }
         }
         break;


### PR DESCRIPTION
This fixes two issues with the Stage All button.

# Reproducing

Reproducing the conflict issue:
- Cause a conflict from another app (e.g. by running a `git pull`)
- Delete the file that's in conflict
- In GitUp, try to _Stage All_: the operation aborts with a “No such file or directory” error

Reproducing the submodule issue:
- In a repository, copy another repository (just copy a repo folder; don't use submodule features or anything)
- In GitUp, try to _Stage All_ in the outer repository: the operation aborts with a “submodule 'SUB_REPO_PATH' has not been added yet” error

# Notes

The fixes look at the error messages to decide what to do—that might not be ideal, but:
- The specific submodule error is [emitted by libgit2](https://github.com/git-up/libgit2/blob/fc0392bbcdffca9edfb5a09e6d330aa00431d4d3/src/submodule.c#L129), with no distinguishing metadata. To avoid reading the error message, we'd have to essentially reimplement that libgit2 behavior. The fix should hold over time, as libgit2 seems to change existing code fairly rarely, and is English-only. The fallout if the fix does break is minimal.
- The “no such file” error also doesn't have distinguishing features that I could find (its code is a generic `-1`). That one feels flakier, as Apple could change the error message at any time, and the message could be localized if the app runs in a different language; but in practice, Apple is unlikely to change that message, and GitUp is in English only.
