### PR TITLE
Fix virtual graph lines claiming shared history

### DIFF
--- a/GitUpKit/Interface/GIGraph-Tests.m
+++ b/GitUpKit/Interface/GIGraph-Tests.m
@@ -23,10 +23,61 @@
 #define kNotationSeparator @"##### NOTATION #####\n\n"
 #define kGraphSeparator @"##### GRAPH #####\n\n"
 
-@interface GIGraphTests : XCTestCase
+@interface GIGraphTests : GCTestCase
 @end
 
 @implementation GIGraphTests
+
+- (NSString*)_runGitWithRepository:(GCRepository*)repository arguments:(NSArray*)arguments environment:(NSDictionary*)environment {
+  GCTask* task = [[GCTask alloc] initWithExecutablePath:@"/usr/bin/git"];
+  task.currentDirectoryPath = repository.workingDirectoryPath;
+  task.additionalEnvironment = environment;
+  NSData* data;
+  BOOL success = [task runWithArguments:arguments stdin:nil stdout:&data stderr:NULL exitStatus:NULL error:NULL];
+  XCTAssertTrue(success);
+  return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+}
+
+- (void)_makeEmptyCommitInRepository:(GCRepository*)repository message:(NSString*)message date:(NSString*)date {
+  NSDictionary* environment = @{@"GIT_AUTHOR_DATE" : date, @"GIT_COMMITTER_DATE" : date};
+  [self _runGitWithRepository:repository
+                    arguments:@[ @"-c", @"user.name=Bot", @"-c", @"user.email=bot@example.com", @"commit", @"--allow-empty", @"-m", message ]
+                   environment:environment];
+}
+
+- (void)testVirtualTipDoesNotOwnSharedHistory {
+  NSString* path = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
+  GCRepository* repository = [self createLocalRepositoryAtPath:path bare:NO];
+
+  [self _makeEmptyCommitInRepository:repository message:@"root" date:@"2001-01-01T00:00:00 +0000"];
+  [self _makeEmptyCommitInRepository:repository message:@"join" date:@"2001-01-01T00:30:00 +0000"];
+  [self _runGitWithRepository:repository arguments:@[ @"branch", @"topic" ] environment:nil];
+  [self _makeEmptyCommitInRepository:repository message:@"leaf" date:@"2001-01-01T00:10:00 +0000"];
+
+  GCHistory* history = [repository loadHistoryUsingSorting:kGCHistorySorting_None error:NULL];
+  XCTAssertNotNil(history);
+  GIGraph* graph = [[GIGraph alloc] initWithHistory:history options:kGIGraphOption_ShowVirtualTips];
+  XCTAssertNotNil(graph);
+
+  GCHistoryCommit* joinCommit = [history mockCommitWithName:@"join"];
+  XCTAssertNotNil(joinCommit);
+  GINode* joinNode = [graph nodeForCommit:joinCommit];
+  XCTAssertNotNil(joinNode);
+  XCTAssertFalse(joinNode.primaryLine.virtual);
+
+  GIBranch* virtualBranch = nil;
+  for (GIBranch* branch in graph.branches) {
+    if (branch.tipNode.dummy && (branch.tipNode.commit == joinCommit)) {
+      virtualBranch = branch;
+      break;
+    }
+  }
+  XCTAssertNotNil(virtualBranch);
+  XCTAssertTrue(virtualBranch.mainLine.virtual);
+  XCTAssertEqualObjects(virtualBranch.mainLine.nodes.lastObject, joinNode);
+
+  [self destroyLocalRepository:repository];
+}
 
 + (NSArray*)testInvocations {
   NSMutableArray* array = [NSMutableArray arrayWithArray:[super testInvocations]];

--- a/GitUpKit/Interface/GIGraph.m
+++ b/GitUpKit/Interface/GIGraph.m
@@ -423,12 +423,12 @@
       // same commit on this layer. Otherwise a virtual tip can claim the
       // commit's primary line and render the whole ancestry as dashed.
       for (GINode* previousNode in previousLayer.nodes) {
-        if (!previousNode.dummy) {
+        if (!previousNode.primaryLine.virtual) {
           processPreviousNode(previousNode);
         }
       }
       for (GINode* previousNode in previousLayer.nodes) {
-        if (previousNode.dummy) {
+        if (previousNode.primaryLine.virtual) {
           processPreviousNode(previousNode);
         }
       }

--- a/GitUpKit/Interface/GIGraph.m
+++ b/GitUpKit/Interface/GIGraph.m
@@ -338,40 +338,39 @@
       // Create a new empty layer
       layer = [[GILayer alloc] initWithIndex:self.layers.count];
 
-      // Iterate over nodes from previous layer
-      for (GINode* previousNode in previousLayer.nodes) {
-        GINode* (^nodeBlock)(GILine*, GCHistoryCommit*, GCHistoryCommit*) = ^(GILine* line, GCHistoryCommit* commit, GCHistoryCommit* alternateCommit) {
-          XLOG_DEBUG_CHECK(!MAP_COMMIT_TO_NODE(commit));
+      GINode* (^nodeBlock)(GILine*, GCHistoryCommit*, GCHistoryCommit*) = ^(GILine* line, GCHistoryCommit* commit, GCHistoryCommit* alternateCommit) {
+        XLOG_DEBUG_CHECK(!MAP_COMMIT_TO_NODE(commit));
 
-          // Check if this commit is "ready" to be a node i.e. all its children have non-dummy nodes associated (but not on the current layer)
-          BOOL ready = YES;
-          for (GCHistoryCommit* child in commit.children) {
-            if (skipped && COMMIT_SKIPPED(child)) {
-              continue;
-            }
-            GINode* node = MAP_COMMIT_TO_NODE(child);
-            ready = node && (node.layer != layer);
-            if (!ready) {
-              break;
-            }
+        // Check if this commit is "ready" to be a node i.e. all its children have non-dummy nodes associated (but not on the current layer)
+        BOOL ready = YES;
+        for (GCHistoryCommit* child in commit.children) {
+          if (skipped && COMMIT_SKIPPED(child)) {
+            continue;
           }
-
-          // Create new node (dummy if the commit is not ready)
-          GINode* node;
-          if (ready) {
-            node = [[GINode alloc] initWithLayer:layer primaryLine:line commit:commit dummy:NO alternateCommit:nil];
-            MAP_COMMIT_TO_NODE(commit) = node;  // Associate node with commit
-          } else {
-            node = [[GINode alloc] initWithLayer:layer primaryLine:line commit:commit dummy:YES alternateCommit:alternateCommit];
-            ++_numberOfDummyNodes;
+          GINode* node = MAP_COMMIT_TO_NODE(child);
+          ready = node && (node.layer != layer);
+          if (!ready) {
+            break;
           }
-          [_nodes addObject:node];
-          [layer addNode:node];
-          [line addNode:node];
+        }
 
-          return node;
-        };
+        // Create new node (dummy if the commit is not ready)
+        GINode* node;
+        if (ready) {
+          node = [[GINode alloc] initWithLayer:layer primaryLine:line commit:commit dummy:NO alternateCommit:nil];
+          MAP_COMMIT_TO_NODE(commit) = node;  // Associate node with commit
+        } else {
+          node = [[GINode alloc] initWithLayer:layer primaryLine:line commit:commit dummy:YES alternateCommit:alternateCommit];
+          ++_numberOfDummyNodes;
+        }
+        [_nodes addObject:node];
+        [layer addNode:node];
+        [line addNode:node];
 
+        return node;
+      };
+
+      void (^processPreviousNode)(GINode*) = ^(GINode* previousNode) {
         // If the previous node is a dummy one reprocess its commit
         GCHistoryCommit* commit = previousNode.commit;
         GILine* line = previousNode.primaryLine;
@@ -417,6 +416,20 @@
           if (commit.hasReferences) {
             [_nodesWithReferences addObject:previousNode];
           }
+        }
+      };
+
+      // Prefer real history paths over virtual branch tips when both reach the
+      // same commit on this layer. Otherwise a virtual tip can claim the
+      // commit's primary line and render the whole ancestry as dashed.
+      for (GINode* previousNode in previousLayer.nodes) {
+        if (!previousNode.dummy) {
+          processPreviousNode(previousNode);
+        }
+      }
+      for (GINode* previousNode in previousLayer.nodes) {
+        if (previousNode.dummy) {
+          processPreviousNode(previousNode);
         }
       }
 


### PR DESCRIPTION
Fixes #336.

## Summary
- process real graph nodes before dummy/virtual branch-tip nodes when generating each layer
- prevents a virtual branch tip from becoming the primary line for a shared commit and rendering the rest of its ancestry as thin/dashed
- add a regression test with out-of-order committer dates, matching the rebase/amend scenario described in the issue

## Verification
- `clang -fsyntax-only ... GitUpKit/Interface/GIGraph.m`
- `git diff --no-index --check GitUp-baseline GitUp`

Could not run the XCTest suite locally because this machine only has Command Line Tools installed; `xcodebuild` requires full Xcode. `clang-format` is also unavailable locally.