### PR TITLE
Fix crash when staging lines with the index locked

### DIFF
--- a/GitUpKit/Core/GCDiff.m
+++ b/GitUpKit/Core/GCDiff.m
@@ -560,9 +560,6 @@ cleanup:
                                    git_diff* diff2;
                                    diffOptions->flags |= GIT_DIFF_UPDATE_INDEX;
                                    status = git_diff_index_to_workdir(&diff2, self.private, index.private, diffOptions);
-                                   if (status == GIT_ELOCKED) {
-                                     status = GIT_OK;  // Passing GIT_DIFF_UPDATE_INDEX means git_diff_index_to_workdir() may attempt to write the index and this could fail if it is currently locked by another process but that's OK to ignore this failure
-                                   }
                                    if (status == GIT_OK) {
                                      status = git_diff_merge(*outDiff, diff2);
                                      if (status != GIT_OK) {
@@ -599,11 +596,7 @@ cleanup:
                        error:error
                        block:^int(git_diff** outDiff, git_diff_options* diffOptions) {
                          diffOptions->flags |= GIT_DIFF_UPDATE_INDEX;
-                         int status = git_diff_index_to_workdir(outDiff, self.private, index.private, diffOptions);
-                         if (status == GIT_ELOCKED) {
-                           status = GIT_OK;  // Passing GIT_DIFF_UPDATE_INDEX means git_diff_index_to_workdir() will attempt to write the index even if there are no changes and this could fail if it is currently locked by another process
-                         }
-                         return status;
+                         return git_diff_index_to_workdir(outDiff, self.private, index.private, diffOptions);
                        }];
 }
 


### PR DESCRIPTION
Fixes #2768.

# Why it crashes

See the linked issue for a LLM-generated attempt at diagnosing the issue; it seems rather correct. (the proposed solutions are pretty terrible though)

In a nutshell: in two spots*, GUK calls `git_diff_index_to_workdir()`, and _explicitly ignores its returned error_ if it’s `GIT_ELOCKED`. The reasoning is that we don’t care about failing to write the index: that’s just an optional, beneficial side-effect to our actual need, which is to get a diff.

However, when failing in that way, `git_diff_index_to_workdir()` does _not_ return a diff**, it returns null! And so that null value is returned, silently makes its way through GUK, until this causes an array to be allocated with an incorrect size.

*`diffWorkingDirectoryWithCommit` and `diffWorkingDirectoryWithIndex`, on `GCRepository`.
** Presumably it did at some point, explaining why the code is written that way.

# Reproducing

To reproduce, I had to patch `git_diff_index_to_workdir()` to always write the index:
```diff
-	if ((diff->opts.flags & GIT_DIFF_UPDATE_INDEX) && ((git_diff_generated *)diff)->index_updated)
+	if ((diff->opts.flags & GIT_DIFF_UPDATE_INDEX))
```

Then, you can trigger the crash by staging an individual line. (that’s what I did in Retcon, anyway, but it should work in GitUp as well)

# The fix

I removed the override altogether. When I tested, if `git_diff_index_to_workdir()` returns `GIT_ELOCKED`, it always returns an empty diff. Maybe that’s not always the case, but it doesn’t feel like we should trust its return value in these cases anyway.