### PR TITLE
Make the Text Size preference apply to the text in the diff view, not just the line numbers

### DIFF
--- a/GitUpKit/Interface/GISplitDiffView.m
+++ b/GitUpKit/Interface/GISplitDiffView.m
@@ -108,6 +108,7 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
 @implementation GISplitDiffView {
   NSMutableArray* _lines;
   NSSize _size;
+  CGFloat _layoutFontSize;
 
   BOOL _rightSelection;
   NSMutableIndexSet* _selectedLines;
@@ -125,6 +126,7 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
 
   _lines = [[NSMutableArray alloc] initWithCapacity:1024];
   _selectedLines = [[NSMutableIndexSet alloc] init];
+  _layoutFontSize = GIFontSize();
 }
 
 - (BOOL)isEmpty {
@@ -138,7 +140,9 @@ typedef NS_ENUM(NSUInteger, SelectionMode) {
 }
 
 - (CGFloat)updateLayoutForWidth:(CGFloat)width {
-  if (self.patch && (NSInteger)width != (NSInteger)_size.width) {
+  CGFloat fontSize = GIFontSize();
+  if (self.patch && (((NSInteger)width != (NSInteger)_size.width) || (fontSize != _layoutFontSize))) {
+    _layoutFontSize = fontSize;
     [_lines removeAllObjects];
 
     CGFloat lineWidth = floor((width - 2 * textLineNumberMargin() - 2 * textInsetLeft() - 2 * textInsetRight()) / 2);


### PR DESCRIPTION
The Text Size setting in the preference pane currently only changes the size of the line numbers in the diff viewer, which is not that useful. Presumably it is supposed to also change the text size in the diff content.

This PR makes that change. The Text Size setting will now correctly change the size of the text in the diff content, not just the line numbers. 

This addresses https://github.com/git-up/GitUp/issues/470

Below are two screen shots with this change using the smallest and largest text settings.

![GitUp2](https://github.com/user-attachments/assets/94e0b66f-68f7-4afe-ab2b-cd980eae429a)
![GitUp1](https://github.com/user-attachments/assets/34253cb1-e3dc-411d-868c-4a53c174f026)

