### PR TITLE
Leave working dir alone when unable to check out branch checked out in worktree

### DIFF
--- a/GitUpKit/Core/GCRepository+HEAD-Tests.m
+++ b/GitUpKit/Core/GCRepository+HEAD-Tests.m
@@ -194,4 +194,37 @@
   [self assertContentsOfFileAtPath:@"new_file.txt" equalsString:@"New Content\n"];
 }
 
+// Regression test for issue #2713: checking out a branch that is already checked out in another
+// worktree must fail *without* mutating the working directory or index. Previously the target tree
+// was written to disk before the (failing) HEAD move, leaving staged "revert" debris behind.
+- (void)testCheckoutBranchCheckedOutInLinkedWorktree {
+  // We start on master with a clean working directory.
+  [self assertContentsOfFileAtPath:@"hello_world.txt" equalsString:@"Hola Mundo!\n"];
+  XCTAssertTrue([self.repository checkClean:0 error:NULL]);
+
+  // Check out the topic branch in a linked worktree so it becomes off-limits in this one.
+  NSString* worktreePath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
+  NSString* worktreeOutput = [self runGitCLTWithRepository:self.repository command:@"worktree", @"add", worktreePath, @"topic", nil];
+  XCTAssertNotNil(worktreeOutput);  // nil means git exited non-zero, i.e. the worktree wasn't created
+
+  // Switching to that same branch here must fail...
+  NSError* error;
+  XCTAssertFalse([self.repository checkoutLocalBranch:self.topicBranch options:0 error:&error]);
+  XCTAssertNotNil(error);
+
+  // ...and must leave the working directory, index, and HEAD exactly as they were.
+  XCTAssertTrue([self.repository checkClean:0 error:NULL]);
+  [self assertContentsOfFileAtPath:@"hello_world.txt" equalsString:@"Hola Mundo!\n"];
+  GCLocalBranch* branch;
+  GCCommit* head = [self.repository lookupHEAD:&branch error:NULL];
+  XCTAssertEqualObjects(head, self.commit3);
+  XCTAssertEqualObjects(branch, self.masterBranch);
+
+  // Re-checking-out the branch already at this HEAD must still be allowed.
+  XCTAssertTrue([self.repository checkoutLocalBranch:self.masterBranch options:kGCCheckoutOption_Force error:NULL]);
+
+  // Clean up the linked worktree.
+  [[NSFileManager defaultManager] removeItemAtPath:worktreePath error:NULL];
+}
+
 @end

--- a/GitUpKit/Core/GCRepository+HEAD.m
+++ b/GitUpKit/Core/GCRepository+HEAD.m
@@ -242,6 +242,16 @@ cleanup:
 
 // Because by default git_checkout_tree() assumes the baseline (i.e. expected content of workdir) is HEAD we must checkout first, then update HEAD
 - (BOOL)checkoutLocalBranch:(GCLocalBranch*)branch options:(GCCheckoutOptions)options error:(NSError**)error {
+  // Bail out *before* touching the working directory if the branch is checked out in another worktree.
+  // Otherwise _checkoutTreeForCommit: below writes the target tree into the index and working directory, then
+  // setHEADToReference: fails (git_repository_set_head() refuses to point at a branch that is the HEAD of a
+  // linked worktree), leaving those changes behind with no rollback. See issue #2713. git mirrors this check
+  // by only rejecting a *different* branch, so allow re-checking-out the branch that is already this HEAD.
+  git_reference* branchReference = branch.private;
+  if (git_reference_is_branch(branchReference) && !git_branch_is_head(branchReference) && git_branch_is_checked_out(branchReference)) {
+    GC_SET_GENERIC_ERROR(@"Branch '%@' is already checked out in another worktree", branch.name);
+    return NO;
+  }
   GCCommit* tipCommit = [self lookupTipCommitForBranch:branch error:error];
   if (!tipCommit || ![self _checkoutTreeForCommit:tipCommit withBaseline:nil options:options error:error] || ![self setHEADToReference:branch error:error]) {
     return NO;


### PR DESCRIPTION
### Summary

Fixes #2713.

Previously, `checkoutLocalBranch:` wrote the target tree to the working directory and index before moving HEAD. When the branch is checked out in a linked worktree, `git_repository_set_head()` fails, leaving the applied tree changes behind as staged debris.

### Testing

Added a test that checks out a branch in a worktree and then calls `checkoutLocalBranch:` and validates that the working directory is unchanged. Also tested manually.

GitUp 1.5.0 (1058): checking out the branch fails but leaves modified files in the index:

<img width="445" height="306" alt="image" src="https://github.com/user-attachments/assets/e33def75-0171-4d05-a856-6b4284d08d0c" />
<img width="316" height="452" alt="image" src="https://github.com/user-attachments/assets/7d077bed-40bc-49b7-9e7c-12cf37ae34b7" />

Built from this branch: checking out fails (with a slightly clearer message) and does not touch the index:

<img width="498" height="353" alt="image" src="https://github.com/user-attachments/assets/184dfa19-70d6-4c24-bc8c-0d966a36f4d9" />
<img width="313" height="388" alt="image" src="https://github.com/user-attachments/assets/6937f3ab-e7d2-45d8-b585-eab4d961b62b" />

----

I AGREE TO THE GITUP CONTRIBUTOR LICENSE AGREEMENT.