### PR TITLE
Fix: Replace slow custom trash implementation with native `trashItemAtURL:` API

### DIFF
--- a/GitUpKit/Core/GCFoundation.m
+++ b/GitUpKit/Core/GCFoundation.m
@@ -39,19 +39,7 @@
 #if !TARGET_OS_IPHONE
 
 - (BOOL)moveItemAtPathToTrash:(NSString*)path error:(NSError**)error {
-  NSString* trashPath = [NSSearchPathForDirectoriesInDomains(NSTrashDirectory, NSUserDomainMask, YES) firstObject];
-  if (!trashPath) {
-    GC_SET_GENERIC_ERROR(@"Unable to find Trash");
-    return NO;
-  }
-  NSString* extension = path.pathExtension;
-  NSString* name = [path.lastPathComponent stringByDeletingPathExtension];
-  NSString* destinationPath = [trashPath stringByAppendingPathComponent:[name stringByAppendingPathExtension:extension]];
-  NSUInteger counter = 0;
-  while ([self fileExistsAtPath:destinationPath followLastSymlink:NO]) {
-    destinationPath = [trashPath stringByAppendingPathComponent:[[NSString stringWithFormat:@"%@ (%lu)", name, ++counter] stringByAppendingPathExtension:extension]];
-  }
-  return [self moveItemAtPath:path toPath:destinationPath error:error];
+  return [self trashItemAtURL:[NSURL fileURLWithPath:path] resultingItemURL:nil error:error];
 }
 
 #endif


### PR DESCRIPTION
### Problem

Discarding working directory changes in GitUp causes a noticeable lag before files are removed from the list. The `moveItemAtPathToTrash:` method in `GCFoundation.m` used a custom implementation that:

1. Searched for the Trash directory via `NSSearchPathForDirectoriesInDomains`
2. Manually computed destination paths with collision avoidance (looping with incrementing counters)
3. Called `moveItemAtPath:toPath:` for each file

This approach is slow because:
- The `while` loop checks for existing files in Trash one-by-one using `fileExistsAtPath:` — O(n) per conflict
- `moveItemAtPath:toPath:` across volumes (e.g., external drives) has no optimization
- The Trash path resolution is redundant work the system already handles

### Solution

Replaced the 14-line custom implementation with Apple's native `NSFileManager` API:

```objc
- (BOOL)moveItemAtPathToTrash:(NSString*)path error:(NSError**)error {
  return [self trashItemAtURL:[NSURL fileURLWithPath:path] resultingItemURL:nil error:error];
}
```

`trashItemAtURL:resultingItemURL:error:` (available since macOS 10.8) is Apple's optimized system API that:
- Handles filename collision resolution internally and efficiently
- Works correctly across volumes (uses the volume's `.Trashes` folder when appropriate)
- Uses optimized filesystem operations under the hood
- Properly integrates with Finder's "Put Back" functionality
