### PR TITLE
feat: support shallow cloning

### DIFF
--- a/GitUpKit/Core/GCCommit.m
+++ b/GitUpKit/Core/GCCommit.m
@@ -195,7 +195,12 @@ static inline NSComparisonResult _TimeCompare(GCCommit* commit1, GCCommit* commi
   NSMutableArray* array = [[NSMutableArray alloc] init];
   for (unsigned int i = 0, count = git_commit_parentcount(commit.private); i < count; ++i) {
     git_commit* gitCommit;
-    CALL_LIBGIT2_FUNCTION_RETURN(nil, git_commit_parent, &gitCommit, commit.private, i);
+    int status = git_commit_parent(&gitCommit, commit.private, i);
+    if (status == GIT_ENOTFOUND) {
+      XLOG_WARNING(@"Missing parent commit for %s in repository \"%@\"", git_oid_tostr_s(git_commit_id(commit.private)), self.repositoryPath);
+      continue;
+    }
+    CHECK_LIBGIT2_FUNCTION_CALL(return nil, status, == GIT_OK);
     GCCommit* parentCommit = [[GCCommit alloc] initWithRepository:self commit:gitCommit];
     [array addObject:parentCommit];
   }


### PR DESCRIPTION
## Description
Adds support for viewing shallow-cloned repositories.

Currently, when opening a repository an error gets thrown:

<img width="278" height="456" alt="Screenshot 2026-01-28 at 10 56 15 PM" src="https://github.com/user-attachments/assets/0aca2598-4118-42bb-9341-be2d8b4709e1" />

It looks like the error is thrown when reaching a parent commit ID that doesn't exist due to missing the full history. In this approach, if a commit is not found then we will just skip over it.

Resolves #541 