### PR TITLE
Fix highlight range computation for non-ascii characters

### DIFF
--- a/GitUpKit/Interface/GIFunctions-Tests.m
+++ b/GitUpKit/Interface/GIFunctions-Tests.m
@@ -176,6 +176,16 @@
     XCTAssertEqual(addedRange.location, 3);
     XCTAssertEqual(addedRange.length, 2);
   }
+  {
+    // Fix for issue #2740
+    const char* before = "中文命名.md";
+    const char* after = "中文命名1.md";
+    GIComputeHighlightRanges(before, strlen(before), [[NSString stringWithUTF8String:before] length], &deletedRange, after, strlen(after), [[NSString stringWithUTF8String:after] length], &addedRange);
+    XCTAssertEqual(deletedRange.location, 4);
+    XCTAssertEqual(deletedRange.length, 0);
+    XCTAssertEqual(addedRange.location, 4);
+    XCTAssertEqual(addedRange.length, 1);
+  }
 }
 
 @end

--- a/GitUpKit/Interface/GIFunctions.m
+++ b/GitUpKit/Interface/GIFunctions.m
@@ -35,16 +35,16 @@ void GIComputeHighlightRanges(const char* deletedBytes, NSUInteger deletedCount,
     }
     if (remaining == 0) {
       unsigned char byte = *(unsigned char*)deletedMin;
-      if (TEST_BITS(byte, 0b11000000)) {
-        remaining = 2;
-      } else if (TEST_BITS(byte, 0b11100000)) {
-        remaining = 3;
-      } else if (TEST_BITS(byte, 0b11110000)) {
-        remaining = 4;
+      if (TEST_BITS(byte, 0b11111100)) {
+        remaining = 6;
       } else if (TEST_BITS(byte, 0b11111000)) {
         remaining = 5;
-      } else if (TEST_BITS(byte, 0b11111100)) {
-        remaining = 6;
+      } else if (TEST_BITS(byte, 0b11110000)) {
+        remaining = 4;
+      } else if (TEST_BITS(byte, 0b11100000)) {
+        remaining = 3;
+      } else if (TEST_BITS(byte, 0b11000000)) {
+        remaining = 2;
       } else {
         XLOG_DEBUG_CHECK(!(byte & (1 << 7)));
         remaining = 1;


### PR DESCRIPTION
Fixes #2740

We were previously matching on the less specific 2-byte unicode point values, but this meant that something with with a 3 or 4 byte value (asian characters or emoji) would be first offset by 2 then loop incorrectly looking at the next character.

The fix is to look for the largest byte match first and then narrow down to the smaller byte matches.