### PR TITLE
Improve selected files performance lag in Commit View

### DIFF
--- a/GitUpKit/Core/GCIndex.m
+++ b/GitUpKit/Core/GCIndex.m
@@ -541,12 +541,12 @@ cleanup:
   }
 
   git_checkout_options options = GIT_CHECKOUT_OPTIONS_INIT;
-  options.checkout_strategy = GIT_CHECKOUT_FORCE | GIT_CHECKOUT_DONT_UPDATE_INDEX;  // There's no reason to update the index
+  options.checkout_strategy = GIT_CHECKOUT_FORCE | GIT_CHECKOUT_DONT_UPDATE_INDEX | GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;  // There's no reason to update the index
   options.paths.count = paths.count;
   char** pathStrings = malloc(paths.count * sizeof(char*));
   options.paths.strings = pathStrings;
   for (NSUInteger i = 0; i < paths.count; i++) {
-    const char* filePath = GCGitPathFromFileSystemPath([NSRegularExpression escapedPatternForString:paths[i]]);
+    const char* filePath = GCGitPathFromFileSystemPath(paths[i]);
     options.paths.strings[i] = (char*)filePath;
   }
 


### PR DESCRIPTION
### Problem

In the Commit View, selecting all files and pressing Delete to discard changes has a noticeable lag compared to using the "Discard All" button, especially with many files.

The root cause is in `checkoutFilesToWorkingDirectory:fromIndex:error:` — without `GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH`, libgit2 treats each file path as a glob/fnmatch pattern. This causes O(N × M) comparisons where every index entry is checked against every pathspec using pattern matching. With hundreds of files, this becomes very slow.

### Fix

Added `GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH` to the checkout strategy in `GCIndex.m`. This tells libgit2 to treat paths as exact literals, enabling fast binary-search lookup instead of glob matching. Also removed the unnecessary `NSRegularExpression escapedPatternForString:` call since paths are now matched literally (it was a workaround for the pattern-matching behavior).

### Risk

**Low.** The paths passed to this function are always literal file paths from diff deltas — never glob patterns. The previous `escapedPatternForString:` call confirms the intent was always exact matching. This is consistent with how `GCRepository+HEAD.m` already uses `GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH` for similar checkout operations.