### PR TITLE
Fix two APIs

### DIFF
--- a/GitUpKit/Core/GCIndex.m
+++ b/GitUpKit/Core/GCIndex.m
@@ -526,6 +526,10 @@ cleanup:
 }
 
 - (BOOL)checkoutFilesToWorkingDirectory:(NSArray<NSString*>*)paths fromIndex:(GCIndex*)index error:(NSError**)error {
+	if ([paths count] == 0) {
+		return YES;
+	}
+	
   git_checkout_options options = GIT_CHECKOUT_OPTIONS_INIT;
   options.checkout_strategy = GIT_CHECKOUT_FORCE | GIT_CHECKOUT_DONT_UPDATE_INDEX;  // There's no reason to update the index
   options.paths.count = paths.count;

--- a/GitUpKit/Core/GCRepository+Bare.m
+++ b/GitUpKit/Core/GCRepository+Bare.m
@@ -75,7 +75,7 @@ static inline GCCommit* _CopyCommit(GCRepository* repository, git_commit* commit
     for (NSUInteger i = 0; i < count; ++i) {
       [array addObject:_CopyCommit(self, (git_commit*)parents[i])];
     }
-    commit = handler([[GCIndex alloc] initWithRepository:nil index:index], _CopyCommit(self, ourCommit), _CopyCommit(self, theirCommit), array, message, error);  // Doesn't make sense to specify a custom author on conflict anyway
+    commit = handler([[GCIndex alloc] initWithRepository:nil index:index], ourCommit ? _CopyCommit(self, ourCommit) : nil, _CopyCommit(self, theirCommit), array, message, error);  // Doesn't make sense to specify a custom author on conflict anyway
     index = NULL;  // Ownership has been transferred to GCIndex instance
   } else {
     commit = [self createCommitFromIndex:index withParents:parents count:count author:author message:message error:error];
@@ -95,12 +95,12 @@ cleanup:
                       message:(NSString*)message
               conflictHandler:(GCConflictHandler)handler
                         error:(NSError**)error {
-  const git_commit* parents[] = {againstCommit.private};
+  const git_commit** parents = (againstCommit != nil) ? (git_commit*[]) {againstCommit.private} : (git_commit*[]) {};
   return [self _mergeTheirCommit:pickCommit.private
                    intoOurCommit:againstCommit.private
               withAncestorCommit:ancestorCommit.private
                          parents:parents
-                           count:1
+                           count:(againstCommit != nil) ? 1 : 0
                           author:git_commit_author(pickCommit.private)
                          message:message
                  conflictHandler:handler
@@ -113,12 +113,12 @@ cleanup:
                   message:(NSString*)message
           conflictHandler:(GCConflictHandler)handler
                     error:(NSError**)error {
-  const git_commit* parents[] = {againstCommit.private};
+  const git_commit** parents = (againstCommit != nil) ? (git_commit*[]) {againstCommit.private} : (git_commit*[]) {};
   return [self _mergeTheirCommit:ancestorCommit.private
                    intoOurCommit:againstCommit.private
               withAncestorCommit:revertCommit.private
                          parents:parents
-                           count:1
+                           count:(againstCommit != nil) ? 1 : 0
                           author:NULL
                          message:message
                  conflictHandler:handler


### PR DESCRIPTION
This PR doesn't change the current behavior of GitUp the app, but does fix two methods:
- `checkoutFilesToWorkingDirectory`, if passed an empty array, deletes every file in the workdir, instead of doing nothing
- cherry-picking and commit reversal methods fail if passed an empty parent
