### PR TITLE
Handle `kFSEventStreamEventFlagMustScanSubDirs` to prevent missed UI refreshes

### DIFF
--- a/GitUpKit/Core/GCLiveRepository.m
+++ b/GitUpKit/Core/GCLiveRepository.m
@@ -128,7 +128,16 @@ static void _TimerCallBack(CFRunLoopTimerRef timer, void* info) {
   for (size_t i = 0; i < numEvents; ++i) {
     const char* path = ((const char**)eventPaths)[i];
     if (eventFlags[i] & kFSEventStreamEventFlagMustScanSubDirs) {
-      XLOG_WARNING(@"Ignoring event stream request to rescan \"%s\"", path);  // Note that this directory path can be missing the trailing slash
+      // Apple docs: "Your application must rescan not just the directory given in the event,
+      // but all its children, recursively." This flag fires when the kernel event queue overflows
+      // (e.g. during rapid multi-file changes like git checkout). We must not ignore it.
+      XLOG_WARNING(@"Received event stream request to rescan \"%s\"", path);
+      if (stream == _gitDirectoryStream) {
+        _gitDirectoryChanged = YES;
+      } else {
+        _workingDirectoryChanged = YES;
+      }
+      CFRunLoopTimerSetNextFireDate(_updateTimer, CFAbsoluteTimeGetCurrent() + kUpdateLatency);
 
     } else {  // Documentation says "eventFlags" should be 0x0 for regular events but that's not the case on OS X 10.10 at least
 


### PR DESCRIPTION
### Summary

The UI occasionally fails to refresh when files change in the working directory or `.git` directory. This is caused by the FSEvents callback ignoring `kFSEventStreamEventFlagMustScanSubDirs` events, which the kernel sends when its event buffer overflows during rapid filesystem activity.

### Problem

In `GCLiveRepository.m`, the `_stream:didReceiveEvents:withPaths:flags:` method previously discarded events flagged with `kFSEventStreamEventFlagMustScanSubDirs`:

```objc
if (eventFlags[i] & kFSEventStreamEventFlagMustScanSubDirs) {
    XLOG_WARNING(@"Ignoring event stream request to rescan \"%s\"", path);
}
```

Per [Apple's FSEvents documentation](https://developer.apple.com/documentation/coreservices/kfseventstreamcreateflaguseextendeddata), this flag means: *"Your application must rescan not just the directory given in the event, but all its children, recursively."* It fires when the kernel drops or coalesces events due to buffer overflow — typically during rapid multi-file changes (e.g., `git checkout`, `git rebase`, IDE refactoring, build tools).

By ignoring this flag, the app missed those change notifications entirely, leaving the UI stale.

### Fix

When `kFSEventStreamEventFlagMustScanSubDirs` is received, we now mark the appropriate stream as changed and schedule the existing debounced update timer:

```objc
if (eventFlags[i] & kFSEventStreamEventFlagMustScanSubDirs) {
    XLOG_WARNING(@"Received event stream request to rescan \"%s\"", path);
    if (stream == _gitDirectoryStream) {
        _gitDirectoryChanged = YES;
    } else {
        _workingDirectoryChanged = YES;
    }
    CFRunLoopTimerSetNextFireDate(_updateTimer, CFAbsoluteTimeGetCurrent() + kUpdateLatency);
}
```

This follows the exact same code path as regular file change events — no new logic introduced.

### Why This Is Safe

1. **Reuses existing infrastructure** — sets the same boolean flags and reschedules the same timer used by all normal events.
2. **Debounced** — the 0.5s `kUpdateLatency` timer coalesces multiple triggers; no duplicate processing.
3. **Idempotent downstream** — `_updateStatus:` compares the new diff against the current one (`isEqualToDiff:`) and only notifies the UI if something actually changed. No spurious redraws.
4. **Rare trigger** — this flag only fires on kernel buffer overflow, not on every event. Normal single-file edits are unaffected.

---

## Risk Assessment

| Risk | Likelihood | Impact | Mitigation |
|------|-----------|--------|------------|
| Extra status recomputation on buffer overflow events | Low (flag is rare) | Negligible (same cost as any file-save event) | Existing 0.5s debounce timer coalesces bursts |
| UI flicker from unnecessary redraws | Very Low | Low | `_updateStatus:` already diffs against current state and only notifies on actual changes |
| Regression in ignore-path filtering | None | N/A | For `MustScanSubDirs`, we intentionally skip the ignore check — the kernel is telling us events were lost, so we must assume something changed. The downstream status computation will correctly reflect only non-ignored files. |
| Thread safety concerns | None | N/A | All code runs on the main run loop (FSEventStream is scheduled on `CFRunLoopGetMain()`), same as before |

**Overall risk: Very Low.** The change is minimal, follows established patterns in the codebase, and Apple's documentation explicitly mandates this behavior.