### PR TITLE
Update libgit2 fork to v1.9.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2

--- a/GitUp/Application/AppDelegate.m
+++ b/GitUp/Application/AppDelegate.m
@@ -104,6 +104,12 @@
 
 #pragma mark - Initialize
 + (void)initialize {
+  // Ignore when libgit2 writes on a closed pipe
+  // This signal() call causes libgit's closed pipe writes to fail with an EPIPE error, which libgit2 seems to handle correctly.
+  // Without this line, GitUp would instead immediately exit, with no crash log.
+  // libgit2 has what looks like a built-in solution (`disable_signals()`), but it doesn't seem to work for us.
+  signal(SIGPIPE, SIG_IGN);
+  
   NSDictionary* defaults = @{
     GICommitMessageViewUserDefaultKey_ShowInvisibleCharacters : @(YES),
     GICommitMessageViewUserDefaultKey_ShowMargins : @(YES),

--- a/GitUpKit/Core/GCTestCase.m
+++ b/GitUpKit/Core/GCTestCase.m
@@ -201,7 +201,7 @@ static const void* _associatedObjectKey = &_associatedObjectKey;
 }
 
 - (GCRepository *)createLocalRepositoryAtPath:(NSString *)path bare:(BOOL)bare {
-  GCLiveRepository* repo = [[GCLiveRepository alloc] initWithNewLocalRepository:path bare:bare error:NULL];
+  GCLiveRepository* repo = [[GCLiveRepository alloc] initWithNewLocalRepository:path bare:bare defaultBranchName:@"master" error:NULL];
   XCTAssertNotNil(repo);
 
   repo.delegate = self;

--- a/GitUpKit/GitUpKit.xcodeproj/project.pbxproj
+++ b/GitUpKit/GitUpKit.xcodeproj/project.pbxproj
@@ -1636,6 +1636,31 @@
 				PRODUCT_NAME = GitUpKit;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				WARNING_CFLAGS = (
+					"-Wall",
+					"-Weverything",
+					"-Wno-pedantic",
+					"-Wno-padded",
+					"-Wno-direct-ivar-access",
+					"-Wno-documentation-unknown-command",
+					"-Wno-objc-missing-property-synthesis",
+					"-Wno-implicit-retain-self",
+					"-Wno-explicit-ownership-type",
+					"-Wno-assign-enum",
+					"-Wno-cast-align",
+					"-Wno-switch-enum",
+					"-Wno-cstring-format-directive",
+					"-Wno-cast-qual",
+					"-Wno-nullable-to-nonnull-conversion",
+					"-Wno-reserved-id-macro",
+					"-Wno-nonnull",
+					"-Wno-double-promotion",
+					"-Wno-objc-messaging-id",
+					"-Wno-auto-import",
+					"-Wno-atimport-in-framework-header",
+					"-Wno-declaration-after-statement",
+					"-Wno-documentation-deprecated-sync",
+				);
 			};
 			name = Debug;
 		};
@@ -1660,6 +1685,14 @@
 				PRODUCT_NAME = GitUpKit;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				WARNING_CFLAGS = (
+					"-Wall",
+					"-Wno-nonnull",
+					"-Wno-property-attribute-mismatch",
+					"-Wno-auto-import",
+					"-Wno-atimport-in-framework-header",
+					"-Wno-documentation-deprecated-sync",
+				);
 			};
 			name = Release;
 		};

--- a/GitUpKit/Third-Party/Package.swift
+++ b/GitUpKit/Third-Party/Package.swift
@@ -13,6 +13,10 @@ let libssh2Path = "\(librariesPath)/libssh2.xcframework"
 let libsslPath = "\(librariesPath)/libssl.xcframework"
 let libcryptoPath = "\(librariesPath)/libcrypto.xcframework"
 
+let silenceWarningsCSettings: [CSetting] = [ // to see libgit2 warnings, set to empty array
+    CSetting.unsafeFlags(["-w"])
+]
+
 enum FeaturesExtractor {
     private struct Define: CustomStringConvertible {
         let define: String
@@ -217,7 +221,9 @@ let package = Package(
                     // See libgit2/src/CMakeLists.txt
                     .define("GIT_THREADS", to: "1"),
                     
-                ] + FeaturesExtractor.extraLibgit2CSettings(),
+                ]
+                + FeaturesExtractor.extraLibgit2CSettings()
+                + silenceWarningsCSettings,
                 cxxSettings: nil,
                 swiftSettings: nil,
                 linkerSettings: [
@@ -237,7 +243,7 @@ let package = Package(
                 sources: nil,
                 resources: nil,
                 publicHeadersPath: ".",
-                cSettings: [],
+                cSettings: silenceWarningsCSettings,
                 cxxSettings: nil,
                 swiftSettings: nil,
                 linkerSettings: []
@@ -266,7 +272,8 @@ let package = Package(
                     .define("NTLM_STATIC", to: "1"),
                     .define("CRYPT_COMMONCRYPTO"),
                     .define("UNICODE_ICONV", to: "1")
-                ],
+                ]
+                + silenceWarningsCSettings,
                 cxxSettings: nil,
                 swiftSettings: nil,
                 linkerSettings: []

--- a/GitUpKit/Third-Party/Package.swift
+++ b/GitUpKit/Third-Party/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 import Foundation
 
 let libgit2OriginPath = "./libgit2"
-let httpClientPath = "\(libgit2OriginPath)/deps/http-parser"
+let llhttpPath = "\(libgit2OriginPath)/deps/llhttp"
 let ntlmClientPath = "\(libgit2OriginPath)/deps/ntlmclient"
 
 let librariesPath = "."
@@ -73,8 +73,8 @@ let package = Package(
         .library(name: "Libgit2Origin",
                  targets: ["Libgit2Origin"]
         ),
-        .library(name: "http-client",
-                 targets: ["http-client"]
+        .library(name: "llhttp",
+                 targets: ["llhttp"]
         ),
         .library(name: "ntlmclient",
                  targets: ["ntlmclient"]
@@ -85,7 +85,7 @@ let package = Package(
     targets: [
         .target(name: "Libgit2Origin",
                 dependencies: [
-                    "libssh2", "libssl", "libcrypto", "http-client", "ntlmclient"
+                    "libssh2", "libssl", "libcrypto", "llhttp", "ntlmclient"
                 ],
                 path: libgit2OriginPath,
                 exclude: [
@@ -137,10 +137,11 @@ let package = Package(
                 publicHeadersPath: "include",
                 cSettings: [
                     .headerSearchPath("src"),
-                    .headerSearchPath("deps/http-parser"),
+                    .headerSearchPath("deps/llhttp"),
                     .headerSearchPath("deps/ntlmclient"),
                     .define("HAVE_QSORT_R_BSD"),
                     .define("_FILE_OFFSET_BITS", to: "64"),
+                    .define("GIT_HTTPPARSER_BUILTIN", to: "1"),
                     .define("SHA1DC_NO_STANDARD_INCLUDES", to: "1"),
                     .define("SHA1DC_CUSTOM_INCLUDE_SHA1_C", to: "\"common.h\""),
                     .define("SHA1DC_CUSTOM_INCLUDE_UBC_CHECK_C", to: "\"common.h\""),
@@ -155,12 +156,11 @@ let package = Package(
                 ]
         ),
         
-        .target(name: "http-client",
+        .target(name: "llhttp",
                 dependencies: [],
-                path: httpClientPath,
+                path: llhttpPath,
                 exclude: [
-                    "CMakeLists.txt",
-                    "COPYING"
+                    "CMakeLists.txt"
                 ],
                 sources: nil,
                 resources: nil,

--- a/GitUpKit/Third-Party/Package.swift
+++ b/GitUpKit/Third-Party/Package.swift
@@ -70,7 +70,6 @@ let package = Package(
     name: "SwiftPackage",
     platforms: [.macOS(.v10_13)],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(name: "Libgit2Origin",
                  targets: ["Libgit2Origin"]
         ),
@@ -82,12 +81,8 @@ let package = Package(
         ),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(name: "Libgit2Origin",
                 dependencies: [
                     "libssh2", "libssl", "libcrypto", "http-client", "ntlmclient"

--- a/GitUpKit/Third-Party/Package.swift
+++ b/GitUpKit/Third-Party/Package.swift
@@ -86,7 +86,7 @@ let package = Package(
         // Since we don't run libgit2's actual CMake build, we need to replicate its effects here: the files it includes, and the options it resolves
         .target(name: "Libgit2Origin",
                 dependencies: [
-                    "libssh2", "libssl", "libcrypto", "llhttp", "ntlmclient"
+                    "libssl", "libcrypto", "llhttp", "ntlmclient"
                 ],
                 path: libgit2OriginPath,
                 exclude: [
@@ -190,11 +190,11 @@ let package = Package(
                     // See libgit2/cmake/SelectRegex.cmake
                     .define("GIT_REGEX_REGCOMP_L", to: "1"),
                     
-                    // Options set when USE_SSH="libssh2" (default value is ON. exec uses OpenSSH, which supports SSH config files)
+                    // Options set when USE_SSH="exec" (default value is ON. exec uses OpenSSH, which supports SSH config files)
                     // See libgit2/cmake/SelectSSH.cmake
-                    .define("USE_SSH", to: "libssh2"),
+                    .define("USE_SSH", to: "exec"),
                     .define("GIT_SSH", to: "1"),
-                    .define("GIT_SSH_LIBSSH2", to: "1"),
+                    .define("GIT_SSH_EXEC", to: "1"),
                     
                     // Options set when USE_HTTPS="ON" (default value)
                     // See libgit2/cmake/SelectHTTPSBackend.cmake


### PR DESCRIPTION
# Summary

This PR updates the libgit2 fork to [v1.9.0](https://github.com/libgit2/libgit2/releases/tag/v1.9.0), and makes accompanying changes in the GitUp build config.
This PR is for the GitUp repo, and relies on a libgit2 branch currently [in my fork of the repo](https://github.com/Cykelero/gitup-libgit2/commits/update-to-1.9.0/).

This update:
- Adds support for the `core.manyFiles`/`index.skipHash` Git options, which forced index version 4, and made the index unreadable to GitUpKit.
- Replaces libssh2 with OpenSSH, as a SSH backend for libgit2. This means that `.ssh/config` files are now supported: complex setups where different keys are used depending on the domain/username should now work in GitUp, and integration with third-party SSH agents like 1Password should be simpler.
- Many smaller changes since libgit 1.4.4

Of note, switching to OpenSSH seems to have broken the `credentials` callback, which doesn't called anymore when SSH auth fails.
GitUp already displayed a cryptic error in that case (`Failed connecting to "origin" remote: authentication required but no callback set`) but the error is now even less clear: `Failed connecting to "origin" remote: could not read refs from remote repository.`
This is something I'm still investigating.

# Changes

## In the libgit2 repo

The [`update-to-1.9.0`](https://github.com/Cykelero/GitUp/commits/update-libgit2-fork-to-1.9.0/) branch is a rebase of the [`gitup_libgit_updated`](https://github.com/git-up/libgit2/commits/gitup_libgit_updated/) branch onto the latest libgit2 v1.9.0 commit.

The first commit contains most of the fork's changes. Some conflicts were resolved while rebasing it. Code that was calling `libssh2_session_set_timeout()` to set the timeout to 30 has been dropped, as libssh2 is no longer used. (that function call was superseded by the `git_socket_stream__timeout` variable, too)

These commits have been dropped because they're now part of the main libgit2 tree:
- “Cherry-pick of 3847522e86e9c65be674f1372cefefdbfbe9ba2b” (69bd034) (“filter: Fix Segfault”)
- “GitUp: Fix revwalk to not give up when it hits a symbolic reference. Should investigate this further to figure out if this is a bug in mainline libgit2.” (3ade0d5)

A couple of fix commits have been added.

## In the GitUpKit repo

This is what's listed in this PR.

Most of the changes are to the build settings of the embedded Third-Party Swift package, which is used to embed libgit2. Since libgit2 relies on CMake but the GitUpKit build does _not_ run CMake, we need to inline resolved settings (included source files, and compiler options) in `Package.swift`.

# Testing the PR

To test the PR locally, you need to fetch the libgit2 update branch from the other repo, before checking out this PR's branch:

```bash
git remote add cykelero git@github.com:Cykelero/gitup-libgit2.git
git fetch cykelero
```
